### PR TITLE
Add serial TCP mode

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1002,12 +1002,14 @@ mod unit_tests {
                 mode: ConsoleOutputMode::Null,
                 iommu: false,
                 socket: None,
+                url: None,
             },
             console: ConsoleConfig {
                 file: None,
                 mode: ConsoleOutputMode::Tty,
                 iommu: false,
                 socket: None,
+                url: None,
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -420,7 +420,7 @@ fn get_cli_options_sorted(
             .default_value("true"),
         Arg::new("serial")
             .long("serial")
-            .help("Control serial port: off|null|pty|tty|file=</path/to/a/file>|socket=</path/to/a/file>")
+            .help("Control serial port: off|null|pty|tty|file=</path/to/a/file>|socket=</path/to/a/file>|tcp=<host:port>")
             .default_value("null")
             .group("vm-config"),
         Arg::new("tpm")

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -1844,12 +1844,6 @@ impl ConsoleConfig {
             mode = ConsoleOutputMode::Tty
         } else if parser.is_set("null") {
             mode = ConsoleOutputMode::Null
-        } else if parser.is_set("file") {
-            mode = ConsoleOutputMode::File;
-            file =
-                Some(PathBuf::from(parser.get("file").ok_or(
-                    Error::Validation(ValidationError::ConsoleFileMissing),
-                )?));
         } else if parser.is_set("tcp") {
             mode = ConsoleOutputMode::Tcp;
             url = Some(
@@ -1857,6 +1851,18 @@ impl ConsoleConfig {
                     .get("tcp")
                     .ok_or(Error::Validation(ValidationError::ConsoleTcpAddressMissing))?,
             );
+            if parser.is_set("file") {
+                file =
+                    Some(PathBuf::from(parser.get("file").ok_or(
+                        Error::Validation(ValidationError::ConsoleFileMissing),
+                    )?));
+            }
+        } else if parser.is_set("file") {
+            mode = ConsoleOutputMode::File;
+            file =
+                Some(PathBuf::from(parser.get("file").ok_or(
+                    Error::Validation(ValidationError::ConsoleFileMissing),
+                )?));
         } else if parser.is_set("socket") {
             mode = ConsoleOutputMode::Socket;
             socket = Some(PathBuf::from(parser.get("socket").ok_or(

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -182,6 +182,9 @@ pub enum ValidationError {
     /// Missing file value for console
     #[error("Path missing when using file console mode")]
     ConsoleFileMissing,
+    /// Missing TCP address for console
+    #[error("Address missing when using TCP console mode")]
+    ConsoleTcpAddressMissing,
     /// Missing socket path for console
     #[error("Path missing when using socket console mode")]
     ConsoleSocketPathMissing,
@@ -1825,11 +1828,13 @@ impl ConsoleConfig {
             .add_valueless("null")
             .add("file")
             .add("iommu")
+            .add("tcp")
             .add("socket");
         parser.parse(console).map_err(Error::ParseConsole)?;
 
         let mut file: Option<PathBuf> = default_consoleconfig_file();
         let mut socket: Option<PathBuf> = None;
+        let mut url: Option<String> = None;
         let mut mode: ConsoleOutputMode = ConsoleOutputMode::Off;
 
         if parser.is_set("off") {
@@ -1845,6 +1850,13 @@ impl ConsoleConfig {
                 Some(PathBuf::from(parser.get("file").ok_or(
                     Error::Validation(ValidationError::ConsoleFileMissing),
                 )?));
+        } else if parser.is_set("tcp") {
+            mode = ConsoleOutputMode::Tcp;
+            url = Some(
+                parser
+                    .get("tcp")
+                    .ok_or(Error::Validation(ValidationError::ConsoleTcpAddressMissing))?,
+            );
         } else if parser.is_set("socket") {
             mode = ConsoleOutputMode::Socket;
             socket = Some(PathBuf::from(parser.get("socket").ok_or(
@@ -1864,6 +1876,7 @@ impl ConsoleConfig {
             mode,
             iommu,
             socket,
+            url,
         })
     }
 }
@@ -3726,6 +3739,7 @@ mod tests {
                 iommu: false,
                 file: None,
                 socket: None,
+                url: None,
             }
         );
         assert_eq!(
@@ -3735,6 +3749,7 @@ mod tests {
                 iommu: false,
                 file: None,
                 socket: None,
+                url: None,
             }
         );
         assert_eq!(
@@ -3744,6 +3759,7 @@ mod tests {
                 iommu: false,
                 file: None,
                 socket: None,
+                url: None,
             }
         );
         assert_eq!(
@@ -3753,6 +3769,7 @@ mod tests {
                 iommu: false,
                 file: None,
                 socket: None,
+                url: None,
             }
         );
         assert_eq!(
@@ -3762,6 +3779,7 @@ mod tests {
                 iommu: false,
                 file: Some(PathBuf::from("/tmp/console")),
                 socket: None,
+                url: None,
             }
         );
         assert_eq!(
@@ -3771,6 +3789,7 @@ mod tests {
                 iommu: true,
                 file: None,
                 socket: None,
+                url: None,
             }
         );
         assert_eq!(
@@ -3780,6 +3799,7 @@ mod tests {
                 iommu: true,
                 file: Some(PathBuf::from("/tmp/console")),
                 socket: None,
+                url: None,
             }
         );
         assert_eq!(
@@ -3789,6 +3809,7 @@ mod tests {
                 iommu: true,
                 file: None,
                 socket: Some(PathBuf::from("/tmp/serial.sock")),
+                url: None,
             }
         );
         Ok(())
@@ -4155,12 +4176,14 @@ mod tests {
                 mode: ConsoleOutputMode::Null,
                 iommu: false,
                 socket: None,
+                url: None,
             },
             console: ConsoleConfig {
                 file: None,
                 mode: ConsoleOutputMode::Tty,
                 iommu: false,
                 socket: None,
+                url: None,
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),

--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -227,6 +227,7 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
             ConsoleOutputMode::Socket => {
                 return Err(ConsoleDeviceError::NoSocketOptionSupportForConsoleDevice);
             }
+            ConsoleOutputMode::Tcp => ConsoleOutput::Null,
             ConsoleOutputMode::Null => ConsoleOutput::Null,
             ConsoleOutputMode::Off => ConsoleOutput::Off,
         },
@@ -264,6 +265,7 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                     .map_err(ConsoleDeviceError::CreateConsoleDevice)?;
                 ConsoleOutput::Socket(Arc::new(listener))
             }
+            ConsoleOutputMode::Tcp => ConsoleOutput::Null,
             ConsoleOutputMode::Null => ConsoleOutput::Null,
             ConsoleOutputMode::Off => ConsoleOutput::Off,
         },
@@ -290,6 +292,7 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
             ConsoleOutputMode::Socket => {
                 return Err(ConsoleDeviceError::NoSocketOptionSupportForConsoleDevice);
             }
+            ConsoleOutputMode::Tcp => ConsoleOutput::Null,
             ConsoleOutputMode::Null => ConsoleOutput::Null,
             ConsoleOutputMode::Off => ConsoleOutput::Off,
         },

--- a/vmm/src/console_devices.rs
+++ b/vmm/src/console_devices.rs
@@ -12,6 +12,7 @@
 
 use std::fs::{File, OpenOptions, read_link};
 use std::mem::zeroed;
+use std::net::TcpListener;
 use std::os::fd::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::net::UnixListener;
@@ -40,6 +41,10 @@ pub enum ConsoleDeviceError {
     #[error("No socket option support for console device")]
     NoSocketOptionSupportForConsoleDevice,
 
+    /// Error parsing the TCP address
+    #[error("Wrong TCP address format: {0}")]
+    WrongTcpAddressFormat(std::string::String),
+
     /// Error setting pty raw mode
     #[error("Error setting pty raw mode")]
     SetPtyRaw(#[source] vmm_sys_util::errno::Error),
@@ -62,6 +67,7 @@ pub enum ConsoleOutput {
     Tty(Arc<File>),
     Null,
     Socket(Arc<UnixListener>),
+    Tcp(Arc<TcpListener>),
     Off,
 }
 
@@ -265,7 +271,15 @@ pub(crate) fn pre_create_console_devices(vmm: &mut Vmm) -> ConsoleDeviceResult<C
                     .map_err(ConsoleDeviceError::CreateConsoleDevice)?;
                 ConsoleOutput::Socket(Arc::new(listener))
             }
-            ConsoleOutputMode::Tcp => ConsoleOutput::Null,
+            ConsoleOutputMode::Tcp => {
+                let url = vmconfig.serial.url.as_ref().unwrap();
+                let socket_addr: std::net::SocketAddr = url
+                    .parse()
+                    .map_err(|_| ConsoleDeviceError::WrongTcpAddressFormat(url.to_string()))?;
+                let listener = TcpListener::bind(socket_addr)
+                    .map_err(ConsoleDeviceError::CreateConsoleDevice)?;
+                ConsoleOutput::Tcp(Arc::new(listener))
+            }
             ConsoleOutputMode::Null => ConsoleOutput::Null,
             ConsoleOutputMode::Off => ConsoleOutput::Off,
         },

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2350,6 +2350,9 @@ impl DeviceManager {
             ConsoleOutput::Socket(_) => {
                 return Err(DeviceManagerError::NoSocketOptionSupportForConsoleDevice);
             }
+            ConsoleOutput::Tcp(_) => {
+                return Err(DeviceManagerError::NoSocketOptionSupportForConsoleDevice);
+            }
             ConsoleOutput::Null => Endpoint::Null,
             ConsoleOutput::Off => return Ok(None),
         };
@@ -2424,12 +2427,16 @@ impl DeviceManager {
             | ConsoleOutput::Null
             | ConsoleOutput::Pty(_)
             | ConsoleOutput::Socket(_) => None,
+            ConsoleOutput::Tcp(_) => None,
         };
 
         if !matches!(console_info.serial_main_fd, ConsoleOutput::Off) {
             let serial = self.add_serial_device(interrupt_manager, serial_writer)?;
             self.serial_manager = match console_info.serial_main_fd {
-                ConsoleOutput::Pty(_) | ConsoleOutput::Tty(_) | ConsoleOutput::Socket(_) => {
+                ConsoleOutput::Pty(_)
+                | ConsoleOutput::Tty(_)
+                | ConsoleOutput::Socket(_)
+                | ConsoleOutput::Tcp(_) => {
                     let serial_manager = SerialManager::new(
                         serial,
                         console_info.serial_main_fd,
@@ -2462,6 +2469,7 @@ impl DeviceManager {
                     | ConsoleOutput::Null
                     | ConsoleOutput::Pty(_)
                     | ConsoleOutput::Socket(_) => None,
+                    ConsoleOutput::Tcp(_) => None,
                 };
             if let Some(writer) = debug_console_writer {
                 let _ = self.add_debug_console_device(writer)?;

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -2350,7 +2350,7 @@ impl DeviceManager {
             ConsoleOutput::Socket(_) => {
                 return Err(DeviceManagerError::NoSocketOptionSupportForConsoleDevice);
             }
-            ConsoleOutput::Tcp(_) => {
+            ConsoleOutput::Tcp(_, _) => {
                 return Err(DeviceManagerError::NoSocketOptionSupportForConsoleDevice);
             }
             ConsoleOutput::Null => Endpoint::Null,
@@ -2427,7 +2427,7 @@ impl DeviceManager {
             | ConsoleOutput::Null
             | ConsoleOutput::Pty(_)
             | ConsoleOutput::Socket(_) => None,
-            ConsoleOutput::Tcp(_) => None,
+            ConsoleOutput::Tcp(_, _) => None,
         };
 
         if !matches!(console_info.serial_main_fd, ConsoleOutput::Off) {
@@ -2436,7 +2436,7 @@ impl DeviceManager {
                 ConsoleOutput::Pty(_)
                 | ConsoleOutput::Tty(_)
                 | ConsoleOutput::Socket(_)
-                | ConsoleOutput::Tcp(_) => {
+                | ConsoleOutput::Tcp(_, _) => {
                     let serial_manager = SerialManager::new(
                         serial,
                         console_info.serial_main_fd,
@@ -2469,7 +2469,7 @@ impl DeviceManager {
                     | ConsoleOutput::Null
                     | ConsoleOutput::Pty(_)
                     | ConsoleOutput::Socket(_) => None,
-                    ConsoleOutput::Tcp(_) => None,
+                    ConsoleOutput::Tcp(_, _) => None,
                 };
             if let Some(writer) = debug_console_writer {
                 let _ = self.add_debug_console_device(writer)?;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2656,12 +2656,14 @@ mod unit_tests {
                 mode: ConsoleOutputMode::Null,
                 iommu: false,
                 socket: None,
+                url: None,
             },
             console: ConsoleConfig {
                 file: None,
                 mode: ConsoleOutputMode::Tty,
                 iommu: false,
                 socket: None,
+                url: None,
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1160,7 +1160,7 @@ impl Vmm {
             false
         } else {
             let iteration = s.iteration - AUTO_CONVERGE_ITERATION_DELAY;
-            iteration % AUTO_CONVERGE_ITERATION_INCREASE == 0
+            iteration.is_multiple_of(AUTO_CONVERGE_ITERATION_INCREASE)
         }
     }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -809,6 +809,7 @@ fn vcpu_thread_rules(
         (libc::SYS_rt_sigreturn, vec![]),
         (libc::SYS_sched_yield, vec![]),
         (libc::SYS_sendmsg, vec![]),
+        (libc::SYS_sendto, vec![]),
         (libc::SYS_shutdown, vec![]),
         (libc::SYS_sigaltstack, vec![]),
         (libc::SYS_tgkill, vec![]),

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -220,7 +220,7 @@ impl SerialManager {
                 }
                 fd.as_raw_fd()
             }
-            ConsoleOutput::Tcp(ref fd) => fd.as_raw_fd(),
+            ConsoleOutput::Tcp(ref fd, _) => fd.as_raw_fd(),
             _ => return Ok(None),
         };
 
@@ -242,7 +242,7 @@ impl SerialManager {
             ConsoleOutput::Null => EpollDispatch::File,
             ConsoleOutput::Off => EpollDispatch::File,
             ConsoleOutput::Socket(_) => EpollDispatch::Socket,
-            ConsoleOutput::Tcp(_) => EpollDispatch::Tcp,
+            ConsoleOutput::Tcp(_, _) => EpollDispatch::Tcp,
         };
 
         epoll::ctl(
@@ -422,7 +422,7 @@ impl SerialManager {
                                         write_distributor.remove_writer("tcp");
                                     }
 
-                                    let ConsoleOutput::Tcp(ref listener) = in_file else {
+                                    let ConsoleOutput::Tcp(ref listener, _) = in_file else {
                                         unreachable!();
                                     };
 
@@ -473,7 +473,7 @@ impl SerialManager {
                                                     0
                                                 }
                                             }
-                                            ConsoleOutput::Tcp(_) => {
+                                            ConsoleOutput::Tcp(_, _) => {
                                                 if let Some(mut serial_reader) = reader_tcp.as_ref()
                                                 {
                                                     let count = serial_reader

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -335,6 +335,10 @@ impl SerialManager {
                 std::panic::catch_unwind(AssertUnwindSafe(move || {
                     let write_distributor = FanoutWriter::new();
 
+                    if let ConsoleOutput::Tcp(_, Some(f)) = &in_file {
+                        write_distributor.add_writer("file".into(), f.clone());
+                    }
+
                     let mut events =
                         [epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
                     serial

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -91,9 +91,10 @@ pub enum EpollDispatch {
     File = 0,
     Kill = 1,
     Socket = 2,
+    Tcp = 3,
     Unknown,
 }
-const EPOLL_EVENTS_LEN: usize = 4;
+const EPOLL_EVENTS_LEN: usize = 5;
 
 impl From<u64> for EpollDispatch {
     fn from(v: u64) -> Self {
@@ -102,6 +103,7 @@ impl From<u64> for EpollDispatch {
             0 => File,
             1 => Kill,
             2 => Socket,
+            3 => Tcp,
             _ => Unknown,
         }
     }
@@ -345,6 +347,7 @@ impl SerialManager {
                                     .map_err(Error::Epoll)?;
                                     serial.lock().unwrap().set_out(Some(Box::new(writer)));
                                 }
+                                EpollDispatch::Tcp => {}
                                 EpollDispatch::File => {
                                     if event.events & libc::EPOLLIN as u32 != 0 {
                                         let mut input = [0u8; 64];

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -67,9 +67,9 @@ pub enum Error {
     #[error("Error accepting connection")]
     AcceptConnection(#[source] io::Error),
 
-    /// Cannot clone the UnixStream
-    #[error("Error cloning UnixStream")]
-    CloneUnixStream(#[source] io::Error),
+    /// Cannot clone the Stream
+    #[error("Error cloning Stream")]
+    CloneStream(#[source] io::Error),
 
     /// Cannot shutdown the connection
     #[error("Error shutting down a connection")]
@@ -330,10 +330,9 @@ impl SerialManager {
                                     let (unix_stream, _) =
                                         listener.accept().map_err(Error::AcceptConnection)?;
                                     let writer =
-                                        unix_stream.try_clone().map_err(Error::CloneUnixStream)?;
-                                    reader = Some(
-                                        unix_stream.try_clone().map_err(Error::CloneUnixStream)?,
-                                    );
+                                        unix_stream.try_clone().map_err(Error::CloneStream)?;
+                                    reader =
+                                        Some(unix_stream.try_clone().map_err(Error::CloneStream)?);
 
                                     epoll::ctl(
                                         epoll_fd,

--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
+use std::any::TypeId;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write};
@@ -115,7 +116,7 @@ impl From<u64> for EpollDispatch {
 /// a TCP socket and a file.
 #[derive(Clone)]
 pub struct FanoutWriter {
-    writers: Arc<Mutex<HashMap<String, Box<dyn Write + Send>>>>,
+    writers: Arc<Mutex<HashMap<TypeId, Box<dyn Write + Send>>>>,
 }
 
 impl FanoutWriter {
@@ -125,14 +126,14 @@ impl FanoutWriter {
         }
     }
 
-    pub fn add_writer<W: Write + Send + 'static>(&self, key: String, writer: W) {
+    pub fn add_writer<W: Write + Send + 'static>(&self, writer: W) {
         let mut writers = self.writers.lock().unwrap();
-        writers.insert(key, Box::new(writer));
+        writers.insert(TypeId::of::<W>(), Box::new(writer));
     }
 
-    pub fn remove_writer(&self, key: &str) -> Option<Box<dyn Write + Send>> {
+    pub fn remove_writer(&self, id: TypeId) -> Option<Box<dyn Write + Send>> {
         let mut writers = self.writers.lock().unwrap();
-        writers.remove(key)
+        writers.remove(&id)
     }
 }
 
@@ -336,7 +337,7 @@ impl SerialManager {
                     let write_distributor = FanoutWriter::new();
 
                     if let ConsoleOutput::Tcp(_, Some(f)) = &in_file {
-                        write_distributor.add_writer("file".into(), f.clone());
+                        write_distributor.add_writer(f.clone());
                     }
 
                     let mut events =
@@ -423,7 +424,7 @@ impl SerialManager {
                                         previous_reader
                                             .shutdown(Shutdown::Both)
                                             .map_err(Error::AcceptConnection)?;
-                                        write_distributor.remove_writer("tcp");
+                                        write_distributor.remove_writer(TypeId::of::<TcpStream>());
                                     }
 
                                     let ConsoleOutput::Tcp(ref listener, _) = in_file else {
@@ -449,7 +450,7 @@ impl SerialManager {
                                         ),
                                     )
                                     .map_err(Error::Epoll)?;
-                                    write_distributor.add_writer("tcp".into(), writer);
+                                    write_distributor.add_writer(writer);
                                 }
                                 EpollDispatch::File => {
                                     if event.events & libc::EPOLLIN as u32 != 0 {
@@ -489,7 +490,9 @@ impl SerialManager {
                                                             .shutdown(Shutdown::Both)
                                                             .map_err(Error::ShutdownConnection)?;
                                                         reader_tcp = None;
-                                                        write_distributor.remove_writer("tcp");
+                                                        write_distributor.remove_writer(
+                                                            TypeId::of::<TcpStream>(),
+                                                        );
                                                     }
                                                     count
                                                 } else {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -496,6 +496,7 @@ pub enum ConsoleOutputMode {
     Tty,
     File,
     Socket,
+    Tcp,
     Null,
 }
 
@@ -507,6 +508,7 @@ pub struct ConsoleConfig {
     #[serde(default)]
     pub iommu: bool,
     pub socket: Option<PathBuf>,
+    pub url: Option<String>,
 }
 
 pub fn default_consoleconfig_file() -> Option<PathBuf> {
@@ -856,6 +858,7 @@ pub fn default_serial() -> ConsoleConfig {
         mode: ConsoleOutputMode::Null,
         iommu: false,
         socket: None,
+        url: None,
     }
 }
 
@@ -865,6 +868,7 @@ pub fn default_console() -> ConsoleConfig {
         mode: ConsoleOutputMode::Tty,
         iommu: false,
         socket: None,
+        url: None,
     }
 }
 


### PR DESCRIPTION
This MR adds a TCP mode to the serial device configuration, allowing to send and receive serial communication via TCP.

The MR is meant for early review and shouldn't be merged until we have some feedback from the upstream maintainers how the API can look like.

Best reviewed commit by commit. Please watch out for wild `unwraps` ;)

Further, I think the current structure of the code, especially in the `serial_manager.rs`, looks pretty sub-optimal. Please avoid fix the world suggestions for now, I think that should be done in an separate effort.

### Usage:

```
cloud-hypervisor --serial tcp=127.0.0.1:2222,file=/tmp/vm.log ...
socat - TCP:localhost:2222
```

### Opens:
* Currently, only the TCP mode allows for an additional `file` parameter. I guess for upstreaming, also TTY and PTY modes require the ability to log to file in parallel. Any idea how to elegantly add that to the current codebase?
* Any unittests to add?