### PR TITLE
Allow VM config change of TCP serial url during live migration

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -897,6 +897,7 @@ fn coredump_config(destination_url: &str) -> String {
 fn receive_migration_data(url: &str) -> String {
     let receive_migration_data = vmm::api::VmReceiveMigrationData {
         receiver_url: url.to_owned(),
+        tcp_serial_url: None,
         // Only FDs transmitted via an SCM_RIGHTS UNIX Domain Socket message
         // are valid. Transmitting specific FD nums via the HTTP API is
         // almost always invalid.

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -249,6 +249,9 @@ pub struct VmCoredumpData {
 pub struct VmReceiveMigrationData {
     /// URL for the reception of migration state
     pub receiver_url: String,
+    /// Optional URL if the TCP serial configuration must be changed during
+    /// migration. Example: "192.168.1.1:2222".
+    pub tcp_serial_url: Option<String>,
     /// Map with new network FDs on the new host.
     pub net_fds: Option<Vec<RestoredNetConfig>>,
 }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -884,6 +884,7 @@ impl Vmm {
         req: &Request,
         socket: &mut T,
         existing_memory_files: Option<HashMap<u32, File>>,
+        tcp_serial_url: Option<String>,
     ) -> std::result::Result<Arc<Mutex<MemoryManager>>, MigratableError>
     where
         T: Read + Write,
@@ -908,6 +909,12 @@ impl Vmm {
 
         let config = vm_migration_config.vm_config.clone();
         self.vm_config = Some(vm_migration_config.vm_config);
+
+        if let Some(tcp_serial_url) = tcp_serial_url {
+            let mut vm_config = self.vm_config.as_mut().unwrap().lock().unwrap();
+            vm_config.serial.url = Some(tcp_serial_url);
+        }
+
         self.console_info = Some(pre_create_console_devices(self).map_err(|e| {
             MigratableError::MigrateReceive(anyhow!("Error creating console devices: {:?}", e))
         })?);
@@ -2391,8 +2398,12 @@ impl RequestHandler for Vmm {
                         continue;
                     }
 
-                    let memory_manager_config =
-                        self.vm_receive_config(&req, &mut socket, existing_memory_files.take())?;
+                    let memory_manager_config = self.vm_receive_config(
+                        &req,
+                        &mut socket,
+                        existing_memory_files.take(),
+                        receive_data_migration.tcp_serial_url.clone(),
+                    )?;
                     memory_manager = Some(memory_manager_config);
 
                     if let Some(ref restored_net_configs) = receive_data_migration.net_fds {


### PR DESCRIPTION
The TCP serial mode utilizes a port on the host and needs to listen on a specific IP. If that IP or port are not available on the receiver host when migrating, we need to be able to set a new configuration for the destination host.

As a shortcut, we add a tcp_serial_url parameter to the receive migration API call. The caller can specify a new value, that will lead to an update of the VM config on the receiver side.