### PR TITLE
vmm: fix kicking vCPU out of KVM_RUN vCPU from signal handler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2453,6 +2453,7 @@ dependencies = [
  "hypervisor",
  "igvm",
  "igvm_defs",
+ "kvm-bindings",
  "landlock",
  "libc",
  "linux-loader",

--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -10,6 +10,8 @@
 //
 //
 
+#[cfg(feature = "kvm")]
+use std::os::fd::RawFd;
 #[cfg(target_arch = "aarch64")]
 use std::sync::Arc;
 
@@ -602,4 +604,11 @@ pub trait Vcpu: Send + Sync {
     /// Trigger NMI interrupt
     ///
     fn nmi(&self) -> Result<()>;
+    /// Returns the underlying vCPU FD of KVM.
+    ///
+    /// # SAFETY
+    /// This is safe as we only use this to map the KVM_RUN structure for the
+    /// signal handler and only use it from there.
+    #[cfg(feature = "kvm")]
+    unsafe fn get_kvm_vcpu_raw_fd(&self) -> RawFd;
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1987,7 +1987,8 @@ impl cpu::Vcpu for KvmVcpu {
     /// Triggers the running of the current virtual CPU returning an exit reason.
     ///
     fn run(&self) -> std::result::Result<cpu::VmExit, cpu::HypervisorCpuError> {
-        match self.fd.lock().unwrap().run() {
+        let mut lock = self.fd.lock().unwrap();
+        match lock.run() {
             Ok(run) => match run {
                 #[cfg(target_arch = "x86_64")]
                 VcpuExit::IoIn(addr, data) => {
@@ -2066,7 +2067,11 @@ impl cpu::Vcpu for KvmVcpu {
             },
 
             Err(ref e) => match e.errno() {
-                libc::EAGAIN | libc::EINTR => Ok(cpu::VmExit::Ignore),
+                libc::EINTR => {
+                    lock.set_kvm_immediate_exit(0);
+                    Ok(cpu::VmExit::Ignore)
+                }
+                libc::EAGAIN => Ok(cpu::VmExit::Ignore),
                 _ => Err(cpu::HypervisorCpuError::RunVcpu(anyhow!(
                     "VCPU error {:?}",
                     e

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 use std::fs::File;
 #[cfg(target_arch = "x86_64")]
 use std::os::unix::io::AsRawFd;
-#[cfg(feature = "tdx")]
+#[cfg(any(feature = "tdx", feature = "kvm"))]
 use std::os::unix::io::RawFd;
 use std::result;
 #[cfg(target_arch = "x86_64")]
@@ -2772,6 +2772,13 @@ impl cpu::Vcpu for KvmVcpu {
     ///
     fn set_immediate_exit(&self, exit: bool) {
         self.fd.lock().unwrap().set_kvm_immediate_exit(exit.into());
+    }
+
+    #[cfg(feature = "kvm")]
+    unsafe fn get_kvm_vcpu_raw_fd(&self) -> RawFd {
+        let kvm_vcpu = self.fd.lock().unwrap();
+        let kvm_vcpu = &*kvm_vcpu;
+        kvm_vcpu.as_raw_fd()
     }
 
     ///

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -1581,7 +1581,7 @@ impl cpu::Vcpu for MshvVcpu {
 
     #[cfg(feature = "kvm")]
     unsafe fn get_kvm_vcpu_raw_fd(&self) -> RawFd {
-        todo!()
+        unimplemented!()
     }
 }
 

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -43,6 +43,8 @@ pub mod x86_64;
 pub mod aarch64;
 #[cfg(target_arch = "x86_64")]
 use std::fs::File;
+#[cfg(feature = "kvm")]
+use std::os::fd::RawFd;
 use std::os::unix::io::AsRawFd;
 #[cfg(target_arch = "aarch64")]
 use std::sync::Mutex;
@@ -1575,6 +1577,11 @@ impl cpu::Vcpu for MshvVcpu {
             .map_err(|e| cpu::HypervisorCpuError::SetRegister(e.into()))?;
 
         Ok(())
+    }
+
+    #[cfg(feature = "kvm")]
+    unsafe fn get_kvm_vcpu_raw_fd(&self) -> RawFd {
+        todo!()
     }
 }
 

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -52,6 +52,7 @@ linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }
 log = "0.4.22"
 # Special fork of micro_http that combines HTTP traffic over a UNIX domain
 # socket with UNIX' SCM_RIGHTS mechanism for transferring file descriptors.
+kvm-bindings = "0.10.0"
 micro_http = { git = "https://github.com/firecracker-microvm/micro-http", branch = "main" }
 mshv-bindings = { workspace = true, features = [
   "fam-wrappers",

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -16,8 +16,6 @@ use std::collections::BTreeMap;
 use std::io::Write;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use std::mem::size_of;
-#[cfg(feature = "kvm")]
-use std::os::fd::RawFd;
 use std::os::unix::thread::JoinHandleExt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
@@ -75,6 +73,8 @@ use vm_migration::{
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::{register_signal_handler, SIGRTMIN};
 use zerocopy::{FromBytes, Immutable, IntoBytes};
+#[cfg(feature = "kvm")]
+use {kvm_bindings::kvm_run, std::cell::Cell, std::os::fd::RawFd, std::sync::RwLock};
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::coredump::{
@@ -91,6 +91,16 @@ use crate::seccomp_filters::{get_seccomp_filter, Thread};
 use crate::vm::physical_bits;
 use crate::vm_config::CpusConfig;
 use crate::{GuestMemoryMmap, CPU_MANAGER_SNAPSHOT_ID};
+
+#[cfg(feature = "kvm")]
+thread_local! {
+    static KVM_RUN: Cell<*mut kvm_run> = const {Cell::new(core::ptr::null_mut())};
+}
+#[cfg(feature = "kvm")]
+/// Tell signal handler to not access certain stuff anymore during shutdown.
+/// Otherwise => panics.
+/// Better alternative would be to prevent signals there at all.
+pub static IS_IN_SHUTDOWN: RwLock<bool> = RwLock::new(false);
 
 #[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
 /// Extract the specified bits of a 64-bit integer.
@@ -1040,6 +1050,28 @@ impl CpuManager {
             thread::Builder::new()
                 .name(format!("vcpu{vcpu_id}"))
                 .spawn(move || {
+                    // init thread-local kvm_run structure
+                    #[cfg(feature = "kvm")]
+                    {
+                        let raw_kvm_fd = vcpu.lock().unwrap().get_kvm_vcpu_raw_fd();
+
+                        // SAFETY: We know the FD is valid and have the proper args.
+                        let buffer = unsafe {
+                            libc::mmap(
+                                core::ptr::null_mut(),
+                                4096,
+                                libc::PROT_WRITE | libc::PROT_READ,
+                                libc::MAP_SHARED,
+                                raw_kvm_fd,
+                                0,
+                            )
+                        };
+                        assert!(!buffer.is_null());
+                        assert_ne!(buffer, libc::MAP_FAILED);
+                        let kvm_run = buffer.cast::<kvm_run>();
+                        KVM_RUN.set(kvm_run);
+                    }
+
                     // Schedule the thread to run on the expected CPU set
                     if let Some(cpuset) = cpuset.as_ref() {
                         // SAFETY: FFI call with correct arguments
@@ -1070,7 +1102,36 @@ impl CpuManager {
                             return;
                         }
                     }
+
+                    #[cfg(not(feature = "kvm"))]
                     extern "C" fn handle_signal(_: i32, _: *mut siginfo_t, _: *mut c_void) {}
+                    #[cfg(feature = "kvm")]
+                    extern "C" fn handle_signal(_: i32, _: *mut siginfo_t, _: *mut c_void) {
+                        // We do not need a self-pipe for safe UNIX signal handling here as in this
+                        // signal handler, we only expect the same signal over and over again. While
+                        // different signals can interrupt a signal being handled, the same signal
+                        // again can't by default. Therefore, this is safe.
+
+                        // This lock prevents accessing thread locals when a signal is received
+                        // in the teardown phase of the Rust standard library. Otherwise, we would
+                        // panic.
+                        //
+                        // Masking signals would be a nicer approach but this is the pragmatic
+                        // solution.
+                        //
+                        // We don't have lock contention in normal operation. When the writer
+                        // sets the bool to true, the lock is only held for a couple of µs.
+                        let lock = IS_IN_SHUTDOWN.read().unwrap();
+                        if *lock {
+                            return;
+                        }
+
+                        let kvm_run = KVM_RUN.get();
+                        // SAFETY: the mapping is valid
+                        let kvm_run = unsafe {
+                            kvm_run.as_mut().expect("kvm_run should have been mapped as part of vCPU setup") };
+                        kvm_run.immediate_exit = 1;
+                    }
                     // This uses an async signal safe handler to kill the vcpu handles.
                     register_signal_handler(SIGRTMIN(), handle_signal)
                         .expect("Failed to register vcpu signal handler");

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -16,6 +16,8 @@ use std::collections::BTreeMap;
 use std::io::Write;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use std::mem::size_of;
+#[cfg(feature = "kvm")]
+use std::os::fd::RawFd;
 use std::os::unix::thread::JoinHandleExt;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
@@ -486,6 +488,13 @@ impl Vcpu {
             .set_gic_redistributor_addr(gicr_base)
             .map_err(Error::VcpuSetGicrBaseAddr)?;
         Ok(())
+    }
+
+    #[cfg(feature = "kvm")]
+    pub fn get_kvm_vcpu_raw_fd(&self) -> RawFd {
+        // SAFETY: We happen to know that all current uses respect the safety contract.
+        // TODO find a better way to keep this safe and/or express its fragile state.
+        unsafe { self.vcpu.get_kvm_vcpu_raw_fd() }
     }
 }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1100,12 +1100,14 @@ impl CpuManager {
 
                                 #[cfg(feature = "kvm")]
                                 if matches!(hypervisor_type, HypervisorType::Kvm) {
-                                    vcpu.lock().as_ref().unwrap().vcpu.set_immediate_exit(true);
-                                    if !matches!(vcpu.lock().unwrap().run(), Ok(VmExit::Ignore)) {
+                                    let lock = vcpu.lock();
+                                    let lock = lock.as_ref().unwrap();
+                                    lock.vcpu.set_immediate_exit(true);
+                                    if !matches!(lock.run(), Ok(VmExit::Ignore)) {
                                         error!("Unexpected VM exit on \"immediate_exit\" run");
                                         break;
                                     }
-                                    vcpu.lock().as_ref().unwrap().vcpu.set_immediate_exit(false);
+                                    lock.vcpu.set_immediate_exit(false);
                                 }
 
                                 vcpu_run_interrupted.store(true, Ordering::SeqCst);

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1983,6 +1983,10 @@ impl RequestHandler for Vmm {
     ) -> result::Result<(), VmError> {
         self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
 
+        if desired_vcpus.is_some() {
+            todo!("doesn't work currently with our thread-local KVM_RUN approach");
+        }
+
         if let Some(ref mut vm) = self.vm {
             if let Err(e) = vm.resize(desired_vcpus, desired_ram, desired_balloon) {
                 error!("Error when resizing VM: {:?}", e);

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -54,6 +54,8 @@ use crate::api::{
 use crate::config::{add_to_config, RestoreConfig};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::coredump::GuestDebuggable;
+#[cfg(feature = "kvm")]
+use crate::cpu::IS_IN_SHUTDOWN;
 use crate::landlock::Landlock;
 use crate::memory_manager::MemoryManager;
 #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -1372,6 +1374,14 @@ impl Vmm {
         // The VM is already stopped.
         vm.release_disk_locks()
             .map_err(|e| MigratableError::UnlockError(anyhow!("{e}")))?;
+
+        #[cfg(feature = "kvm")]
+        // Prevent signal handler to access thread local storage when signals are received
+        // close to the end when thread-local storage is already destroyed.
+        {
+            let mut lock = IS_IN_SHUTDOWN.write().unwrap();
+            *lock = true;
+        }
 
         // Capture snapshot and send it
         let vm_snapshot = vm.snapshot()?;


### PR DESCRIPTION
## About

vmm: fix kicking vCPU out of kvm run vCPU from signal handler

More details in the commit messages!


## Checklist (for Author)

- [x] [libvirt-tests](https://github.com/cyberus-technology/libvirt-tests) 
  pipeline succeeded (currently this must be done manually locally)
- [x] PR associated with [ticket](https://github.com/cobaltcore-dev/cobaltcore/issues?q=is%3Aissue%20state%3Aopen%20label%3Acyberus%2Ccyberus-maybe)

## Hints for Reviewers

- please note that we need this to unblock the vCPU auto-converge feature
- we nevertheless can improve this code here, but we should **be pragmatic**


## Steps to Undraft (if draft)

None.

