### PR TITLE
vmm: preserved FDs: prevent usage of same FD multiple times 

### DIFF
--- a/fuzz/fuzz_targets/http_api.rs
+++ b/fuzz/fuzz_targets/http_api.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![no_main]
+use std::collections::BTreeSet;
 use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::sync::mpsc::{channel, Receiver};
@@ -192,7 +193,7 @@ impl RequestHandler for StubApiRequestHandler {
                 pci_segments: None,
                 platform: None,
                 tpm: None,
-                preserved_fds: None,
+                preserved_fds: BTreeSet::new(),
                 landlock_enable: false,
                 landlock_rules: None,
                 #[cfg(feature = "ivshmem")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -904,6 +904,7 @@ fn main() {
 
 #[cfg(test)]
 mod unit_tests {
+    use std::collections::BTreeSet;
     use std::path::PathBuf;
 
     use vmm::config::VmParams;
@@ -1028,7 +1029,7 @@ mod unit_tests {
             pci_segments: None,
             platform: None,
             tpm: None,
-            preserved_fds: None,
+            preserved_fds: BTreeSet::new(),
             landlock_enable: false,
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -4132,9 +4132,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_config_validation() {
-        let mut valid_config = VmConfig {
+    fn valid_vmconfig() -> VmConfig {
+        VmConfig {
             cpus: CpusConfig {
                 boot_vcpus: 1,
                 max_vcpus: 1,
@@ -4213,16 +4212,19 @@ mod tests {
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]
             ivshmem: None,
-        };
+        }
+    }
 
-        valid_config.validate().unwrap();
+    #[test]
+    fn test_config_validation() {
+        valid_vmconfig().validate().unwrap();
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.serial.mode = ConsoleOutputMode::Tty;
         invalid_config.console.mode = ConsoleOutputMode::Tty;
-        valid_config.validate().unwrap();
+        valid_vmconfig().validate().unwrap();
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.payload = None;
         assert_eq!(
             invalid_config.validate(),
@@ -4231,7 +4233,7 @@ mod tests {
             ))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.serial.mode = ConsoleOutputMode::File;
         invalid_config.serial.file = None;
         assert_eq!(
@@ -4239,7 +4241,7 @@ mod tests {
             Err(ValidationError::ConsoleFileMissing)
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.cpus.max_vcpus = 16;
         invalid_config.cpus.boot_vcpus = 32;
         assert_eq!(
@@ -4247,7 +4249,7 @@ mod tests {
             Err(ValidationError::CpusMaxLowerThanBoot)
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.cpus.max_vcpus = 16;
         invalid_config.cpus.boot_vcpus = 16;
         invalid_config.cpus.topology = Some(CpuTopology {
@@ -4261,7 +4263,7 @@ mod tests {
             Err(ValidationError::CpuTopologyCount)
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.disks = Some(vec![DiskConfig {
             vhost_socket: Some("/path/to/sock".to_owned()),
             path: Some(PathBuf::from("/path/to/image")),
@@ -4272,7 +4274,7 @@ mod tests {
             Err(ValidationError::DiskSocketAndPath)
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.memory.shared = true;
         invalid_config.disks = Some(vec![DiskConfig {
             path: None,
@@ -4284,7 +4286,7 @@ mod tests {
             Err(ValidationError::VhostUserMissingSocket)
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.disks = Some(vec![DiskConfig {
             path: None,
             vhost_user: true,
@@ -4296,7 +4298,7 @@ mod tests {
             Err(ValidationError::VhostUserRequiresSharedMemory)
         );
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.disks = Some(vec![DiskConfig {
             path: None,
             vhost_user: true,
@@ -4306,7 +4308,7 @@ mod tests {
         still_valid_config.memory.shared = true;
         still_valid_config.validate().unwrap();
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.net = Some(vec![NetConfig {
             vhost_user: true,
             ..net_fixture()
@@ -4316,7 +4318,7 @@ mod tests {
             Err(ValidationError::VhostUserRequiresSharedMemory)
         );
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.net = Some(vec![NetConfig {
             vhost_user: true,
             vhost_socket: Some("/path/to/sock".to_owned()),
@@ -4325,7 +4327,7 @@ mod tests {
         still_valid_config.memory.shared = true;
         still_valid_config.validate().unwrap();
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.net = Some(vec![NetConfig {
             fds: Some(vec![0]),
             ..net_fixture()
@@ -4335,7 +4337,7 @@ mod tests {
             Err(ValidationError::VnetReservedFd(0))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.net = Some(vec![NetConfig {
             offload_csum: false,
             ..net_fixture()
@@ -4345,27 +4347,27 @@ mod tests {
             Err(ValidationError::NoHardwareChecksumOffload)
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig();
         invalid_config.fs = Some(vec![fs_fixture()]);
         assert_eq!(
             invalid_config.validate(),
             Err(ValidationError::VhostUserRequiresSharedMemory)
         );
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.memory.shared = true;
         still_valid_config.validate().unwrap();
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.memory.hugepages = true;
         still_valid_config.validate().unwrap();
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.memory.hugepages = true;
         still_valid_config.memory.hugepage_size = Some(2 << 20);
         still_valid_config.validate().unwrap();
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.memory.hugepages = false;
         invalid_config.memory.hugepage_size = Some(2 << 20);
         assert_eq!(
@@ -4373,7 +4375,7 @@ mod tests {
             Err(ValidationError::HugePageSizeWithoutHugePages)
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.memory.hugepages = true;
         invalid_config.memory.hugepage_size = Some(3 << 20);
         assert_eq!(
@@ -4381,11 +4383,11 @@ mod tests {
             Err(ValidationError::InvalidHugePageSize(3 << 20))
         );
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.platform = Some(platform_fixture());
         still_valid_config.validate().unwrap();
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: MAX_NUM_PCI_SEGMENTS + 1,
             ..platform_fixture()
@@ -4397,14 +4399,14 @@ mod tests {
             ))
         );
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
         });
         still_valid_config.validate().unwrap();
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![MAX_NUM_PCI_SEGMENTS + 1, MAX_NUM_PCI_SEGMENTS + 2]),
             ..platform_fixture()
@@ -4414,7 +4416,7 @@ mod tests {
             Err(ValidationError::InvalidPciSegment(MAX_NUM_PCI_SEGMENTS + 1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             iommu_address_width_bits: MAX_IOMMU_ADDRESS_WIDTH_BITS + 1,
             ..platform_fixture()
@@ -4426,7 +4428,7 @@ mod tests {
             ))
         );
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
@@ -4438,7 +4440,7 @@ mod tests {
         }]);
         still_valid_config.validate().unwrap();
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
@@ -4450,7 +4452,7 @@ mod tests {
         }]);
         still_valid_config.validate().unwrap();
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
@@ -4462,7 +4464,7 @@ mod tests {
         }]);
         still_valid_config.validate().unwrap();
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
@@ -4474,7 +4476,7 @@ mod tests {
         }]);
         still_valid_config.validate().unwrap();
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig().clone();
         still_valid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
@@ -4488,7 +4490,7 @@ mod tests {
         });
         still_valid_config.validate().unwrap();
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
@@ -4503,7 +4505,7 @@ mod tests {
             Err(ValidationError::OnIommuSegment(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
@@ -4518,7 +4520,7 @@ mod tests {
             Err(ValidationError::OnIommuSegment(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: MAX_NUM_PCI_SEGMENTS,
             iommu_segments: Some(vec![1, 2, 3]),
@@ -4534,7 +4536,7 @@ mod tests {
             Err(ValidationError::OnIommuSegment(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: MAX_NUM_PCI_SEGMENTS,
             iommu_segments: Some(vec![1, 2, 3]),
@@ -4550,7 +4552,7 @@ mod tests {
             Err(ValidationError::OnIommuSegment(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
@@ -4567,7 +4569,7 @@ mod tests {
             Err(ValidationError::OnIommuSegment(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.memory.shared = true;
         invalid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
@@ -4583,7 +4585,7 @@ mod tests {
             Err(ValidationError::IommuNotSupportedOnSegment(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
             ..platform_fixture()
@@ -4597,7 +4599,7 @@ mod tests {
             Err(ValidationError::OnIommuSegment(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.memory.shared = true;
         invalid_config.platform = Some(PlatformConfig {
             iommu_segments: Some(vec![1, 2, 3]),
@@ -4612,7 +4614,7 @@ mod tests {
             Err(ValidationError::IommuNotSupportedOnSegment(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.platform = Some(PlatformConfig {
             num_pci_segments: 2,
             ..platform_fixture()
@@ -4634,7 +4636,7 @@ mod tests {
             Err(ValidationError::PciSegmentReused(1, 0, 1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.pci_segments = Some(vec![PciSegmentConfig {
             pci_segment: 0,
             mmio32_aperture_weight: 1,
@@ -4645,7 +4647,7 @@ mod tests {
             Err(ValidationError::InvalidPciSegmentApertureWeight(0))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.pci_segments = Some(vec![PciSegmentConfig {
             pci_segment: 0,
             mmio32_aperture_weight: 0,
@@ -4656,7 +4658,7 @@ mod tests {
             Err(ValidationError::InvalidPciSegmentApertureWeight(0))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.numa = Some(vec![
             NumaConfig {
                 guest_numa_id: 0,
@@ -4673,7 +4675,7 @@ mod tests {
             Err(ValidationError::DefaultPciSegmentInvalidNode(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig().clone();
         invalid_config.numa = Some(vec![
             NumaConfig {
                 guest_numa_id: 0,
@@ -4691,7 +4693,7 @@ mod tests {
             Err(ValidationError::InvalidPciSegment(1))
         );
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig();
         invalid_config.disks = Some(vec![DiskConfig {
             rate_limit_group: Some("foo".into()),
             ..disk_fixture()
@@ -4702,7 +4704,7 @@ mod tests {
         );
 
         // Test serial length validation
-        let mut valid_serial_config = valid_config.clone();
+        let mut valid_serial_config = valid_vmconfig();
         valid_serial_config.disks = Some(vec![DiskConfig {
             serial: Some("valid_serial".to_string()),
             ..disk_fixture()
@@ -4710,7 +4712,7 @@ mod tests {
         valid_serial_config.validate().unwrap();
 
         // Test empty string serial (should be valid)
-        let mut empty_serial_config = valid_config.clone();
+        let mut empty_serial_config = valid_vmconfig();
         empty_serial_config.disks = Some(vec![DiskConfig {
             serial: Some("".to_string()),
             ..disk_fixture()
@@ -4718,7 +4720,7 @@ mod tests {
         empty_serial_config.validate().unwrap();
 
         // Test None serial (should be valid)
-        let mut none_serial_config = valid_config.clone();
+        let mut none_serial_config = valid_vmconfig();
         none_serial_config.disks = Some(vec![DiskConfig {
             serial: None,
             ..disk_fixture()
@@ -4727,7 +4729,7 @@ mod tests {
 
         // Test maximum length serial (exactly VIRTIO_BLK_ID_BYTES)
         let max_serial = "a".repeat(VIRTIO_BLK_ID_BYTES as usize);
-        let mut max_serial_config = valid_config.clone();
+        let mut max_serial_config = valid_vmconfig();
         max_serial_config.disks = Some(vec![DiskConfig {
             serial: Some(max_serial),
             ..disk_fixture()
@@ -4736,7 +4738,7 @@ mod tests {
 
         // Test serial length exceeding VIRTIO_BLK_ID_BYTES
         let long_serial = "a".repeat(VIRTIO_BLK_ID_BYTES as usize + 1);
-        let mut invalid_serial_config = valid_config.clone();
+        let mut invalid_serial_config = valid_vmconfig();
         invalid_serial_config.disks = Some(vec![DiskConfig {
             serial: Some(long_serial.clone()),
             ..disk_fixture()
@@ -4749,7 +4751,7 @@ mod tests {
             ))
         );
 
-        let mut still_valid_config = valid_config.clone();
+        let mut still_valid_config = valid_vmconfig();
         still_valid_config.devices = Some(vec![
             DeviceConfig {
                 path: "/device1".into(),
@@ -4762,7 +4764,7 @@ mod tests {
         ]);
         still_valid_config.validate().unwrap();
 
-        let mut invalid_config = valid_config.clone();
+        let mut invalid_config = valid_vmconfig();
         invalid_config.devices = Some(vec![
             DeviceConfig {
                 path: "/device1".into(),
@@ -4777,7 +4779,7 @@ mod tests {
         #[cfg(feature = "sev_snp")]
         {
             // Payload with empty host data
-            let mut config_with_no_host_data = valid_config.clone();
+            let mut config_with_no_host_data = valid_vmconfig();
             config_with_no_host_data.payload = Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),
                 firmware: None,
@@ -4793,7 +4795,7 @@ mod tests {
             config_with_no_host_data.validate().unwrap_err();
 
             // Payload with no host data provided
-            let mut valid_config_with_no_host_data = valid_config.clone();
+            let mut valid_config_with_no_host_data = valid_vmconfig();
             valid_config_with_no_host_data.payload = Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),
                 firmware: None,
@@ -4809,7 +4811,7 @@ mod tests {
             valid_config_with_no_host_data.validate().unwrap();
 
             // Payload with invalid host data length i.e less than 64
-            let mut config_with_invalid_host_data = valid_config.clone();
+            let mut config_with_invalid_host_data = valid_vmconfig();
             config_with_invalid_host_data.payload = Some(PayloadConfig {
                 kernel: Some(PathBuf::from("/path/to/kernel")),
                 firmware: None,
@@ -4827,7 +4829,7 @@ mod tests {
             config_with_invalid_host_data.validate().unwrap_err();
         }
 
-        let mut still_valid_config = valid_config;
+        let mut still_valid_config = valid_vmconfig();
         // SAFETY: Safe as the file was just opened
         let fd1 = unsafe { libc::dup(File::open("/dev/null").unwrap().as_raw_fd()) };
         // SAFETY: Safe as the file was just opened

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -6,10 +6,10 @@
 use std::collections::{BTreeSet, HashMap};
 #[cfg(feature = "ivshmem")]
 use std::fs;
-use std::os::fd::RawFd;
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::PathBuf;
-use std::result;
 use std::str::FromStr;
+use std::{mem, result};
 
 use clap::ArgMatches;
 use option_parser::{
@@ -361,6 +361,14 @@ pub enum ValidationError {
     InvalidIvshmemPath,
     #[error("Payload configuration is not bootable")]
     PayloadError(#[from] PayloadConfigError),
+    /// Multiple things in a VM can be backed up by externally provided FDs,
+    /// such as memory zones, virtio-net devices, or virtio-blk devices (not
+    /// yet implemented, but likely in future).
+    ///
+    /// It is a hard configuration error to use the same FD for multiple
+    /// things.
+    #[error("Externally provided FD already in use! FD={0}")]
+    ExternalFdAlreadyInUse(RawFd),
 }
 
 type ValidationResult<T> = std::result::Result<T, ValidationError>;
@@ -3058,7 +3066,7 @@ impl VmConfig {
             pci_segments,
             platform,
             tpm,
-            preserved_fds: None,
+            preserved_fds: BTreeSet::new(),
             landlock_enable: vm_params.landlock_enable,
             landlock_rules,
             #[cfg(feature = "ivshmem")]
@@ -3131,21 +3139,81 @@ impl VmConfig {
         removed
     }
 
+    /// Adds the provided external FDs to the preserved FDs.
+    ///
+    /// This is useful to keep external FDs valid across VM reboots, where no
+    /// device instance holds open FDs.
+    ///
     /// # Safety
     /// To use this safely, the caller must guarantee that the input
-    /// fds are all valid.
-    pub unsafe fn add_preserved_fds(&mut self, mut fds: Vec<i32>) {
-        debug!("adding preserved FDs to VM list: {fds:?}");
+    /// FDs are all valid.
+    ///
+    /// # Arguments
+    /// - `fds`: Iterator over the external FDs of some component
+    /// - `hot`: Whether this happens when the VM is running, i.e., whether
+    ///   device instances also have open (dup'ed) FDs of this or just the VM
+    ///   config.
+    ///
+    /// # Panics
+    /// This panics when an external FD is used multiple times to force
+    /// programmers to do proper checking early.
+    pub fn add_preserved_fds(
+        &mut self,
+        fds: impl IntoIterator<Item = RawFd> + Clone,
+        hot: bool,
+    ) -> ValidationResult<()> {
+        self.can_add_preserved_fds(fds.clone(), hot)
+            .unwrap_or_else(|_| {
+                panic!(
+                    "should have detected earlier that FDs {:?} can't be added: preserved: {:?}",
+                    fds.clone().into_iter().collect::<Vec<_>>().len(),
+                    self.preserved_fds
+                )
+            });
 
-        if fds.is_empty() {
-            return;
+        for fd in fds.into_iter() {
+            let pfd = self.preserved_fds.iter().find(|pfd| pfd.as_raw_fd() == fd);
+            match (pfd, hot) {
+                (None, false) => {
+                    self.preserved_fds.insert(PreservedFd::Cold(fd));
+                }
+                (None, true) => {
+                    self.preserved_fds.insert(PreservedFd::Hot(fd));
+                }
+                // We allow the transition from Cold to Hot, i.e., "in use"
+                (Some(PreservedFd::Cold(_)), true) => {
+                    self.preserved_fds.remove(&PreservedFd::Cold(fd));
+                    self.preserved_fds.insert(PreservedFd::Hot(fd));
+                }
+                // Invalid state transition, propagate error
+                (Some(_), _) => return Err(ValidationError::ExternalFdAlreadyInUse(fd)),
+            }
         }
+        Ok(())
+    }
 
-        if let Some(preserved_fds) = &self.preserved_fds {
-            fds.append(&mut preserved_fds.clone());
+    /// Checks if any of the externally provided FDs is already preserved in the
+    /// list of preserved FDs.
+    ///
+    /// This function is supposed to be called early in every code path that adds
+    /// configurations tide to such FDs.
+    pub fn can_add_preserved_fds(
+        &self,
+        external_fds: impl IntoIterator<Item = RawFd>,
+        hot: bool,
+    ) -> ValidationResult<()> {
+        #[allow(clippy::never_loop)] // false-positive
+        for fd in external_fds.into_iter() {
+            let pfd = self.preserved_fds.iter().find(|pfd| pfd.as_raw_fd() == fd);
+            return match (pfd, hot) {
+                (None, _) => Ok(()),
+                // We allow the transition from Cold to Hot, i.e., "in use now"
+                (Some(PreservedFd::Cold(_)), true) => Ok(()),
+                // Invalid state transition, propagate error
+                (Some(_), _) => Err(ValidationError::ExternalFdAlreadyInUse(fd)),
+            };
         }
-
-        self.preserved_fds = Some(fds);
+        Ok(())
     }
 
     #[cfg(feature = "tdx")]
@@ -3188,18 +3256,10 @@ impl Clone for VmConfig {
             tpm: self.tpm.clone(),
             preserved_fds: self
                 .preserved_fds
-                .as_ref()
+                .iter()
                 // SAFETY: FFI call with valid FDs
-                .map(|fds| {
-                    fds.iter()
-                        .map(|fd| {
-                            // SAFETY: Trivially safe.
-                            let fd_duped = unsafe { libc::dup(*fd) };
-                            warn!("Cloning VM config: duping preserved FD {fd} => {fd_duped}");
-                            fd_duped
-                        })
-                        .collect()
-                }),
+                .map(|fd| fd.dup())
+                .collect(),
             landlock_rules: self.landlock_rules.clone(),
             #[cfg(feature = "ivshmem")]
             ivshmem: self.ivshmem.clone(),
@@ -3210,12 +3270,13 @@ impl Clone for VmConfig {
 
 impl Drop for VmConfig {
     fn drop(&mut self) {
-        if let Some(mut fds) = self.preserved_fds.take() {
-            debug!("Closing preserved FDs from VM: fds={fds:?}");
-            for fd in fds.drain(..) {
-                // SAFETY: FFI call with valid FDs
-                unsafe { libc::close(fd) };
-            }
+        debug!("Closing preserved FDs: fds={:?}", self.preserved_fds);
+
+        // There is no .drain() for BTreeSet yet
+        let fds = mem::take(&mut self.preserved_fds);
+        for fd in fds {
+            // SAFETY: FFI call with valid FDs
+            unsafe { libc::close(fd.as_raw_fd()) };
         }
     }
 }
@@ -3994,7 +4055,7 @@ mod tests {
             pci_segments: None,
             platform: None,
             tpm: None,
-            preserved_fds: None,
+            preserved_fds: BTreeSet::new(),
             net: Some(vec![
                 NetConfig {
                     id: Some("net0".to_owned()),
@@ -4207,7 +4268,7 @@ mod tests {
             pci_segments: None,
             platform: None,
             tpm: None,
-            preserved_fds: None,
+            preserved_fds: BTreeSet::new(),
             landlock_enable: false,
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]
@@ -4834,12 +4895,53 @@ mod tests {
         let fd1 = unsafe { libc::dup(File::open("/dev/null").unwrap().as_raw_fd()) };
         // SAFETY: Safe as the file was just opened
         let fd2 = unsafe { libc::dup(File::open("/dev/null").unwrap().as_raw_fd()) };
-        // SAFETY: safe as both FDs are valid
-        unsafe {
-            still_valid_config.add_preserved_fds(vec![fd1, fd2]);
-        }
+        still_valid_config
+            .add_preserved_fds([fd1, fd2], false)
+            .unwrap();
         let _still_valid_config = still_valid_config.clone();
     }
+
+    #[test]
+    fn test_add_preserved_fds_corner_cases() {
+        let mut config = valid_vmconfig();
+
+        config.can_add_preserved_fds([3], false).unwrap();
+        config.add_preserved_fds([3], false).unwrap();
+
+        config.can_add_preserved_fds([3], false).unwrap_err();
+
+        config.can_add_preserved_fds([3], true).unwrap();
+        config.add_preserved_fds([3], true).unwrap();
+
+        config.can_add_preserved_fds([3], true).unwrap_err();
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_add_preserved_fds_corner_cases_panic_cold_cold() {
+        let mut config = valid_vmconfig();
+
+        config.add_preserved_fds([3], false).unwrap();
+
+        // panic here
+        config
+            .add_preserved_fds([3], false)
+            .expect_err("should fail as the device is already hot");
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_add_preserved_fds_corner_cases_panic_hot_hot() {
+        let mut config = valid_vmconfig();
+
+        config.add_preserved_fds([3], true).unwrap();
+
+        // panic here
+        config
+            .add_preserved_fds([3], true)
+            .expect_err("should fail as the device is already hot");
+    }
+
     #[test]
     fn test_landlock_parsing() -> Result<()> {
         // should not be empty

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -124,7 +124,7 @@ use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, UserDeviceConfig, VdpaConfig,
     VhostMode, VmConfig, VsockConfig,
 };
-use crate::{DEVICE_MANAGER_SNAPSHOT_ID, GuestRegionMmap, PciDeviceInfo, device_node};
+use crate::{DEVICE_MANAGER_SNAPSHOT_ID, GuestRegionMmap, PciDeviceInfo, config, device_node};
 
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 const MMIO_LEN: u64 = 0x1000;
@@ -667,6 +667,9 @@ pub enum DeviceManagerError {
     /// Error adding fw_cfg to bus.
     #[error("Error adding fw_cfg to bus")]
     ErrorAddingFwCfgToBus(#[source] vm_device::BusError),
+
+    #[error("Multiple use of the same FD is misconfiguration")]
+    ExternalFdMisconfiguration(#[source] config::ValidationError),
 }
 
 pub type DeviceManagerResult<T> = result::Result<T, DeviceManagerError>;
@@ -2955,10 +2958,11 @@ impl DeviceManager {
                 )
                 .map_err(DeviceManagerError::CreateVirtioNet)?;
 
-                // SAFETY: 'fds' are valid because TAP devices are created successfully
-                unsafe {
-                    self.config.lock().unwrap().add_preserved_fds(fds.clone());
-                }
+                self.config
+                    .lock()
+                    .unwrap()
+                    .add_preserved_fds(fds.iter().cloned(), true)
+                    .map_err(DeviceManagerError::ExternalFdMisconfiguration)?;
 
                 Arc::new(Mutex::new(net))
             } else {
@@ -4542,8 +4546,8 @@ impl DeviceManager {
 
                     debug!("Closing preserved FDs from virtio-net device: id={id}, fds={fds:?}");
                     for fd in fds {
-                        config.preserved_fds.as_mut().unwrap().retain(|x| *x != fd);
-                        // SAFETY: Trivially safe. We know the FD is not referenced any longer.
+                        config.preserved_fds.retain(|x| x.as_raw_fd() != fd);
+                        // SAFETY: We are closing the only remaining instance of this FD.
                         unsafe {
                             libc::close(fd);
                         }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2253,10 +2253,17 @@ impl RequestHandler for Vmm {
 
     fn vm_add_net(&mut self, net_cfg: NetConfig) -> result::Result<Option<Vec<u8>>, VmError> {
         self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
-
         {
             // Validate the configuration change in a cloned configuration
             let mut config = self.vm_config.as_ref().unwrap().lock().unwrap().clone();
+
+            // Special handling for externally provided FDs
+            if let Some(fds) = &net_cfg.fds {
+                config
+                    .can_add_preserved_fds(fds.iter().cloned(), true)
+                    .map_err(VmError::ConfigValidation)?;
+            }
+
             add_to_config(&mut config.net, net_cfg.clone());
             config.validate().map_err(VmError::ConfigValidation)?;
         }
@@ -2593,6 +2600,8 @@ const DEVICE_MANAGER_SNAPSHOT_ID: &str = "device-manager";
 
 #[cfg(test)]
 mod unit_tests {
+    use std::collections::BTreeSet;
+
     use super::*;
     #[cfg(target_arch = "x86_64")]
     use crate::vm_config::DebugConsoleConfig;
@@ -2693,7 +2702,7 @@ mod unit_tests {
             pci_segments: None,
             platform: None,
             tpm: None,
-            preserved_fds: None,
+            preserved_fds: BTreeSet::new(),
             landlock_enable: false,
             landlock_rules: None,
             #[cfg(feature = "ivshmem")]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -11,7 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs::{File, OpenOptions};
 use std::io::{self, Seek, SeekFrom, Write};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -100,7 +100,7 @@ use crate::vcpu_throttling::ThrottleThreadHandle;
 use crate::vm_config::FwCfgConfig;
 use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, HotplugMethod, NetConfig, NumaConfig, PayloadConfig,
-    PmemConfig, UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
+    PmemConfig, PreservedFd, UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
 };
 use crate::{
     CPU_MANAGER_SNAPSHOT_ID, DEVICE_MANAGER_SNAPSHOT_ID, GuestMemoryMmap,
@@ -1663,6 +1663,27 @@ impl Vm {
             .unwrap()
             .shutdown()
             .map_err(Error::CpuManager)?;
+
+        // Mark all preserved FDs as cold
+        {
+            let mut config = self.config.lock().unwrap();
+
+            let mut new_set = BTreeSet::new();
+            for fd in config.preserved_fds.iter() {
+                match fd {
+                    PreservedFd::Cold(fd) => {
+                        // very unlikely; can only be a programming error as we expect all FDs to be Hot
+                        // after the VM has booted.
+                        log::debug!("Preserved FD {} is still cold", fd);
+                    }
+                    PreservedFd::Hot(fd) => {
+                        new_set.insert(PreservedFd::Cold(*fd));
+                    }
+                }
+            }
+
+            config.preserved_fds = new_set;
+        }
 
         // Wait for all the threads to finish
         for thread in self.threads.drain(..) {

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -2,7 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+use std::collections::BTreeSet;
 use std::net::{IpAddr, Ipv4Addr};
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::{Path, PathBuf};
 #[cfg(feature = "fw_cfg")]
 use std::str::FromStr;
@@ -897,6 +899,40 @@ impl ApplyLandlock for LandlockConfig {
     }
 }
 
+/// Helps to identify the context of a preserved FD.
+///
+/// Specifically, we need to distinguish between FDs coming from a "cold" config ([`PreservedFd::Cold`])
+/// or a "warm" config ([`PreservedFd::Hot`]). This type helps to better prevent misconfiguration
+/// in [`VmConfig::add_preserved_fds`].
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum PreservedFd {
+    /// The FD is preserved by the VMM but not yet associated with a device.
+    Cold(RawFd),
+    /// The FD is associated with a device and in active use.
+    Hot(RawFd),
+}
+
+impl PreservedFd {
+    pub fn dup(&self) -> Self {
+        let fd = self.as_raw_fd();
+        // SAFETY: FFI call with valid FDs
+        let fd_dup = unsafe { libc::dup(fd.as_raw_fd()) };
+        match self {
+            PreservedFd::Cold(_) => PreservedFd::Cold(fd_dup),
+            PreservedFd::Hot(_) => PreservedFd::Cold(fd_dup),
+        }
+    }
+}
+
+impl AsRawFd for PreservedFd {
+    fn as_raw_fd(&self) -> RawFd {
+        match self {
+            PreservedFd::Cold(fd) => *fd,
+            PreservedFd::Hot(fd) => *fd,
+        }
+    }
+}
+
 #[derive(Debug, PartialEq, Eq, Deserialize, Serialize)]
 pub struct VmConfig {
     #[serde(default)]
@@ -944,7 +980,7 @@ pub struct VmConfig {
     // Preserved FDs will stay open as long as the holding VmConfig instance is
     // valid, and will be closed when the holding VmConfig instance is destroyed.
     #[serde(skip)]
-    pub preserved_fds: Option<Vec<i32>>,
+    pub preserved_fds: BTreeSet<PreservedFd>,
     #[serde(default)]
     pub landlock_enable: bool,
     pub landlock_rules: Option<Vec<LandlockConfig>>,


### PR DESCRIPTION
## About

Part of https://github.com/cobaltcore-dev/cobaltcore/issues/292. Currently not a big issue, but technically it can be a severe problem. And it might be beneficial to have this to detect misconfiguration.

Technical description: See commit message.


## Why I worked on this

I worked on this in my attempt to finish some upstream PRs. I noticed this is more complicated than anticipated. So I created this PoC for us and upstreaming is future work.


- [x] libvirt-tests passed 
- [ ] add libvirt-tests test case for this
- [ ] libvirt-tests still passes