### PR TITLE
vmm: live migration asynchronization (dedicated thread)

### DIFF
--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -50,7 +50,7 @@ pub enum MigratableError {
     #[error("Failed to complete migration for migratable component")]
     CompleteMigration(#[source] anyhow::Error),
 
-    #[error("Failed to release a disk lock before the migration")]
+    #[error("Failed to release a disk lock")]
     UnlockError(#[source] anyhow::Error),
 }
 

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -32,10 +32,21 @@
 
 use std::fs::File;
 use std::os::unix::io::IntoRawFd;
-use std::sync::mpsc::Sender;
+use std::sync::mpsc::{Receiver, Sender, SyncSender};
+use std::sync::{LazyLock, Mutex};
 
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use vmm_sys_util::eventfd::EventFd;
+
+/// Helper to make the VmSendMigration call blocking as long as a migration is ongoing.
+#[allow(clippy::type_complexity)]
+pub static ONGOING_LIVEMIGRATION: LazyLock<(
+    SyncSender<Result<(), vm_migration::MigratableError>>,
+    Mutex<Receiver<Result<(), vm_migration::MigratableError>>>,
+)> = LazyLock::new(|| {
+    let (sender, receiver) = std::sync::mpsc::sync_channel(0);
+    (sender, Mutex::new(receiver))
+});
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::api::VmCoredump;
@@ -230,7 +241,6 @@ vm_action_put_handler_body!(VmRemoveDevice);
 vm_action_put_handler_body!(VmResizeDisk);
 vm_action_put_handler_body!(VmResizeZone);
 vm_action_put_handler_body!(VmSnapshot);
-vm_action_put_handler_body!(VmSendMigration);
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 vm_action_put_handler_body!(VmCoredump);
@@ -381,6 +391,46 @@ impl PutHandler for VmReceiveMigration {
 }
 
 impl GetHandler for VmReceiveMigration {}
+
+// Special Handling for virtio-net Devices Backed by Network File Descriptors
+//
+// See above.
+impl PutHandler for VmSendMigration {
+    fn handle_request(
+        &'static self,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+        body: &Option<Body>,
+        _files: Vec<File>,
+    ) -> std::result::Result<Option<Body>, HttpError> {
+        if let Some(body) = body {
+            let res = self
+                .send(
+                    api_notifier,
+                    api_sender,
+                    serde_json::from_slice(body.raw())?,
+                )
+                .map_err(HttpError::ApiError)?;
+
+            info!("live migration started");
+
+            let (_, receiver) = &*ONGOING_LIVEMIGRATION;
+
+            info!("waiting for live migration result");
+            let mig_res = receiver.lock().unwrap().recv().unwrap();
+            info!("received live migration result");
+
+            // We forward the migration error here to the guest
+            mig_res
+                .map(|_| res)
+                .map_err(|e| HttpError::ApiError(ApiError::VmSendMigration(e)))
+        } else {
+            Err(HttpError::BadRequest)
+        }
+    }
+}
+
+impl GetHandler for VmSendMigration {}
 
 impl PutHandler for VmResize {
     fn handle_request(

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -118,8 +118,8 @@ pub enum ApiError {
     #[error("The VM could not be snapshotted")]
     VmSnapshot(#[source] VmError),
 
-    /// The VM could not restored.
-    #[error("The VM could not restored")]
+    /// The VM could not be restored.
+    #[error("The VM could not be restored")]
     VmRestore(#[source] VmError),
 
     /// The VM could not be coredumped.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -243,6 +243,7 @@ pub enum EpollDispatch {
     Api = 2,
     ActivateVirtioDevices = 3,
     Debug = 4,
+    CheckMigration = 5,
     Unknown,
 }
 
@@ -255,6 +256,7 @@ impl From<u64> for EpollDispatch {
             2 => Api,
             3 => ActivateVirtioDevices,
             4 => Debug,
+            5 => CheckMigration,
             _ => Unknown,
         }
     }
@@ -739,6 +741,7 @@ pub struct Vmm {
     original_termios_opt: Arc<Mutex<Option<termios>>>,
     console_resize_pipe: Option<Arc<File>>,
     console_info: Option<ConsoleInfo>,
+    check_migration_evt: EventFd,
 }
 
 /// Wait for a file descriptor to become readable. In this case, we return
@@ -1467,6 +1470,7 @@ impl Vmm {
         let mut epoll = EpollContext::new().map_err(Error::Epoll)?;
         let reset_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
         let activate_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
+        let check_migration_evt = EventFd::new(EFD_NONBLOCK).map_err(Error::EventFdCreate)?;
 
         epoll
             .add_event(&exit_evt, EpollDispatch::Exit)
@@ -1489,6 +1493,10 @@ impl Vmm {
             .add_event(&debug_evt, EpollDispatch::Debug)
             .map_err(Error::Epoll)?;
 
+        epoll
+            .add_event(&check_migration_evt, EpollDispatch::CheckMigration)
+            .map_err(Error::Epoll)?;
+
         Ok(Vmm {
             epoll,
             exit_evt,
@@ -1509,6 +1517,7 @@ impl Vmm {
             original_termios_opt: Arc::new(Mutex::new(None)),
             console_resize_pipe: None,
             console_info: None,
+            check_migration_evt,
         })
     }
 
@@ -2255,6 +2264,14 @@ impl Vmm {
         }
     }
 
+    /// Checks the migration result.
+    ///
+    /// This should be called when the migration thread indicated a state
+    /// change (and therefore, its termination). The function checks the result
+    /// of that thread and either shuts down the VMM on success or keeps the VM
+    /// and the VMM running on migration failure.
+    fn check_migration_result(&mut self) {}
+
     fn control_loop(
         &mut self,
         api_receiver: Rc<Receiver<ApiRequest>>,
@@ -2348,6 +2365,14 @@ impl Vmm {
                     }
                     #[cfg(not(feature = "guest_debug"))]
                     EpollDispatch::Debug => {}
+                    EpollDispatch::CheckMigration => {
+                        info!("VM migration check event");
+                        // Consume the event.
+                        self.check_migration_evt
+                            .read()
+                            .map_err(Error::EventFdRead)?;
+                        self.check_migration_result();
+                    }
                 }
             }
         }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -64,6 +64,7 @@ use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::unblock_signal;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
+use crate::api::http::http_endpoint::ONGOING_LIVEMIGRATION;
 use crate::api::{
     ApiRequest, ApiResponse, RequestHandler, VmInfoResponse, VmReceiveMigrationData,
     VmSendMigrationData, VmmPingResponse,
@@ -2388,6 +2389,13 @@ impl Vmm {
 
         match migration_res {
             Ok(()) => {
+                {
+                    info!("Sending Receiver in HTTP thread that migration succeeded");
+                    let (sender, _) = &*ONGOING_LIVEMIGRATION;
+                    // unblock API call; propagate migration result
+                    sender.send(Ok(())).unwrap();
+                }
+
                 // Shutdown the VM after the migration succeeded
                 if let Err(e) = self.exit_evt.write(1) {
                     error!("Failed shutting down the VM after migration: {}", e);
@@ -2395,6 +2403,13 @@ impl Vmm {
             }
             Err(e) => {
                 error!("Migration failed: {}", e);
+                {
+                    info!("Sending Receiver in HTTP thread that migration failed");
+                    let (sender, _) = &*ONGOING_LIVEMIGRATION;
+                    // unblock API call; propagate migration result
+                    sender.send(Err(e)).unwrap();
+                }
+                // we don't fail the VMM here, it just continues running its VM
             }
         }
     }
@@ -2922,10 +2937,18 @@ impl RequestHandler for Vmm {
     }
 
     fn vm_resize_disk(&mut self, id: String, desired_size: u64) -> result::Result<(), VmError> {
+        info!("request to resize disk: id={id}");
         self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
 
         match self.vm {
-            MaybeVmOwnership::Vmm(ref mut vm) => vm.resize_disk(id, desired_size),
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                if let Err(e) = vm.resize_disk(id, desired_size) {
+                    error!("Error when resizing disk: {:?}", e);
+                    Err(e)
+                } else {
+                    Ok(())
+                }
+            }
             MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => Err(VmError::ResizeDisk),
         }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -33,7 +33,7 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::thread::JoinHandle;
 #[cfg(not(target_arch = "riscv64"))]
 use std::time::{Duration, Instant};
-use std::{io, result, thread};
+use std::{io, mem, result, thread};
 
 use anyhow::anyhow;
 #[cfg(feature = "dbus_api")]
@@ -778,6 +778,41 @@ pub struct VmmThreadHandle {
     pub http_api_handle: Option<HttpApiHandle>,
 }
 
+/// Describes the current ownership of a running VM.
+#[allow(clippy::large_enum_variant)]
+pub enum MaybeVmOwnership {
+    /// The VMM holds the ownership of the VM.
+    Vmm(Vm),
+    /// The VM is temporarily blocked by the current ongoing migration.
+    Migration,
+    /// No VM is running.
+    None,
+}
+
+impl MaybeVmOwnership {
+    /// Takes the VM and replaces it with [`Self::Migration`].
+    ///
+    /// # Panics
+    /// This method panics if `self` is not [`Self::Vmm`].
+    fn take_vm_for_migration(&mut self) -> Vm {
+        if !matches!(self, Self::Vmm(_)) {
+            panic!("should only be called when a migration can start");
+        }
+
+        match mem::replace(self, Self::Migration) {
+            MaybeVmOwnership::Vmm(vm) => vm,
+            _ => unreachable!(),
+        }
+    }
+
+    fn vm_mut(&mut self) -> Option<&mut Vm> {
+        match self {
+            MaybeVmOwnership::Vmm(vm) => Some(vm),
+            _ => None,
+        }
+    }
+}
+
 pub struct Vmm {
     epoll: EpollContext,
     exit_evt: EventFd,
@@ -788,12 +823,7 @@ pub struct Vmm {
     #[cfg(feature = "guest_debug")]
     vm_debug_evt: EventFd,
     version: VmmVersionInfo,
-    /// The currently running [`Vm`] instance, if any.
-    ///
-    /// This is `Some` from the boot to the shutdown of a VM. In the special
-    /// case of an ongoing live-migration, this is temporarily `None` and held
-    /// by a guard to prevent modifications to the VM.
-    vm: Option<Vm>,
+    vm: MaybeVmOwnership,
     vm_config: Option<Arc<Mutex<VmConfig>>>,
     seccomp_action: SeccompAction,
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
@@ -1573,7 +1603,7 @@ impl Vmm {
             #[cfg(feature = "guest_debug")]
             vm_debug_evt,
             version: vmm_version,
-            vm: None,
+            vm: MaybeVmOwnership::None,
             vm_config: None,
             seccomp_action,
             hypervisor,
@@ -1727,7 +1757,7 @@ impl Vmm {
                 Command::Complete => {
                     // The unwrap is safe, because the state machine makes sure we called
                     // vm_receive_state before, which creates the VM.
-                    let vm = self.vm.as_mut().unwrap();
+                    let vm = self.vm.vm_mut().unwrap();
                     vm.resume()?;
                     Ok(Completed)
                 }
@@ -1898,7 +1928,7 @@ impl Vmm {
         vm.restore().map_err(|e| {
             MigratableError::MigrateReceive(anyhow!("Failed restoring the Vm: {}", e))
         })?;
-        self.vm = Some(vm);
+        self.vm = MaybeVmOwnership::Vmm(vm);
 
         Ok(())
     }
@@ -2272,6 +2302,10 @@ impl Vmm {
         vm_config: Arc<Mutex<VmConfig>>,
         prefault: bool,
     ) -> std::result::Result<(), VmError> {
+        if matches!(self.vm, MaybeVmOwnership::Migration) {
+            return Err(VmError::VmMigrating);
+        }
+
         let snapshot = recv_vm_state(source_url).map_err(VmError::Restore)?;
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         let vm_snapshot = get_vm_snapshot(&snapshot).map_err(VmError::Restore)?;
@@ -2314,7 +2348,7 @@ impl Vmm {
             Some(source_url),
             Some(prefault),
         )?;
-        self.vm = Some(vm);
+        self.vm = MaybeVmOwnership::Vmm(vm);
 
         if self
             .vm_config
@@ -2329,11 +2363,8 @@ impl Vmm {
         }
 
         // Now we can restore the rest of the VM.
-        if let Some(ref mut vm) = self.vm {
-            vm.restore()
-        } else {
-            Err(VmError::VmNotCreated)
-        }
+        // PANIC: won't panic, we just checked that the VM is there.
+        self.vm.vm_mut().unwrap().restore()
     }
 
     /// Checks the migration result.
@@ -2353,7 +2384,7 @@ impl Vmm {
             .expect("should have joined");
 
         // Give VMM back control.
-        self.vm = Some(vm);
+        self.vm = MaybeVmOwnership::Vmm(vm);
 
         match migration_res {
             Ok(()) => {
@@ -2418,7 +2449,7 @@ impl Vmm {
                         self.vm_reboot().map_err(Error::VmReboot)?;
                     }
                     EpollDispatch::ActivateVirtioDevices => {
-                        if let Some(ref vm) = self.vm {
+                        if let MaybeVmOwnership::Vmm(ref vm) = self.vm {
                             let count = self.activate_evt.read().map_err(Error::EventFdRead)?;
                             info!(
                                 "Trying to activate pending virtio devices: count = {}",
@@ -2446,7 +2477,7 @@ impl Vmm {
                             // Read from the API receiver channel
                             let gdb_request = gdb_receiver.recv().map_err(Error::GdbRequestRecv)?;
 
-                            let response = if let Some(ref mut vm) = self.vm {
+                            let response = if let MaybeVmOwnership::Vmm(ref mut vm) = self.vm {
                                 vm.debug_request(&gdb_request.payload, gdb_request.cpu_id)
                             } else {
                                 Err(VmError::VmNotRunning)
@@ -2522,102 +2553,116 @@ impl RequestHandler for Vmm {
         tracer::start();
         info!("Booting VM");
         event!("vm", "booting");
-        let r = {
-            trace_scoped!("vm_boot");
-            // If we don't have a config, we cannot boot a VM.
-            if self.vm_config.is_none() {
-                return Err(VmError::VmMissingConfig);
-            };
 
-            // console_info is set to None in vm_shutdown. re-populate here if empty
-            if self.console_info.is_none() {
-                self.console_info =
-                    Some(pre_create_console_devices(self).map_err(VmError::CreateConsoleDevices)?);
-            }
-
-            // Create a new VM if we don't have one yet.
-            if self.vm.is_none() {
-                let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
-                let reset_evt = self.reset_evt.try_clone().map_err(VmError::EventFdClone)?;
-                #[cfg(feature = "guest_debug")]
-                let vm_debug_evt = self
-                    .vm_debug_evt
-                    .try_clone()
-                    .map_err(VmError::EventFdClone)?;
-                let activate_evt = self
-                    .activate_evt
-                    .try_clone()
-                    .map_err(VmError::EventFdClone)?;
-
-                if let Some(ref vm_config) = self.vm_config {
-                    let vm = Vm::new(
-                        Arc::clone(vm_config),
-                        exit_evt,
-                        reset_evt,
-                        #[cfg(feature = "guest_debug")]
-                        vm_debug_evt,
-                        &self.seccomp_action,
-                        self.hypervisor.clone(),
-                        activate_evt,
-                        self.console_info.clone(),
-                        self.console_resize_pipe.clone(),
-                        Arc::clone(&self.original_termios_opt),
-                        None,
-                        None,
-                        None,
-                    )?;
-
-                    self.vm = Some(vm);
-                }
-            }
-
-            // Now we can boot the VM.
-            if let Some(ref mut vm) = self.vm {
-                vm.boot()
-            } else {
-                Err(VmError::VmNotCreated)
-            }
-        };
-        tracer::end();
-        if r.is_ok() {
-            event!("vm", "booted");
+        if matches!(self.vm, MaybeVmOwnership::Migration) {
+            return Err(VmError::VmMigrating);
         }
-        r
+
+        trace_scoped!("vm_boot");
+        // If we don't have a config, we cannot boot a VM.
+        if self.vm_config.is_none() {
+            return Err(VmError::VmMissingConfig);
+        };
+
+        // console_info is set to None in vm_shutdown. re-populate here if empty
+        if self.console_info.is_none() {
+            self.console_info =
+                Some(pre_create_console_devices(self).map_err(VmError::CreateConsoleDevices)?);
+        }
+
+        // Create a new VM if we don't have one yet.
+        if matches!(self.vm, MaybeVmOwnership::None) {
+            let exit_evt = self.exit_evt.try_clone().map_err(VmError::EventFdClone)?;
+            let reset_evt = self.reset_evt.try_clone().map_err(VmError::EventFdClone)?;
+            #[cfg(feature = "guest_debug")]
+            let vm_debug_evt = self
+                .vm_debug_evt
+                .try_clone()
+                .map_err(VmError::EventFdClone)?;
+            let activate_evt = self
+                .activate_evt
+                .try_clone()
+                .map_err(VmError::EventFdClone)?;
+
+            if let Some(ref vm_config) = self.vm_config {
+                let vm = Vm::new(
+                    Arc::clone(vm_config),
+                    exit_evt,
+                    reset_evt,
+                    #[cfg(feature = "guest_debug")]
+                    vm_debug_evt,
+                    &self.seccomp_action,
+                    self.hypervisor.clone(),
+                    activate_evt,
+                    self.console_info.clone(),
+                    self.console_resize_pipe.clone(),
+                    Arc::clone(&self.original_termios_opt),
+                    None,
+                    None,
+                    None,
+                )?;
+
+                self.vm = MaybeVmOwnership::Vmm(vm);
+            }
+        }
+
+        // Now we can boot the VM.
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                vm.boot()?;
+                event!("vm", "booted");
+            }
+            MaybeVmOwnership::None => {
+                return Err(VmError::VmNotCreated);
+            }
+            _ => unreachable!(),
+        }
+
+        tracer::end();
+        Ok(())
     }
 
     fn vm_pause(&mut self) -> result::Result<(), VmError> {
-        if let Some(ref mut vm) = self.vm {
-            vm.pause().map_err(VmError::Pause)
-        } else {
-            Err(VmError::VmNotRunning)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => vm.pause().map_err(VmError::Pause),
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating)?,
+            MaybeVmOwnership::None => Err(VmError::VmNotRunning)?,
         }
     }
 
     fn vm_resume(&mut self) -> result::Result<(), VmError> {
-        if let Some(ref mut vm) = self.vm {
-            vm.resume().map_err(VmError::Resume)
-        } else {
-            Err(VmError::VmNotRunning)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => vm.resume().map_err(VmError::Resume),
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating)?,
+            MaybeVmOwnership::None => Err(VmError::VmNotRunning)?,
         }
     }
 
     fn vm_snapshot(&mut self, destination_url: &str) -> result::Result<(), VmError> {
-        if let Some(ref mut vm) = self.vm {
-            // Drain console_info so that FDs are not reused
-            let _ = self.console_info.take();
-            vm.snapshot()
-                .map_err(VmError::Snapshot)
-                .and_then(|snapshot| {
-                    vm.send(&snapshot, destination_url)
-                        .map_err(VmError::SnapshotSend)
-                })
-        } else {
-            Err(VmError::VmNotRunning)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                // Drain console_info so that FDs are not reused
+                let _ = self.console_info.take();
+                vm.snapshot()
+                    .map_err(VmError::Snapshot)
+                    .and_then(|snapshot| {
+                        vm.send(&snapshot, destination_url)
+                            .map_err(VmError::SnapshotSend)
+                    })
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating)?,
+            MaybeVmOwnership::None => Err(VmError::VmNotRunning)?,
         }
     }
 
     fn vm_restore(&mut self, restore_cfg: RestoreConfig) -> result::Result<(), VmError> {
-        if self.vm.is_some() || self.vm_config.is_some() {
+        match &self.vm {
+            MaybeVmOwnership::Vmm(_vm) => return Err(VmError::VmAlreadyCreated),
+            MaybeVmOwnership::Migration => return Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => (),
+        };
+
+        if self.vm_config.is_some() {
             return Err(VmError::VmAlreadyCreated);
         }
 
@@ -2664,21 +2709,25 @@ impl RequestHandler for Vmm {
 
     #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
     fn vm_coredump(&mut self, destination_url: &str) -> result::Result<(), VmError> {
-        if let Some(ref mut vm) = self.vm {
-            vm.coredump(destination_url).map_err(VmError::Coredump)
-        } else {
-            Err(VmError::VmNotRunning)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                vm.coredump(destination_url).map_err(VmError::Coredump)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => Err(VmError::VmNotRunning),
         }
     }
 
     fn vm_shutdown(&mut self) -> result::Result<(), VmError> {
-        let r = if let Some(ref mut vm) = self.vm.take() {
-            // Drain console_info so that the FDs are not reused
-            let _ = self.console_info.take();
-            vm.shutdown()
-        } else {
-            Err(VmError::VmNotRunning)
+        let vm = match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => vm,
+            MaybeVmOwnership::Migration => return Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => return Err(VmError::VmNotRunning),
         };
+        // Drain console_info so that the FDs are not reused
+        let _ = self.console_info.take();
+        let r = vm.shutdown();
+        self.vm = MaybeVmOwnership::None;
 
         if r.is_ok() {
             event!("vm", "shutdown");
@@ -2691,13 +2740,14 @@ impl RequestHandler for Vmm {
         event!("vm", "rebooting");
 
         // First we stop the current VM
-        let config = if let Some(mut vm) = self.vm.take() {
-            let config = vm.get_config();
-            vm.shutdown()?;
-            config
-        } else {
-            return Err(VmError::VmNotCreated);
+        let vm = match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => vm,
+            MaybeVmOwnership::Migration => return Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => return Err(VmError::VmNotRunning),
         };
+        let config = vm.get_config();
+        vm.shutdown()?;
+        self.vm = MaybeVmOwnership::None;
 
         // vm.shutdown() closes all the console devices, so set console_info to None
         // so that the closed FD #s are not reused.
@@ -2746,7 +2796,7 @@ impl RequestHandler for Vmm {
         // And we boot it
         vm.boot()?;
 
-        self.vm = Some(vm);
+        self.vm = MaybeVmOwnership::Vmm(vm);
 
         event!("vm", "rebooted");
 
@@ -2754,33 +2804,38 @@ impl RequestHandler for Vmm {
     }
 
     fn vm_info(&self) -> result::Result<VmInfoResponse, VmError> {
-        match &self.vm_config {
-            Some(vm_config) => {
-                let state = match &self.vm {
-                    Some(vm) => vm.get_state()?,
-                    None => VmState::Created,
-                };
-                let config = vm_config.lock().unwrap().clone();
+        let vm_config = self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
+        let vm_config = vm_config.lock().unwrap().clone();
 
-                let mut memory_actual_size = config.memory.total_size();
-                if let Some(vm) = &self.vm {
-                    memory_actual_size -= vm.balloon_size();
-                }
+        let state = match &self.vm {
+            MaybeVmOwnership::Vmm(vm) => vm.get_state()?,
+            // TODO in theory one could live-migrate a non-running VM ..
+            MaybeVmOwnership::Migration => VmState::Running,
+            MaybeVmOwnership::None => VmState::Created,
+        };
 
-                let device_tree = self
-                    .vm
-                    .as_ref()
-                    .map(|vm| vm.device_tree().lock().unwrap().clone());
-
-                Ok(VmInfoResponse {
-                    config: Box::new(config),
-                    state,
-                    memory_actual_size,
-                    device_tree,
-                })
+        let mut memory_actual_size = vm_config.memory.total_size();
+        match &self.vm {
+            MaybeVmOwnership::Vmm(vm) => {
+                memory_actual_size -= vm.balloon_size();
             }
-            None => Err(VmError::VmNotCreated),
+            MaybeVmOwnership::Migration => {}
+            MaybeVmOwnership::None => {}
         }
+
+        let device_tree = match &self.vm {
+            MaybeVmOwnership::Vmm(vm) => Some(vm.device_tree().lock().unwrap().clone()),
+            // TODO we need to fix this
+            MaybeVmOwnership::Migration => None,
+            MaybeVmOwnership::None => None,
+        };
+
+        Ok(VmInfoResponse {
+            config: Box::new(vm_config),
+            state,
+            memory_actual_size,
+            device_tree,
+        })
     }
 
     fn vmm_ping(&self) -> VmmPingResponse {
@@ -2802,14 +2857,19 @@ impl RequestHandler for Vmm {
             return Ok(());
         }
 
-        // If a VM is booted, we first try to shut it down.
-        if self.vm.is_some() {
-            self.vm_shutdown()?;
+        match &self.vm {
+            MaybeVmOwnership::Vmm(_vm) => {
+                event!("vm", "deleted");
+
+                // If a VM is booted, we first try to shut it down.
+                self.vm_shutdown()?;
+                self.vm_config = None;
+            }
+            MaybeVmOwnership::None => {
+                self.vm_config = None;
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating)?,
         }
-
-        self.vm_config = None;
-
-        event!("vm", "deleted");
 
         Ok(())
     }
@@ -2832,64 +2892,73 @@ impl RequestHandler for Vmm {
             todo!("doesn't work currently with our thread-local KVM_RUN approach");
         }
 
-        if let Some(ref mut vm) = self.vm {
-            if let Err(e) = vm.resize(desired_vcpus, desired_ram, desired_balloon) {
-                error!("Error when resizing VM: {:?}", e);
-                Err(e)
-            } else {
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                if let Err(e) = vm.resize(desired_vcpus, desired_ram, desired_balloon) {
+                    error!("Error when resizing VM: {:?}", e);
+                    Err(e)
+                } else {
+                    Ok(())
+                }
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+                if let Some(desired_vcpus) = desired_vcpus {
+                    config.cpus.boot_vcpus = desired_vcpus;
+                }
+                if let Some(desired_ram) = desired_ram {
+                    config.memory.size = desired_ram;
+                }
+                if let Some(desired_balloon) = desired_balloon
+                    && let Some(balloon_config) = &mut config.balloon
+                {
+                    balloon_config.size = desired_balloon;
+                }
+
                 Ok(())
             }
-        } else {
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            if let Some(desired_vcpus) = desired_vcpus {
-                config.cpus.boot_vcpus = desired_vcpus;
-            }
-            if let Some(desired_ram) = desired_ram {
-                config.memory.size = desired_ram;
-            }
-            if let Some(desired_balloon) = desired_balloon
-                && let Some(balloon_config) = &mut config.balloon
-            {
-                balloon_config.size = desired_balloon;
-            }
-            Ok(())
         }
     }
 
     fn vm_resize_disk(&mut self, id: String, desired_size: u64) -> result::Result<(), VmError> {
         self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
 
-        if let Some(ref mut vm) = self.vm {
-            return vm.resize_disk(id, desired_size);
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => vm.resize_disk(id, desired_size),
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => Err(VmError::ResizeDisk),
         }
-
-        Err(VmError::ResizeDisk)
     }
     fn vm_resize_zone(&mut self, id: String, desired_ram: u64) -> result::Result<(), VmError> {
         self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
 
-        if let Some(ref mut vm) = self.vm {
-            if let Err(e) = vm.resize_zone(id, desired_ram) {
-                error!("Error when resizing VM: {:?}", e);
-                Err(e)
-            } else {
-                Ok(())
-            }
-        } else {
-            // Update VmConfig by setting the new desired ram.
-            let memory_config = &mut self.vm_config.as_ref().unwrap().lock().unwrap().memory;
-
-            if let Some(zones) = &mut memory_config.zones {
-                for zone in zones.iter_mut() {
-                    if zone.id == id {
-                        zone.size = desired_ram;
-                        return Ok(());
-                    }
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                if let Err(e) = vm.resize_zone(id, desired_ram) {
+                    error!("Error when resizing VM: {:?}", e);
+                    Err(e)
+                } else {
+                    Ok(())
                 }
             }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                // Update VmConfig by setting the new desired ram.
+                let memory_config = &mut self.vm_config.as_ref().unwrap().lock().unwrap().memory;
 
-            error!("Could not find the memory zone {} for the resize", id);
-            Err(VmError::ResizeZone)
+                if let Some(zones) = &mut memory_config.zones {
+                    for zone in zones.iter_mut() {
+                        if zone.id == id {
+                            zone.size = desired_ram;
+                            return Ok(());
+                        }
+                    }
+                }
+
+                error!("Could not find the memory zone {} for the resize", id);
+                Err(VmError::ResizeZone)
+            }
         }
     }
 
@@ -2906,19 +2975,23 @@ impl RequestHandler for Vmm {
             config.validate().map_err(VmError::ConfigValidation)?;
         }
 
-        if let Some(ref mut vm) = self.vm {
-            let info = vm.add_device(device_cfg).map_err(|e| {
-                error!("Error when adding new device to the VM: {:?}", e);
-                e
-            })?;
-            serde_json::to_vec(&info)
-                .map(Some)
-                .map_err(VmError::SerializeJson)
-        } else {
-            // Update VmConfig by adding the new device.
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            add_to_config(&mut config.devices, device_cfg);
-            Ok(None)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                let info = vm.add_device(device_cfg).map_err(|e| {
+                    error!("Error when adding new device to the VM: {:?}", e);
+                    e
+                })?;
+                serde_json::to_vec(&info)
+                    .map(Some)
+                    .map_err(VmError::SerializeJson)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                // Update VmConfig by adding the new device.
+                let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+                add_to_config(&mut config.devices, device_cfg);
+                Ok(None)
+            }
         }
     }
 
@@ -2935,39 +3008,49 @@ impl RequestHandler for Vmm {
             config.validate().map_err(VmError::ConfigValidation)?;
         }
 
-        if let Some(ref mut vm) = self.vm {
-            let info = vm.add_user_device(device_cfg).map_err(|e| {
-                error!("Error when adding new user device to the VM: {:?}", e);
-                e
-            })?;
-            serde_json::to_vec(&info)
-                .map(Some)
-                .map_err(VmError::SerializeJson)
-        } else {
-            // Update VmConfig by adding the new device.
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            add_to_config(&mut config.user_devices, device_cfg);
-            Ok(None)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                let info = vm.add_user_device(device_cfg).map_err(|e| {
+                    error!("Error when adding new user device to the VM: {:?}", e);
+                    e
+                })?;
+                serde_json::to_vec(&info)
+                    .map(Some)
+                    .map_err(VmError::SerializeJson)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                // Update VmConfig by adding the new device.
+                let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+                add_to_config(&mut config.user_devices, device_cfg);
+                Ok(None)
+            }
         }
     }
 
     fn vm_remove_device(&mut self, id: String) -> result::Result<(), VmError> {
-        if let Some(ref mut vm) = self.vm {
-            if let Err(e) = vm.remove_device(id) {
-                error!("Error when removing device from the VM: {:?}", e);
-                Err(e)
-            } else {
-                Ok(())
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                if let Err(e) = vm.remove_device(id) {
+                    error!("Error when removing device from the VM: {:?}", e);
+                    Err(e)
+                } else {
+                    Ok(())
+                }
             }
-        } else if let Some(ref config) = self.vm_config {
-            let mut config = config.lock().unwrap();
-            if config.remove_device(&id) {
-                Ok(())
-            } else {
-                Err(VmError::NoDeviceToRemove(id))
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                if let Some(ref config) = self.vm_config {
+                    let mut config = config.lock().unwrap();
+                    if config.remove_device(&id) {
+                        Ok(())
+                    } else {
+                        Err(VmError::NoDeviceToRemove(id))
+                    }
+                } else {
+                    Err(VmError::VmNotCreated)
+                }
             }
-        } else {
-            Err(VmError::VmNotCreated)
         }
     }
 
@@ -2981,19 +3064,23 @@ impl RequestHandler for Vmm {
             config.validate().map_err(VmError::ConfigValidation)?;
         }
 
-        if let Some(ref mut vm) = self.vm {
-            let info = vm.add_disk(disk_cfg).map_err(|e| {
-                error!("Error when adding new disk to the VM: {:?}", e);
-                e
-            })?;
-            serde_json::to_vec(&info)
-                .map(Some)
-                .map_err(VmError::SerializeJson)
-        } else {
-            // Update VmConfig by adding the new device.
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            add_to_config(&mut config.disks, disk_cfg);
-            Ok(None)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                let info = vm.add_disk(disk_cfg).map_err(|e| {
+                    error!("Error when adding new disk to the VM: {:?}", e);
+                    e
+                })?;
+                serde_json::to_vec(&info)
+                    .map(Some)
+                    .map_err(VmError::SerializeJson)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                // Update VmConfig by adding the new device.
+                let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+                add_to_config(&mut config.disks, disk_cfg);
+                Ok(None)
+            }
         }
     }
 
@@ -3007,19 +3094,23 @@ impl RequestHandler for Vmm {
             config.validate().map_err(VmError::ConfigValidation)?;
         }
 
-        if let Some(ref mut vm) = self.vm {
-            let info = vm.add_fs(fs_cfg).map_err(|e| {
-                error!("Error when adding new fs to the VM: {:?}", e);
-                e
-            })?;
-            serde_json::to_vec(&info)
-                .map(Some)
-                .map_err(VmError::SerializeJson)
-        } else {
-            // Update VmConfig by adding the new device.
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            add_to_config(&mut config.fs, fs_cfg);
-            Ok(None)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                let info = vm.add_fs(fs_cfg).map_err(|e| {
+                    error!("Error when adding new fs to the VM: {:?}", e);
+                    e
+                })?;
+                serde_json::to_vec(&info)
+                    .map(Some)
+                    .map_err(VmError::SerializeJson)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                // Update VmConfig by adding the new device.
+                let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+                add_to_config(&mut config.fs, fs_cfg);
+                Ok(None)
+            }
         }
     }
 
@@ -3033,19 +3124,23 @@ impl RequestHandler for Vmm {
             config.validate().map_err(VmError::ConfigValidation)?;
         }
 
-        if let Some(ref mut vm) = self.vm {
-            let info = vm.add_pmem(pmem_cfg).map_err(|e| {
-                error!("Error when adding new pmem device to the VM: {:?}", e);
-                e
-            })?;
-            serde_json::to_vec(&info)
-                .map(Some)
-                .map_err(VmError::SerializeJson)
-        } else {
-            // Update VmConfig by adding the new device.
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            add_to_config(&mut config.pmem, pmem_cfg);
-            Ok(None)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                let info = vm.add_pmem(pmem_cfg).map_err(|e| {
+                    error!("Error when adding new pmem device to the VM: {:?}", e);
+                    e
+                })?;
+                serde_json::to_vec(&info)
+                    .map(Some)
+                    .map_err(VmError::SerializeJson)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                // Update VmConfig by adding the new device.
+                let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+                add_to_config(&mut config.pmem, pmem_cfg);
+                Ok(None)
+            }
         }
     }
 
@@ -3059,19 +3154,23 @@ impl RequestHandler for Vmm {
             config.validate().map_err(VmError::ConfigValidation)?;
         }
 
-        if let Some(ref mut vm) = self.vm {
-            let info = vm.add_net(net_cfg).map_err(|e| {
-                error!("Error when adding new network device to the VM: {:?}", e);
-                e
-            })?;
-            serde_json::to_vec(&info)
-                .map(Some)
-                .map_err(VmError::SerializeJson)
-        } else {
-            // Update VmConfig by adding the new device.
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            add_to_config(&mut config.net, net_cfg);
-            Ok(None)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                let info = vm.add_net(net_cfg).map_err(|e| {
+                    error!("Error when adding new network device to the VM: {:?}", e);
+                    e
+                })?;
+                serde_json::to_vec(&info)
+                    .map(Some)
+                    .map_err(VmError::SerializeJson)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                // Update VmConfig by adding the new device.
+                let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+                add_to_config(&mut config.net, net_cfg);
+                Ok(None)
+            }
         }
     }
 
@@ -3085,19 +3184,23 @@ impl RequestHandler for Vmm {
             config.validate().map_err(VmError::ConfigValidation)?;
         }
 
-        if let Some(ref mut vm) = self.vm {
-            let info = vm.add_vdpa(vdpa_cfg).map_err(|e| {
-                error!("Error when adding new vDPA device to the VM: {:?}", e);
-                e
-            })?;
-            serde_json::to_vec(&info)
-                .map(Some)
-                .map_err(VmError::SerializeJson)
-        } else {
-            // Update VmConfig by adding the new device.
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            add_to_config(&mut config.vdpa, vdpa_cfg);
-            Ok(None)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                let info = vm.add_vdpa(vdpa_cfg).map_err(|e| {
+                    error!("Error when adding new vDPA device to the VM: {:?}", e);
+                    e
+                })?;
+                serde_json::to_vec(&info)
+                    .map(Some)
+                    .map_err(VmError::SerializeJson)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                // Update VmConfig by adding the new device.
+                let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+                add_to_config(&mut config.vdpa, vdpa_cfg);
+                Ok(None)
+            }
         }
     }
 
@@ -3116,49 +3219,55 @@ impl RequestHandler for Vmm {
             config.validate().map_err(VmError::ConfigValidation)?;
         }
 
-        if let Some(ref mut vm) = self.vm {
-            let info = vm.add_vsock(vsock_cfg).map_err(|e| {
-                error!("Error when adding new vsock device to the VM: {:?}", e);
-                e
-            })?;
-            serde_json::to_vec(&info)
-                .map(Some)
-                .map_err(VmError::SerializeJson)
-        } else {
-            // Update VmConfig by adding the new device.
-            let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            config.vsock = Some(vsock_cfg);
-            Ok(None)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                let info = vm.add_vsock(vsock_cfg).map_err(|e| {
+                    error!("Error when adding new vsock device to the VM: {:?}", e);
+                    e
+                })?;
+                serde_json::to_vec(&info)
+                    .map(Some)
+                    .map_err(VmError::SerializeJson)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => {
+                // Update VmConfig by adding the new device.
+                let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
+                config.vsock = Some(vsock_cfg);
+                Ok(None)
+            }
         }
     }
 
     fn vm_counters(&mut self) -> result::Result<Option<Vec<u8>>, VmError> {
-        if let Some(ref mut vm) = self.vm {
-            let info = vm.counters().map_err(|e| {
-                error!("Error when getting counters from the VM: {:?}", e);
-                e
-            })?;
-            serde_json::to_vec(&info)
-                .map(Some)
-                .map_err(VmError::SerializeJson)
-        } else {
-            Err(VmError::VmNotRunning)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => {
+                let info = vm.counters().map_err(|e| {
+                    error!("Error when getting counters from the VM: {:?}", e);
+                    e
+                })?;
+                serde_json::to_vec(&info)
+                    .map(Some)
+                    .map_err(VmError::SerializeJson)
+            }
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => Err(VmError::VmNotRunning),
         }
     }
 
     fn vm_power_button(&mut self) -> result::Result<(), VmError> {
-        if let Some(ref mut vm) = self.vm {
-            vm.power_button()
-        } else {
-            Err(VmError::VmNotRunning)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => vm.power_button(),
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => Err(VmError::VmNotRunning),
         }
     }
 
     fn vm_nmi(&mut self) -> result::Result<(), VmError> {
-        if let Some(ref mut vm) = self.vm {
-            vm.nmi()
-        } else {
-            Err(VmError::VmNotRunning)
+        match self.vm {
+            MaybeVmOwnership::Vmm(ref mut vm) => vm.nmi(),
+            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::None => Err(VmError::VmNotRunning),
         }
     }
 
@@ -3204,7 +3313,7 @@ impl RequestHandler for Vmm {
         }
 
         if let ReceiveMigrationState::Aborted = state {
-            self.vm = None;
+            self.vm = MaybeVmOwnership::None;
             self.vm_config = None;
         }
 
@@ -3215,13 +3324,22 @@ impl RequestHandler for Vmm {
         &mut self,
         send_data_migration: VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
+        match self.vm {
+            MaybeVmOwnership::Vmm(_) => (),
+            MaybeVmOwnership::Migration => {
+                return Err(MigratableError::MigrateSend(anyhow!(
+                    "There is already an ongoing migration"
+                )));
+            }
+            MaybeVmOwnership::None => {
+                return Err(MigratableError::MigrateSend(anyhow!("VM is not running")));
+            }
+        };
+
         info!(
             "Sending migration: destination_url = {}, local = {}",
             send_data_migration.destination_url, send_data_migration.local
         );
-
-        // TODO Check if there is already a migration in progress
-        // will be done in next commit
 
         if !self
             .vm_config
@@ -3239,10 +3357,7 @@ impl RequestHandler for Vmm {
 
         // Take VM ownership. This also means that API events can no longer
         // change the VM (e.g. net device hotplug).
-        let vm = self
-            .vm
-            .take()
-            .ok_or(MigratableError::MigrateSend(anyhow!("VM is not running")))?;
+        let vm = self.vm.take_vm_for_migration();
 
         // Start migration thread
         let worker = MigrationWorker {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -30,6 +30,7 @@ use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::mpsc::{Receiver, RecvError, SendError, Sender, TrySendError};
 use std::sync::{Arc, Barrier, Mutex};
+use std::thread::JoinHandle;
 #[cfg(not(target_arch = "riscv64"))]
 use std::time::{Duration, Instant};
 use std::{io, result, thread};
@@ -714,6 +715,62 @@ impl MigrationState {
     }
 }
 
+/// Abstraction for the thread controlling and performing the live migration.
+///
+/// The migration thread also takes ownership of the [`Vm`] from the [`Vmm`].
+struct MigrationWorker {
+    vm: Vm,
+    check_migration_evt: EventFd,
+    config: VmSendMigrationData,
+    #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+    hypervisor: Arc<dyn hypervisor::Hypervisor>,
+}
+
+impl MigrationWorker {
+    /// Performs any final cleanup after failed live migrations.
+    ///
+    /// Helper for [`Self::migrate`].
+    fn migrate_error_cleanup(&mut self) -> result::Result<(), MigratableError> {
+        // Stop logging dirty pages only for non-local migrations
+        if !self.config.local {
+            self.vm.stop_dirty_log()?;
+        }
+
+        Ok(())
+    }
+
+    /// Migrate and cleanup.
+    fn migrate(&mut self) -> result::Result<(), MigratableError> {
+        debug!("start sending migration");
+        Vmm::send_migration(
+            &mut self.vm,
+            #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+            self.hypervisor.clone(),
+            self.config.clone(),
+        ).inspect_err(|_| {
+            let e = self.migrate_error_cleanup();
+            if let Err(e) = e {
+                error!("Failed to clean up after a failed live migration. VM might keep running but in an odd or possibly slowed-down state: {e}");
+            }
+        })?;
+
+        Ok(())
+    }
+
+    /// Perform the migration and communicate with the [`Vmm`] thread.
+    fn run(mut self) -> (Vm, result::Result<(), MigratableError>) {
+        debug!("migration thread is starting");
+
+        let res = self.migrate().inspect_err(|e| error!("migrate error: {e}"));
+
+        // Notify VMM thread to get migration result by joining this thread.
+        self.check_migration_evt.write(1).unwrap();
+
+        debug!("migration thread is finished");
+        (self.vm, res)
+    }
+}
+
 pub struct VmmThreadHandle {
     pub thread_handle: thread::JoinHandle<Result<()>>,
     #[cfg(feature = "dbus_api")]
@@ -731,6 +788,11 @@ pub struct Vmm {
     #[cfg(feature = "guest_debug")]
     vm_debug_evt: EventFd,
     version: VmmVersionInfo,
+    /// The currently running [`Vm`] instance, if any.
+    ///
+    /// This is `Some` from the boot to the shutdown of a VM. In the special
+    /// case of an ongoing live-migration, this is temporarily `None` and held
+    /// by a guard to prevent modifications to the VM.
     vm: Option<Vm>,
     vm_config: Option<Arc<Mutex<VmConfig>>>,
     seccomp_action: SeccompAction,
@@ -742,6 +804,10 @@ pub struct Vmm {
     console_resize_pipe: Option<Arc<File>>,
     console_info: Option<ConsoleInfo>,
     check_migration_evt: EventFd,
+    /// Handle to the [`MigrationWorker`] thread.
+    ///
+    /// The handle will return the [`Vm`] back in any case. Further, the underlying error (if any) is returned.
+    migration_thread_handle: Option<JoinHandle<(Vm, result::Result<(), MigratableError>)>>,
 }
 
 /// Wait for a file descriptor to become readable. In this case, we return
@@ -1418,14 +1484,14 @@ impl Vmm {
                         .name("vmm_signal_handler".to_string())
                         .spawn(move || {
                             if !signal_handler_seccomp_filter.is_empty() && let Err(e) = apply_filter(&signal_handler_seccomp_filter)
-                                    .map_err(Error::ApplySeccompFilter)
-                                {
-                                    error!("Error applying seccomp filter: {:?}", e);
-                                    exit_evt.write(1).ok();
-                                    return;
-                                }
+                                .map_err(Error::ApplySeccompFilter)
+                            {
+                                error!("Error applying seccomp filter: {:?}", e);
+                                exit_evt.write(1).ok();
+                                return;
+                            }
 
-                            if landlock_enable{
+                            if landlock_enable {
                                 match Landlock::new() {
                                     Ok(landlock) => {
                                         let _ = landlock.restrict_self().map_err(Error::ApplyLandlock).map_err(|e| {
@@ -1443,11 +1509,11 @@ impl Vmm {
                             std::panic::catch_unwind(AssertUnwindSafe(|| {
                                 Vmm::signal_handler(signals, original_termios_opt, &exit_evt);
                             }))
-                            .map_err(|_| {
-                                error!("vmm signal_handler thread panicked");
-                                exit_evt.write(1).ok()
-                            })
-                            .ok();
+                                .map_err(|_| {
+                                    error!("vmm signal_handler thread panicked");
+                                    exit_evt.write(1).ok()
+                                })
+                                .ok();
                         })
                         .map_err(Error::SignalHandlerSpawn)?,
                 );
@@ -1518,6 +1584,7 @@ impl Vmm {
             console_resize_pipe: None,
             console_info: None,
             check_migration_evt,
+            migration_thread_handle: None,
         })
     }
 
@@ -2016,6 +2083,11 @@ impl Vmm {
         Ok(())
     }
 
+    /// Performs a live-migration.
+    ///
+    /// This function performs necessary after-migration cleanup only in the
+    /// good case. Callers are responsible for properly handling failed
+    /// migrations.
     fn send_migration(
         vm: &mut Vm,
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))] hypervisor: Arc<
@@ -2270,7 +2342,31 @@ impl Vmm {
     /// change (and therefore, its termination). The function checks the result
     /// of that thread and either shuts down the VMM on success or keeps the VM
     /// and the VMM running on migration failure.
-    fn check_migration_result(&mut self) {}
+    fn check_migration_result(&mut self) {
+        // At this point, the thread must be finished.
+        // If we fail here, we have lost anyway. Just panic.
+        let (vm, migration_res) = self
+            .migration_thread_handle
+            .take()
+            .expect("should have thread")
+            .join()
+            .expect("should have joined");
+
+        // Give VMM back control.
+        self.vm = Some(vm);
+
+        match migration_res {
+            Ok(()) => {
+                // Shutdown the VM after the migration succeeded
+                if let Err(e) = self.exit_evt.write(1) {
+                    error!("Failed shutting down the VM after migration: {}", e);
+                }
+            }
+            Err(e) => {
+                error!("Migration failed: {}", e);
+            }
+        }
+    }
 
     fn control_loop(
         &mut self,
@@ -3124,6 +3220,9 @@ impl RequestHandler for Vmm {
             send_data_migration.destination_url, send_data_migration.local
         );
 
+        // TODO Check if there is already a migration in progress
+        // will be done in next commit
+
         if !self
             .vm_config
             .as_ref()
@@ -3138,42 +3237,32 @@ impl RequestHandler for Vmm {
             )));
         }
 
-        if let Some(vm) = self.vm.as_mut() {
-            Self::send_migration(
-                vm,
-                #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-                self.hypervisor.clone(),
-                send_data_migration.clone(),
-            )
-            .map_err(|migration_err| {
-                error!("Migration failed: {:?}", migration_err);
+        // Take VM ownership. This also means that API events can no longer
+        // change the VM (e.g. net device hotplug).
+        let vm = self
+            .vm
+            .take()
+            .ok_or(MigratableError::MigrateSend(anyhow!("VM is not running")))?;
 
-                // Stop logging dirty pages only for non-local migrations
-                if !send_data_migration.local
-                    && let Err(e) = vm.stop_dirty_log()
-                {
-                    return e;
-                }
+        // Start migration thread
+        let worker = MigrationWorker {
+            vm,
+            check_migration_evt: self.check_migration_evt.try_clone().unwrap(),
+            config: send_data_migration,
+            #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+            hypervisor: self.hypervisor.clone(),
+        };
 
-                if vm.get_state().unwrap() == VmState::Paused
-                    && let Err(e) = vm.resume()
-                {
-                    return e;
-                }
+        self.migration_thread_handle = Some(
+            thread::Builder::new()
+                .name("migration".into())
+                .spawn(move || worker.run())
+                // For upstreaming, we should simply continue and return an
+                // error when this fails. For our PoC, this is fine.
+                .unwrap(),
+        );
 
-                migration_err
-            })?;
-
-            // Shutdown the VM after the migration succeeded
-            self.exit_evt.write(1).map_err(|e| {
-                MigratableError::MigrateSend(anyhow!(
-                    "Failed shutting down the VM after migration: {:?}",
-                    e
-                ))
-            })
-        } else {
-            Err(MigratableError::MigrateSend(anyhow!("VM is not running")))
-        }
+        Ok(())
     }
 }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -865,6 +865,7 @@ fn http_api_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError>
         (libc::SYS_write, vec![]),
         (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_getcwd, vec![]),
+        (libc::SYS_clock_nanosleep, vec![]),
     ])
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -177,6 +177,9 @@ pub enum Error {
     #[error("VM is not running")]
     VmNotRunning,
 
+    #[error("VM is currently migrating and can't be modified")]
+    VmMigrating,
+
     #[error("Cannot clone EventFd")]
     EventFdClone(#[source] io::Error),
 


### PR DESCRIPTION
The PR prepares the live-migration statistics. For that, we need to ensure that `SendMigration` won't block the whole VMM thread's event loop all the time ("asynchronization").

Further, this PR lays the groundwork to prevent VM change events (resize, hotplug) when a migration is ongoing.

## Changes
- EventFD logic to sync VMM from the VM Migration Thread
- Put migration into dedicated thread that takes ownership of the VM from the VMM
- Let all endpoints know when a migration is ongoing (the VMM knows the VMs ownership

**Please review this commit-by-commit.**


Closes https://github.com/cobaltcore-dev/cobaltcore/issues/293 and https://github.com/cobaltcore-dev/cobaltcore/issues/230


## Steps Before Merge
- [x] passes libvirt-tests
- [x] Team aggrees design