### PR TITLE
Fix check for undocumented methods

### DIFF
--- a/rate_limiter/src/lib.rs
+++ b/rate_limiter/src/lib.rs
@@ -541,7 +541,8 @@ pub(crate) mod tests {
         }
 
         // After a restore, we cannot be certain that the last_update field has the same value.
-        pub fn partial_eq(&self, other: &TokenBucket) -> bool {
+        #[allow(dead_code)]
+        fn partial_eq(&self, other: &TokenBucket) -> bool {
             (other.capacity() == self.capacity())
                 && (other.one_time_burst() == self.one_time_burst())
                 && (other.refill_time_ms() == self.refill_time_ms())
@@ -550,12 +551,12 @@ pub(crate) mod tests {
     }
 
     impl RateLimiter {
-        pub fn bandwidth(&self) -> Option<TokenBucket> {
+        fn bandwidth(&self) -> Option<TokenBucket> {
             let guard = self.inner.lock().unwrap();
             guard.bandwidth.clone()
         }
 
-        pub fn ops(&self) -> Option<TokenBucket> {
+        fn ops(&self) -> Option<TokenBucket> {
             let guard = self.inner.lock().unwrap();
             guard.ops.clone()
         }


### PR DESCRIPTION
A couple helper methods in the `rate_limiter` crate were marked `pub` and newer toolchains find this to violate `deny(missing_docs)`. This is a partial backport of https://github.com/cloud-hypervisor/cloud-hypervisor/commit/b708db393dbde692803ebe1c65fc22c600b530e3 (we do not have the `group.rs` module on v37) that removes the redundant `pub` declarations.
