### PR TITLE
cargo: add optimized-dev profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,20 @@ lto = true
 opt-level = "s"
 strip = true
 
+# Tradeof between performance and fast compilation times for local testing and
+# development with frequent rebuilds.
+[profile.optimized-dev]
+codegen-units = 16
+inherits = "release"
+lto = false
+opt-level = 2
+strip = false
+
+# Optimize more for dependencies: They don't require frequent rebuilds.
+[profile.optimized-dev.package."*"]
+codegen-units = 1
+opt-level = 3
+
 [profile.profiling]
 debug = true
 inherits = "release"


### PR DESCRIPTION
TL;DR: Fix for long rebuilds locally when testing things.

The release profile is optimized for maximum performance, sacrificing build speed. As local development and testing requires frequent rebuilds, but the dev profile is way too slow for "real testing", this profile is a sweet spot and helps to investigate things.

Instead of `cargo run --release`, one now can use `cargo run --profile optimized-dev`.

# Measurements
 See commit message.