### PR TITLE
Fix PTY serial console

### DIFF
--- a/vmm/src/serial_manager.rs
+++ b/vmm/src/serial_manager.rs
@@ -338,15 +338,15 @@ impl SerialManager {
 
                     if let ConsoleOutput::Tcp(_, Some(f)) = &in_file {
                         write_distributor.add_writer(f.clone());
+                        serial
+                            .as_ref()
+                            .lock()
+                            .unwrap()
+                            .set_out(Some(Box::new(write_distributor.clone())));
                     }
 
                     let mut events =
                         [epoll::Event::new(epoll::Events::empty(), 0); EPOLL_EVENTS_LEN];
-                    serial
-                        .as_ref()
-                        .lock()
-                        .unwrap()
-                        .set_out(Some(Box::new(write_distributor.clone())));
 
                     loop {
                         let num_events = match epoll::wait(epoll_fd, timeout, &mut events[..]) {


### PR DESCRIPTION
As we use the write_distributor only if TCP is used, we only add it to the serial out in that case. Not doing so results in e.g. the console not working in the PTY case, because we would overwrite the out member of the serial that was already set before.