### PR TITLE
Bump LTS for v37.x (virtiofsd compatibility)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,9 +2377,9 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b64e816d0d49769fbfaa1494eb77cc2a3ddc526ead05c7f922cb7d64106286f"
+checksum = "6be08d1166d41a78861ad50212ab3f9eca0729c349ac3a7a8f557c62406b87cc"
 dependencies = [
  "bitflags 2.4.1",
  "libc",
@@ -2389,9 +2389,9 @@ dependencies = [
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.13.1"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c8c447d076ac508d78cb45664d203df7989e891656dce260a7e93d72352c9a"
+checksum = "1f0ffb1dd8e00a708a0e2c32d5efec5812953819888591fff9ff68236b8a5096"
 dependencies = [
  "libc",
  "log",
@@ -2481,9 +2481,9 @@ dependencies = [
 
 [[package]]
 name = "virtio-queue"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3f69a13d6610db9312acbb438b0390362af905d37634a2106be70c0f734986d"
+checksum = "07d8406e7250c934462de585d8f2d2781c31819bca1fbb7c5e964ca6bbaabfe8"
 dependencies = [
  "log",
  "virtio-bindings",

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -21,7 +21,7 @@ uuid = { version = "1.3.4", features = ["v4"] }
 versionize = "0.2.0"
 versionize_derive = "0.1.6"
 virtio-bindings = { version = "0.2.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.11.0"
+virtio-queue = "0.12.0"
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.12.1"

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -23,7 +23,7 @@ net_util = { path = "../net_util" }
 once_cell = "1.19.0"
 seccompiler = "0.4.0"
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.11.0"
+virtio-queue = "0.12.0"
 vmm = { path = "../vmm" }
 vmm-sys-util = "0.12.1"
 vm-memory = "0.14.0"

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = "1.0.52"
 versionize = "0.2.0"
 versionize_derive = "0.1.6"
 virtio-bindings = "0.2.0"
-virtio-queue = "0.11.0"
+virtio-queue = "0.12.0"
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = "0.12.1"

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -13,9 +13,9 @@ epoll = "4.3.3"
 libc = "0.2.147"
 log = "0.4.20"
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.10.0", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.13.1"
+vhost = { version = "0.11.0", features = ["vhost-user-backend"] }
+vhost-user-backend = "0.15.0"
 virtio-bindings = "0.2.0"
-virtio-queue = "0.11.0"
+virtio-queue = "0.12.0"
 vm-memory = "0.14.0"
 vmm-sys-util = "0.12.1"

--- a/vhost_user_block/src/lib.rs
+++ b/vhost_user_block/src/lib.rs
@@ -33,16 +33,18 @@ use std::vec::Vec;
 use std::{convert, error, fmt, io};
 use vhost::vhost_user::message::*;
 use vhost::vhost_user::Listener;
-use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock, VringState, VringT};
+use vhost_user_backend::{
+    bitmap::BitmapMmapRegion, VhostUserBackendMut, VhostUserDaemon, VringRwLock, VringState, VringT,
+};
 use virtio_bindings::virtio_blk::*;
 use virtio_bindings::virtio_config::VIRTIO_F_VERSION_1;
 use virtio_bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::QueueT;
 use vm_memory::GuestAddressSpace;
-use vm_memory::{bitmap::AtomicBitmap, ByteValued, Bytes, GuestMemoryAtomic};
+use vm_memory::{ByteValued, Bytes, GuestMemoryAtomic};
 use vmm_sys_util::{epoll::EventSet, eventfd::EventFd};
 
-type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<BitmapMmapRegion>;
 
 const SECTOR_SHIFT: u8 = 9;
 const SECTOR_SIZE: u64 = 0x01 << SECTOR_SHIFT;
@@ -301,7 +303,7 @@ impl VhostUserBlkBackend {
 }
 
 impl VhostUserBackendMut for VhostUserBlkBackend {
-    type Bitmap = AtomicBitmap;
+    type Bitmap = BitmapMmapRegion;
     type Vring = VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>;
 
     fn num_queues(&self) -> usize {

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -13,8 +13,8 @@ libc = "0.2.147"
 log = "0.4.20"
 net_util = { path = "../net_util" }
 option_parser = { path = "../option_parser" }
-vhost = { version = "0.10.0", features = ["vhost-user-backend"] }
-vhost-user-backend = "0.13.1"
+vhost = { version = "0.11.0", features = ["vhost-user-backend"] }
+vhost-user-backend = "0.15.0"
 virtio-bindings = "0.2.0"
 vm-memory = "0.14.0"
 vmm-sys-util = "0.12.1"

--- a/vhost_user_net/src/lib.rs
+++ b/vhost_user_net/src/lib.rs
@@ -23,14 +23,15 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::vec::Vec;
 use vhost::vhost_user::message::*;
 use vhost::vhost_user::Listener;
+use vhost_user_backend::bitmap::BitmapMmapRegion;
 use vhost_user_backend::{VhostUserBackendMut, VhostUserDaemon, VringRwLock, VringT};
 use virtio_bindings::virtio_config::{VIRTIO_F_NOTIFY_ON_EMPTY, VIRTIO_F_VERSION_1};
 use virtio_bindings::virtio_net::*;
 use vm_memory::GuestAddressSpace;
-use vm_memory::{bitmap::AtomicBitmap, GuestMemoryAtomic};
+use vm_memory::GuestMemoryAtomic;
 use vmm_sys_util::{epoll::EventSet, eventfd::EventFd};
 
-type GuestMemoryMmap = vm_memory::GuestMemoryMmap<AtomicBitmap>;
+type GuestMemoryMmap = vm_memory::GuestMemoryMmap<BitmapMmapRegion>;
 
 pub type Result<T> = std::result::Result<T, Error>;
 type VhostUserBackendResult<T> = std::result::Result<T, std::io::Error>;
@@ -159,7 +160,7 @@ impl VhostUserNetBackend {
 }
 
 impl VhostUserBackendMut for VhostUserNetBackend {
-    type Bitmap = AtomicBitmap;
+    type Bitmap = BitmapMmapRegion;
     type Vring = VringRwLock<GuestMemoryAtomic<GuestMemoryMmap>>;
 
     fn num_queues(&self) -> usize {

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -27,9 +27,9 @@ serial_buffer = { path = "../serial_buffer" }
 thiserror = "1.0.52"
 versionize = "0.2.0"
 versionize_derive = "0.1.6"
-vhost = { version = "0.10.0", features = ["vhost-user-frontend", "vhost-user-backend", "vhost-kern", "vhost-vdpa"] }
+vhost = { version = "0.11.0", features = ["vhost-user-frontend", "vhost-user-backend", "vhost-kern", "vhost-vdpa"] }
 virtio-bindings = { version = "0.2.0", features = ["virtio-v5_0_0"] }
-virtio-queue = "0.11.0"
+virtio-queue = "0.12.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -9,5 +9,5 @@ default = []
 
 [dependencies]
 log = "0.4.20"
-virtio-queue = "0.11.0"
+virtio-queue = "0.12.0"
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -60,7 +60,7 @@ versionize_derive = "0.1.6"
 vfio-ioctls = { git = "https://github.com/rust-vmm/vfio", branch = "main", default-features = false }
 vfio_user = { git = "https://github.com/rust-vmm/vfio-user", branch = "main" }
 virtio-devices = { path = "../virtio-devices" }
-virtio-queue = "0.11.0"
+virtio-queue = "0.12.0"
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { version = "0.14.0", features = ["backend-mmap", "backend-atomic", "backend-bitmap"] }


### PR DESCRIPTION
This pulls in the the changes from https://github.com/cloud-hypervisor/cloud-hypervisor/pull/6675 for virtiofsd 1.10+ compatibility.

Testing done:
 - Successful run of the test suite on Artemis (minus VDPA tests that already fail before).

```
failures:
    common_parallel::test_vdpa_block

test result: 98 passed; 1 failed; 1 ignored; 0 measured; 43 filtered out; finished in 379.24s
```
