### PR TITLE
vmm: improve logger timestamps

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -131,12 +131,14 @@ impl log::Log for Logger {
 
         let now = std::time::Instant::now();
         let duration = now.duration_since(self.start);
+        let duration_s = duration.as_secs_f32();
 
         if record.file().is_some() && record.line().is_some() {
             write!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:.6?}: <{}> {}:{}:{} -- {}\r\n",
-                duration,
+                // 10: 6 decimal places + sep => 0..999s will be properly aligned
+                "cloud-hypervisor: {:>10.6?}s: <{}> {}:{}:{} -- {}\r\n",
+                duration_s,
                 std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),
                 record.file().unwrap(),
@@ -146,8 +148,9 @@ impl log::Log for Logger {
         } else {
             write!(
                 *(*(self.output.lock().unwrap())),
-                "cloud-hypervisor: {:.6?}: <{}> {}:{} -- {}\r\n",
-                duration,
+                // 10: 6 decimal places + sep => 0..999s will be properly aligned
+                "cloud-hypervisor: {:>10.6?}s: <{}> {}:{} -- {}\r\n",
+                duration_s,
                 std::thread::current().name().unwrap_or("anonymous"),
                 record.level(),
                 record.target(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,30 +133,23 @@ impl log::Log for Logger {
         let duration = now.duration_since(self.start);
         let duration_s = duration.as_secs_f32();
 
-        if record.file().is_some() && record.line().is_some() {
-            write!(
-                *(*(self.output.lock().unwrap())),
-                // 10: 6 decimal places + sep => 0..999s will be properly aligned
-                "cloud-hypervisor: {:>10.6?}s: <{}> {}:{}:{} -- {}\r\n",
-                duration_s,
-                std::thread::current().name().unwrap_or("anonymous"),
-                record.level(),
-                record.file().unwrap(),
-                record.line().unwrap(),
-                record.args()
-            )
+        let location = if let (Some(file), Some(line)) = (record.file(), record.line()) {
+            format!("{}:{}", file, line)
         } else {
-            write!(
-                *(*(self.output.lock().unwrap())),
-                // 10: 6 decimal places + sep => 0..999s will be properly aligned
-                "cloud-hypervisor: {:>10.6?}s: <{}> {}:{} -- {}\r\n",
-                duration_s,
-                std::thread::current().name().unwrap_or("anonymous"),
-                record.level(),
-                record.target(),
-                record.args()
-            )
-        }
+            record.target().to_string()
+        };
+
+        let mut out = self.output.lock().unwrap();
+        write!(
+            &mut *out,
+            // 10: 6 decimal places + sep => 0..999s will be properly aligned
+            "cloud-hypervisor: {:>10.6?}s: <{}> {}:{} -- {}\r\n",
+            duration_s,
+            std::thread::current().name().unwrap_or("anonymous"),
+            record.level(),
+            location,
+            record.args(),
+        )
         .ok();
     }
     fn flush(&self) {}


### PR DESCRIPTION

The old output doesn't nicely align across multiple lines.

# Example (old style)
```
cloud-hypervisor: 858.465660ms: <vcpu0> DEBUG:devices/src/ioapic.rs:154 -- IOAPIC_R @ offset 0x10
cloud-hypervisor: 858.507342ms: <vcpu0> DEBUG:devices/src/ioapic.rs:298 -- IOAPIC_R reg 0x1
cloud-hypervisor: 1.010001s: <vcpu0> DEBUG:devices/src/ioapic.rs:174 -- IOAPIC_W @ offset 0x0
cloud-hypervisor: 1.010067s: <vcpu0> DEBUG:devices/src/ioapic.rs:154 -- IOAPIC_R @ offset 0x10
```

# Example (new style)
```
cloud-hypervisor:   0.731399s: <vcpu0> DEBUG:devices/src/ioapic.rs:174 -- IOAPIC_W @ offset 0x10
cloud-hypervisor:   0.731420s: <vcpu0> DEBUG:devices/src/ioapic.rs:252 -- IOAPIC_W reg 0x2a, val 0x10000
cloud-hypervisor:  17.026073s: <vmm> INFO:vmm/src/api/mod.rs:898 -- API request event: VmInfo
cloud-hypervisor:  17.263210s: <vmm> INFO:vmm/src/api/mod.rs:898 -- API request event: VmInfo
cloud-hypervisor:  17.547915s: <vmm> INFO:vmm/src/api/mod.rs:898 -- API request event: VmInfo
```
