### PR TITLE
Multiple TCP Connections for Migration

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -9,6 +9,7 @@ mod test_util;
 
 use std::io::Read;
 use std::marker::PhantomData;
+use std::num::NonZeroU32;
 use std::os::unix::net::UnixStream;
 use std::process;
 
@@ -505,6 +506,11 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .unwrap()
                     .get_one::<u64>("migration-timeout-s")
                     .unwrap_or(&3600),
+                *matches
+                    .subcommand_matches("send-migration")
+                    .unwrap()
+                    .get_one::<NonZeroU32>("connections")
+                    .unwrap_or(&NonZeroU32::new(1).unwrap()),
             );
             simple_api_command(socket, "PUT", "send-migration", Some(&send_migration_data))
                 .map_err(Error::HttpApiClient)
@@ -935,12 +941,19 @@ fn receive_migration_data(url: &str) -> String {
     serde_json::to_string(&receive_migration_data).unwrap()
 }
 
-fn send_migration_data(url: &str, local: bool, downtime: u64, migration_timeout: u64) -> String {
+fn send_migration_data(
+    url: &str,
+    local: bool,
+    downtime: u64,
+    migration_timeout: u64,
+    connections: NonZeroU32,
+) -> String {
     let send_migration_data = vmm::api::VmSendMigrationData {
         destination_url: url.to_owned(),
         local,
         downtime,
         migration_timeout,
+        connections,
     };
 
     serde_json::to_string(&send_migration_data).unwrap()
@@ -1116,6 +1129,14 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
         Command::new("resume").about("Resume the VM"),
         Command::new("send-migration")
             .about("Initiate a VM migration")
+            .arg(
+                Arg::new("connections")
+                    .long("connections")
+                    .help("The number of connections to use for the migration")
+                    .num_args(1)
+                    .value_parser(clap::value_parser!(u32))
+                    .default_value("1"),
+            )
             .arg(
                 Arg::new("downtime-ms")
                     .long("downtime-ms")

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -211,7 +211,7 @@ impl Response {
 }
 
 #[repr(C)]
-#[derive(Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
 pub struct MemoryRange {
     pub gpa: u64,
     pub length: u64,
@@ -244,12 +244,85 @@ impl MemoryRange {
     }
 }
 
-#[derive(Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MemoryRangeTable {
     data: Vec<MemoryRange>,
 }
 
+#[derive(Debug, Clone, Default)]
+struct MemoryRangeTableIterator {
+    chunk_size: u64,
+    data: Vec<MemoryRange>,
+}
+
+impl MemoryRangeTableIterator {
+    pub fn new(table: &MemoryRangeTable, chunk_size: u64) -> Self {
+        MemoryRangeTableIterator {
+            chunk_size,
+            data: table.data.clone(),
+        }
+    }
+}
+
+impl Iterator for MemoryRangeTableIterator {
+    type Item = MemoryRangeTable;
+
+    /// Return the next memory range in the table, making sure that
+    /// the returned range is not larger than `chunk_size`.
+    ///
+    /// **Note**: Do not rely on the order of the ranges returned by this
+    /// iterator. This allows for a more efficient implementation.
+    fn next(&mut self) -> Option<Self::Item> {
+        let mut ranges: Vec<MemoryRange> = vec![];
+        let mut ranges_size: u64 = 0;
+
+        loop {
+            assert!(ranges_size <= self.chunk_size);
+
+            if ranges_size == self.chunk_size || self.data.is_empty() {
+                break;
+            }
+
+            if let Some(range) = self.data.pop() {
+                let next_range: MemoryRange = if ranges_size + range.length > self.chunk_size {
+                    // How many bytes we need to put back into the table.
+                    let leftover_bytes = ranges_size + range.length - self.chunk_size;
+                    assert!(leftover_bytes <= range.length);
+                    let returned_bytes = range.length - leftover_bytes;
+                    assert!(returned_bytes <= range.length);
+                    assert!(leftover_bytes + returned_bytes == range.length);
+
+                    self.data.push(MemoryRange {
+                        gpa: range.gpa + returned_bytes,
+                        length: leftover_bytes,
+                    });
+                    MemoryRange {
+                        gpa: range.gpa,
+                        length: returned_bytes,
+                    }
+                } else {
+                    range
+                };
+
+                ranges_size += next_range.length;
+                ranges.push(next_range);
+            }
+        }
+
+        if ranges.is_empty() {
+            None
+        } else {
+            Some(MemoryRangeTable { data: ranges })
+        }
+    }
+}
+
 impl MemoryRangeTable {
+    /// Partitions the table into chunks of at most `chunk_size` bytes.
+    pub fn partition(&self, chunk_size: u64) -> impl Iterator<Item = MemoryRangeTable> {
+        MemoryRangeTableIterator::new(self, chunk_size)
+    }
+
     pub fn from_bitmap(
         bitmap: impl IntoIterator<Item = u64>,
         start_addr: u64,
@@ -314,5 +387,64 @@ impl MemoryRangeTable {
             data.extend(table.data);
         }
         Self { data }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_memory_range_table() {
+        let mut table = MemoryRangeTable::default();
+        // Test blocks that are shorter than the chunk size.
+        table.push(MemoryRange {
+            gpa: 0,
+            length: 1 << 10,
+        });
+        // Test blocks that are longer than the chunk size.
+        table.push(MemoryRange {
+            gpa: 0x1000,
+            length: 3 << 20,
+        });
+        // And add another blocks, so we get a chunk that spans two memory
+        // ranges.
+        table.push(MemoryRange {
+            gpa: 4 << 20,
+            length: 1 << 20,
+        });
+
+        let table = table; // drop mut
+
+        let chunks = table
+            .partition(2 << 20)
+            .map(|table| table.data)
+            .collect::<Vec<_>>();
+
+        // The implementation currently returns the ranges in reverse order. If
+        // this tests becomes more complex, we can compare everything as sets.
+        assert_eq!(
+            chunks,
+            vec![
+                vec![
+                    MemoryRange {
+                        gpa: 4 << 20,
+                        length: 1 << 20
+                    },
+                    MemoryRange {
+                        gpa: 0x1000,
+                        length: 1 << 20
+                    }
+                ],
+                vec![MemoryRange {
+                    gpa: 0x1000 + (1 << 20),
+                    length: 2 << 20
+                },],
+                vec![MemoryRange {
+                    gpa: 0,
+                    length: 1 << 10
+                }]
+            ]
+        );
     }
 }

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -318,6 +318,10 @@ impl Iterator for MemoryRangeTableIterator {
 }
 
 impl MemoryRangeTable {
+    pub fn ranges(&self) -> &[MemoryRange] {
+        &self.data
+    }
+
     /// Partitions the table into chunks of at most `chunk_size` bytes.
     pub fn partition(&self, chunk_size: u64) -> impl Iterator<Item = MemoryRangeTable> {
         MemoryRangeTableIterator::new(self, chunk_size)

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -34,6 +34,7 @@ pub mod dbus;
 pub mod http;
 
 use std::io;
+use std::num::NonZeroU32;
 use std::sync::mpsc::{RecvError, SendError, Sender, channel};
 
 use micro_http::Body;
@@ -255,7 +256,7 @@ pub struct VmCoredumpData {
     pub destination_url: String,
 }
 
-#[derive(Clone, Deserialize, Serialize, Default, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct VmReceiveMigrationData {
     /// URL for the reception of migration state
     pub receiver_url: String,
@@ -266,9 +267,13 @@ pub struct VmReceiveMigrationData {
     pub net_fds: Option<Vec<RestoredNetConfig>>,
 }
 
-#[derive(Clone, Deserialize, Serialize, Default, Debug)]
+#[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct VmSendMigrationData {
-    /// URL to migrate the VM to
+    /// URL to migrate the VM to.
+    ///
+    /// This is not actually a URL, but we are stuck with the name, because it's
+    /// part of the HTTP API. The destination is a string, such as
+    /// tcp:<host>:<port> or unix:/path/to/socket.
     pub destination_url: String,
     /// Send memory across socket without copying
     #[serde(default)]
@@ -279,11 +284,19 @@ pub struct VmSendMigrationData {
     /// Second level migration timeout
     #[serde(default)]
     pub migration_timeout: u64,
+    /// The number of parallel connections for migration
+    #[serde(default = "default_connections")]
+    pub connections: NonZeroU32,
 }
 
 // Default value for downtime the same as qemu.
 fn default_downtime() -> u64 {
     300
+}
+
+// We use a single connection for backward compatibility as default.
+fn default_connections() -> NonZeroU32 {
+    NonZeroU32::new(1).unwrap()
 }
 
 pub enum ApiResponsePayload {

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1245,6 +1245,10 @@ components:
         - destination_url
       type: object
       properties:
+        connections:
+          type: integer
+          format: int64
+          default: 1
         destination_url:
           type: string
         local:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -22,6 +22,7 @@ use std::fs::File;
 use std::io::{Read, Write, stdout};
 use std::net::{TcpListener, TcpStream};
 use std::num::NonZeroU32;
+use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::panic::AssertUnwindSafe;
@@ -731,11 +732,59 @@ pub struct Vmm {
     console_info: Option<ConsoleInfo>,
 }
 
+/// Wait for a file descriptor to become readable. In this case, we return
+/// true. In case, the eventfd was signaled, return false.
+fn wait_for_readable(
+    fd: &impl AsFd,
+    eventfd: &EventFd,
+) -> std::result::Result<bool, std::io::Error> {
+    let fd_event = eventfd.as_raw_fd().as_raw_fd();
+    let fd_io = fd.as_fd().as_raw_fd();
+    let mut poll_fds = [
+        libc::pollfd {
+            fd: fd_event,
+            events: libc::POLLIN,
+            revents: 0,
+        },
+        libc::pollfd {
+            fd: fd_io,
+            events: libc::POLLIN,
+            revents: 0,
+        },
+    ];
+
+    // SAFETY: This is safe, because the file descriptors are valid and the
+    // poll_fds array is properly initialized.
+    let ret = unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as libc::nfds_t, -1) };
+
+    if ret < 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+
+    if poll_fds[0].revents & libc::POLLIN != 0 {
+        return Ok(false);
+    }
+    if poll_fds[1].revents & libc::POLLIN != 0 {
+        return Ok(true);
+    }
+
+    panic!("Poll returned, but neither file descriptor is readable?");
+}
+
 /// Abstract over the different types of listeners that can be used to receive connections.
 #[derive(Debug)]
 enum ReceiveListener {
     Tcp(TcpListener),
     Unix(UnixListener, Option<PathBuf>),
+}
+
+impl AsFd for ReceiveListener {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match self {
+            ReceiveListener::Tcp(listener) => listener.as_fd(),
+            ReceiveListener::Unix(listener, _) => listener.as_fd(),
+        }
+    }
 }
 
 impl ReceiveListener {
@@ -762,6 +811,16 @@ impl ReceiveListener {
                 Ok(socket)
             }
         }
+    }
+
+    /// Same as accept(), but returns None if the eventfd is signaled.
+    fn abortable_accept(
+        &mut self,
+        eventfd: &EventFd,
+    ) -> std::result::Result<Option<SocketStream>, std::io::Error> {
+        wait_for_readable(&self, eventfd)?
+            .then(|| self.accept())
+            .transpose()
     }
 
     fn try_clone(&self) -> std::result::Result<Self, std::io::Error> {
@@ -823,10 +882,19 @@ where
 /// We keep track of additional connections for receiving VM migration data
 /// here.
 struct ReceiveAdditionalConnections {
-    accept_thread: std::thread::JoinHandle<()>,
+    terminate_fd: EventFd,
+
+    // This is only an option to be able to join it in the destructor.
+    accept_thread: Option<std::thread::JoinHandle<()>>,
 }
 
 impl ReceiveAdditionalConnections {
+    /// Create a pair of file descriptors that map to the same underlying event_fd.
+    fn event_fd_pair() -> std::result::Result<(EventFd, EventFd), std::io::Error> {
+        let event_fd = EventFd::new(0)?;
+        Ok((event_fd.try_clone()?, event_fd))
+    }
+
     /// Starts a thread to accept incoming connections and handle them. These
     /// additional connections are used to receive additional memory regions
     /// during VM migration.
@@ -834,10 +902,13 @@ impl ReceiveAdditionalConnections {
         listener: ReceiveListener,
         guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> std::result::Result<Self, std::io::Error> {
+        let (terminate_fd1, terminate_fd2) = Self::event_fd_pair()?;
+
         let accept_thread = std::thread::spawn(move || {
+            let terminate_fd = terminate_fd2;
             let mut listener = listener;
             let mut threads: Vec<std::thread::JoinHandle<()>> = Vec::new();
-            while let Ok(mut socket) = listener.accept() {
+            while let Ok(Some(mut socket)) = listener.abortable_accept(&terminate_fd) {
                 let guest_memory = guest_memory.clone();
 
                 // We handle errors locally and log them. Passing them along is
@@ -876,19 +947,34 @@ impl ReceiveAdditionalConnections {
             });
         });
 
-        Ok(Self { accept_thread })
+        Ok(Self {
+            accept_thread: Some(accept_thread),
+            terminate_fd: terminate_fd1,
+        })
+    }
+
+    /// Stop accepting additional connections and tear down all connections.
+    ///
+    /// This function does not wait for the operation to complete.
+    fn signal_termination(&self) {
+        // It's not really worth propagating this error, because it only happens if
+        // something hit the fan and we can't really do anything about it.
+        if let Err(e) = self.terminate_fd.write(u64::MAX) {
+            error!("Failed to wake up other threads: {}", e);
+        }
     }
 }
 
 impl Drop for ReceiveAdditionalConnections {
     fn drop(&mut self) {
-        // TODO Here we should make sure to shut down the accept thread before
-        // joining it. This is currently not so easy, because we don't have a
-        // way to signal the thread to stop accepting connections.
+        self.signal_termination();
+        // This unwrap is safe, because we never write a None into
+        // self.accept_thread in other places.
+        let _accept_thread = self.accept_thread.take().unwrap();
 
-        if !self.accept_thread.is_finished() {
-            warn!("Accept thread is still running");
-        }
+        // TODO The accept thread tries to join all threads it started, but we
+        // haven't implemented tearing them down yet.
+        // accept_thread.join().unwrap();
     }
 }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -730,6 +730,40 @@ pub struct Vmm {
     console_info: Option<ConsoleInfo>,
 }
 
+/// Abstract over the different types of listeners that can be used to receive connections.
+#[derive(Debug)]
+enum ReceiveListener {
+    Tcp(TcpListener),
+    Unix(UnixListener, Option<PathBuf>),
+}
+
+impl ReceiveListener {
+    /// Block until a connection is accepted.
+    fn accept(&mut self) -> std::result::Result<SocketStream, std::io::Error> {
+        match self {
+            ReceiveListener::Tcp(listener) => listener
+                .accept()
+                .map(|(socket, _)| SocketStream::Tcp(socket)),
+            ReceiveListener::Unix(listener, opt_path) => {
+                let socket = listener
+                    .accept()
+                    .map(|(socket, _)| SocketStream::Unix(socket))?;
+
+                // Remove the UNIX socket file after accepting the connection. Is this actually safe? If a user
+                // moves the file and creates a new one with the same name, we will delete the wrong file.
+                // Sounds like a confused deputy to me.
+                //
+                // TODO Don't do this?
+                if let Some(path) = opt_path.take() {
+                    std::fs::remove_file(&path)?;
+                }
+
+                Ok(socket)
+            }
+        }
+    }
+}
+
 /// The receiver's state machine behind the migration protocol.
 enum ReceiveMigrationState {
     /// The connection is established and we haven't received any commands yet.
@@ -1293,41 +1327,22 @@ impl Vmm {
         }
     }
 
-    fn receive_migration_socket(
+    fn receive_migration_listener(
         receiver_url: &str,
-    ) -> std::result::Result<SocketStream, MigratableError> {
+    ) -> std::result::Result<ReceiveListener, MigratableError> {
         if let Some(address) = receiver_url.strip_prefix("tcp:") {
-            let listener = TcpListener::bind(address).map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error binding to TCP socket: {}", e))
-            })?;
-
-            let (socket, _addr) = listener.accept().map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!(
-                    "Error accepting connection on TCP socket: {}",
-                    e
-                ))
-            })?;
-
-            Ok(SocketStream::Tcp(socket))
+            TcpListener::bind(address)
+                .map_err(|e| {
+                    MigratableError::MigrateReceive(anyhow!("Error binding to TCP socket: {}", e))
+                })
+                .map(ReceiveListener::Tcp)
         } else {
             let path = Vmm::socket_url_to_path(receiver_url)?;
-            let listener = UnixListener::bind(&path).map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error binding to UNIX socket: {}", e))
-            })?;
-
-            let (socket, _addr) = listener.accept().map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!(
-                    "Error accepting connection on UNIX socket: {}",
-                    e
-                ))
-            })?;
-
-            // Remove the UNIX socket file after accepting the connection
-            std::fs::remove_file(&path).map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error removing UNIX socket file: {}", e))
-            })?;
-
-            Ok(SocketStream::Unix(socket))
+            UnixListener::bind(&path)
+                .map_err(|e| {
+                    MigratableError::MigrateReceive(anyhow!("Error binding to UNIX socket: {}", e))
+                })
+                .map(|listener| ReceiveListener::Unix(listener, Some(path)))
         }
     }
 
@@ -2574,8 +2589,12 @@ impl RequestHandler for Vmm {
             receive_data_migration.receiver_url, &receive_data_migration.net_fds
         );
 
+        let mut listener = Vmm::receive_migration_listener(&receive_data_migration.receiver_url)?;
         // Accept the connection and get the socket
-        let mut socket = Vmm::receive_migration_socket(&receive_data_migration.receiver_url)?;
+        let mut socket = listener.accept().map_err(|e| {
+            warn!("Failed to accept migration connection: {}", e);
+            MigratableError::MigrateReceive(anyhow!("Failed to accept migration connection: {}", e))
+        })?;
 
         let mut state = ReceiveMigrationState::Established;
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1444,27 +1444,27 @@ impl Vmm {
         }
     }
 
+    // Send memory from the given table.
     // Returns true if there were dirty pages to send
-    fn vm_maybe_send_dirty_pages(
+    fn vm_send_memory(
         vm: &mut Vm,
         socket: &mut SocketStream,
-        table: MemoryRangeTable,
-    ) -> result::Result<bool, MigratableError> {
-        // But if there are no regions go straight to pause
+        table: &MemoryRangeTable,
+    ) -> result::Result<(), MigratableError> {
         if table.regions().is_empty() {
-            return Ok(false);
+            return Ok(());
         }
 
         Request::memory(table.length()).write_to(socket).unwrap();
         table.write_to(socket)?;
         // And then the memory itself
-        vm.send_memory_regions(&table, socket)?;
+        vm.send_memory_regions(table, socket)?;
         Response::read_from(socket)?.ok_or_abandon(
             socket,
             MigratableError::MigrateSend(anyhow!("Error during dirty memory migration")),
         )?;
 
-        Ok(true)
+        Ok(())
     }
 
     fn can_increase_autoconverge_step(s: &MigrationState) -> bool {
@@ -1543,7 +1543,7 @@ impl Vmm {
 
             // Send the current dirty pages
             let transfer_start = Instant::now();
-            Self::vm_maybe_send_dirty_pages(vm, socket, iteration_table.clone())?;
+            Self::vm_send_memory(vm, socket, &iteration_table)?;
             let transfer_time = transfer_start.elapsed().as_millis() as f64;
 
             // Update bandwidth
@@ -1579,16 +1579,7 @@ impl Vmm {
         // Start logging dirty pages
         vm.start_dirty_log()?;
 
-        // Send memory table
-        let table = vm.memory_range_table()?;
-        Request::memory(table.length()).write_to(socket).unwrap();
-        table.write_to(socket)?;
-        // And then the memory itself
-        vm.send_memory_regions(&table, socket)?;
-        Response::read_from(socket)?.ok_or_abandon(
-            socket,
-            MigratableError::MigrateSend(anyhow!("Error during dirty memory migration")),
-        )?;
+        Self::vm_send_memory(vm, socket, &vm.memory_range_table()?)?;
 
         // Define the maximum allowed downtime 2000 seconds(2000000 milliseconds)
         const MAX_MIGRATE_DOWNTIME: u64 = 2000000;
@@ -1630,7 +1621,7 @@ impl Vmm {
         // Send last batch of dirty pages
         let mut final_table = vm.dirty_log()?;
         final_table.extend(iteration_table.clone());
-        Self::vm_maybe_send_dirty_pages(vm, socket, final_table.clone())?;
+        Self::vm_send_memory(vm, socket, &final_table)?;
 
         // Update statistics
         s.pending_size = final_table.regions().iter().map(|range| range.length).sum();

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -977,6 +977,67 @@ fn receive_migration_listener(
     }
 }
 
+fn send_memory_regions(
+    guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
+    ranges: &MemoryRangeTable,
+    fd: &mut SocketStream,
+) -> std::result::Result<(), MigratableError> {
+    let mem = guest_memory.memory();
+
+    for range in ranges.regions() {
+        let mut offset: u64 = 0;
+        // Here we are manually handling the retry in case we can't the
+        // whole region at once because we can't use the implementation
+        // from vm-memory::GuestMemory of write_all_to() as it is not
+        // following the correct behavior. For more info about this issue
+        // see: https://github.com/rust-vmm/vm-memory/issues/174
+        loop {
+            let bytes_written = mem
+                .write_volatile_to(
+                    GuestAddress(range.gpa + offset),
+                    fd,
+                    (range.length - offset) as usize,
+                )
+                .map_err(|e| {
+                    MigratableError::MigrateSend(anyhow!(
+                        "Error transferring memory to socket: {}",
+                        e
+                    ))
+                })?;
+            offset += bytes_written as u64;
+
+            if offset == range.length {
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+// Send memory from the given table.
+// Returns true if there were dirty pages to send
+fn vm_send_memory(
+    guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
+    socket: &mut SocketStream,
+    table: &MemoryRangeTable,
+) -> result::Result<(), MigratableError> {
+    if table.regions().is_empty() {
+        return Ok(());
+    }
+
+    Request::memory(table.length()).write_to(socket).unwrap();
+    table.write_to(socket)?;
+    // And then the memory itself
+    send_memory_regions(guest_memory, table, socket)?;
+    Response::read_from(socket)?.ok_or_abandon(
+        socket,
+        MigratableError::MigrateSend(anyhow!("Error during dirty memory migration")),
+    )?;
+
+    Ok(())
+}
+
 impl Vmm {
     pub const HANDLED_SIGNALS: [i32; 2] = [SIGTERM, SIGINT];
 
@@ -1444,29 +1505,6 @@ impl Vmm {
         Ok(())
     }
 
-    // Send memory from the given table.
-    // Returns true if there were dirty pages to send
-    fn vm_send_memory(
-        vm: &mut Vm,
-        socket: &mut SocketStream,
-        table: &MemoryRangeTable,
-    ) -> result::Result<(), MigratableError> {
-        if table.regions().is_empty() {
-            return Ok(());
-        }
-
-        Request::memory(table.length()).write_to(socket).unwrap();
-        table.write_to(socket)?;
-        // And then the memory itself
-        vm.send_memory_regions(table, socket)?;
-        Response::read_from(socket)?.ok_or_abandon(
-            socket,
-            MigratableError::MigrateSend(anyhow!("Error during dirty memory migration")),
-        )?;
-
-        Ok(())
-    }
-
     fn can_increase_autoconverge_step(s: &MigrationState) -> bool {
         if s.iteration < AUTO_CONVERGE_ITERATION_DELAY {
             false
@@ -1543,7 +1581,7 @@ impl Vmm {
 
             // Send the current dirty pages
             let transfer_start = Instant::now();
-            Self::vm_send_memory(vm, socket, &iteration_table)?;
+            vm_send_memory(&vm.guest_memory(), socket, &iteration_table)?;
             let transfer_time = transfer_start.elapsed().as_millis() as f64;
 
             // Update bandwidth
@@ -1579,7 +1617,7 @@ impl Vmm {
         // Start logging dirty pages
         vm.start_dirty_log()?;
 
-        Self::vm_send_memory(vm, socket, &vm.memory_range_table()?)?;
+        vm_send_memory(&vm.guest_memory(), socket, &vm.memory_range_table()?)?;
 
         // Define the maximum allowed downtime 2000 seconds(2000000 milliseconds)
         const MAX_MIGRATE_DOWNTIME: u64 = 2000000;
@@ -1621,7 +1659,7 @@ impl Vmm {
         // Send last batch of dirty pages
         let mut final_table = vm.dirty_log()?;
         final_table.extend(iteration_table.clone());
-        Self::vm_send_memory(vm, socket, &final_table)?;
+        vm_send_memory(&vm.guest_memory(), socket, &final_table)?;
 
         // Update statistics
         s.pending_size = final_table.regions().iter().map(|range| range.length).sum();

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{Read, Write, stdout};
 use std::net::{TcpListener, TcpStream};
+use std::num::NonZeroU32;
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::panic::AssertUnwindSafe;
@@ -927,6 +928,101 @@ impl ReceiveMigrationState {
     }
 }
 
+/// This struct keeps track of additional threads we use to send VM memory.
+struct SendAdditionalConnections {
+    guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
+    threads: Vec<thread::JoinHandle<()>>,
+    channels: Vec<std::sync::mpsc::Sender<MemoryRangeTable>>,
+}
+
+/// Send memory from the given table.
+fn vm_send_memory(
+    guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
+    socket: &mut SocketStream,
+    table: &MemoryRangeTable,
+) -> result::Result<(), MigratableError> {
+    if table.regions().is_empty() {
+        return Ok(());
+    }
+
+    Request::memory(table.length()).write_to(socket).unwrap();
+    table.write_to(socket)?;
+    // And then the memory itself
+    send_memory_regions(guest_memory, table, socket)?;
+    Response::read_from(socket)?.ok_or_abandon(
+        socket,
+        MigratableError::MigrateSend(anyhow!("Error during dirty memory migration")),
+    )?;
+
+    Ok(())
+}
+
+impl SendAdditionalConnections {
+    fn new(
+        destination: &str,
+        connections: NonZeroU32,
+        guest_mem: &GuestMemoryAtomic<GuestMemoryMmap>,
+    ) -> std::result::Result<Self, MigratableError> {
+        let mut threads = Vec::new();
+        let mut channels = Vec::new();
+
+        for _ in 0..(connections.get() - 1) {
+            let socket = send_migration_socket(destination)?;
+            let guest_mem = guest_mem.clone();
+            let (send, recv) = std::sync::mpsc::channel::<MemoryRangeTable>();
+
+            let thread = thread::spawn(move || {
+                let mut socket = socket;
+                while let Ok(table) = recv.recv() {
+                    vm_send_memory(&guest_mem, &mut socket, &table).unwrap()
+                }
+            });
+
+            threads.push(thread);
+            channels.push(send);
+        }
+
+        Ok(Self {
+            guest_memory: guest_mem.clone(),
+            threads,
+            channels,
+        })
+    }
+
+    /// Send memory via all connections that we have. This may be just one.
+    /// `socket` is the original socket that was used to connect to the
+    /// destination.
+    fn send_memory(
+        &self,
+        table: &MemoryRangeTable,
+        socket: &mut SocketStream,
+    ) -> std::result::Result<(), MigratableError> {
+        warn!("Not sending via multiple connections yet");
+
+        Request::memory(table.length()).write_to(socket).unwrap();
+        table.write_to(socket)?;
+        // And then the memory itself
+        send_memory_regions(&self.guest_memory, table, socket)?;
+        Response::read_from(socket)?.ok_or_abandon(
+            socket,
+            MigratableError::MigrateSend(anyhow!("Error during dirty memory migration")),
+        )?;
+
+        Ok(())
+    }
+}
+
+impl Drop for SendAdditionalConnections {
+    fn drop(&mut self) {
+        // Drop all channels, so the threads will exit.
+        self.channels.clear();
+
+        self.threads
+            .drain(..)
+            .for_each(|thread| thread.join().unwrap());
+    }
+}
+
 /// Establishes a connection to a migration destination socket (TCP or UNIX).
 fn send_migration_socket(
     destination_url: &str,
@@ -1011,29 +1107,6 @@ fn send_memory_regions(
             }
         }
     }
-
-    Ok(())
-}
-
-// Send memory from the given table.
-// Returns true if there were dirty pages to send
-fn vm_send_memory(
-    guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
-    socket: &mut SocketStream,
-    table: &MemoryRangeTable,
-) -> result::Result<(), MigratableError> {
-    if table.regions().is_empty() {
-        return Ok(());
-    }
-
-    Request::memory(table.length()).write_to(socket).unwrap();
-    table.write_to(socket)?;
-    // And then the memory itself
-    send_memory_regions(guest_memory, table, socket)?;
-    Response::read_from(socket)?.ok_or_abandon(
-        socket,
-        MigratableError::MigrateSend(anyhow!("Error during dirty memory migration")),
-    )?;
 
     Ok(())
 }
@@ -1516,6 +1589,7 @@ impl Vmm {
 
     fn memory_copy_iterations(
         vm: &mut Vm,
+        mem_send: &SendAdditionalConnections,
         socket: &mut SocketStream,
         s: &mut MigrationState,
         migration_timeout: Duration,
@@ -1581,7 +1655,7 @@ impl Vmm {
 
             // Send the current dirty pages
             let transfer_start = Instant::now();
-            vm_send_memory(&vm.guest_memory(), socket, &iteration_table)?;
+            mem_send.send_memory(&iteration_table, socket)?;
             let transfer_time = transfer_start.elapsed().as_millis() as f64;
 
             // Update bandwidth
@@ -1614,10 +1688,16 @@ impl Vmm {
         s: &mut MigrationState,
         send_data_migration: &VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
+        let mem_send = SendAdditionalConnections::new(
+            &send_data_migration.destination_url,
+            send_data_migration.connections,
+            &vm.guest_memory(),
+        )?;
+
         // Start logging dirty pages
         vm.start_dirty_log()?;
 
-        vm_send_memory(&vm.guest_memory(), socket, &vm.memory_range_table()?)?;
+        mem_send.send_memory(&vm.memory_range_table()?, socket)?;
 
         // Define the maximum allowed downtime 2000 seconds(2000000 milliseconds)
         const MAX_MIGRATE_DOWNTIME: u64 = 2000000;
@@ -1643,8 +1723,14 @@ impl Vmm {
             )));
         }
 
-        let iteration_table =
-            Self::memory_copy_iterations(vm, socket, s, migration_timeout, migrate_downtime_limit)?;
+        let iteration_table = Self::memory_copy_iterations(
+            vm,
+            &mem_send,
+            socket,
+            s,
+            migration_timeout,
+            migrate_downtime_limit,
+        )?;
 
         info!("Entering downtime phase");
         s.downtime_start = Instant::now();
@@ -1659,8 +1745,7 @@ impl Vmm {
         // Send last batch of dirty pages
         let mut final_table = vm.dirty_log()?;
         final_table.extend(iteration_table.clone());
-        vm_send_memory(&vm.guest_memory(), socket, &final_table)?;
-
+        mem_send.send_memory(&final_table, socket)?;
         // Update statistics
         s.pending_size = final_table.regions().iter().map(|range| range.length).sum();
         s.total_transferred_bytes += s.pending_size;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -19,7 +19,7 @@ const AUTO_CONVERGE_MAX: u8 = 99;
 
 use std::collections::HashMap;
 use std::fs::File;
-use std::io::{Read, Write, stdout};
+use std::io::{ErrorKind, Read, Write, stdout};
 use std::net::{TcpListener, TcpStream};
 use std::num::NonZeroU32;
 use std::os::fd::{AsFd, BorrowedFd};
@@ -286,6 +286,15 @@ impl Write for SocketStream {
         match self {
             SocketStream::Unix(stream) => stream.flush(),
             SocketStream::Tcp(stream) => stream.flush(),
+        }
+    }
+}
+
+impl AsFd for SocketStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match self {
+            SocketStream::Unix(s) => s.as_fd(),
+            SocketStream::Tcp(s) => s.as_fd(),
         }
     }
 }
@@ -895,6 +904,56 @@ impl ReceiveAdditionalConnections {
         Ok((event_fd.try_clone()?, event_fd))
     }
 
+    /// Handle incoming requests.
+    ///
+    /// For now we only handle `Command::Memory` requests here. Everything else
+    /// needs to come via the main connection. This function returns when the
+    /// abort_event_fd is triggered or the connection is closed or encountered
+    /// an error.
+    fn handle_requests(
+        socket: &mut SocketStream,
+        abort_event_fd: &EventFd,
+        guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
+    ) -> std::result::Result<(), MigratableError> {
+        loop {
+            if !wait_for_readable(socket, abort_event_fd).map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Failed to poll descriptors: {e}"))
+            })? {
+                info!("Got signal to tear down connection.");
+                return Ok(());
+            }
+
+            // TODO We only check whether we should abort when waiting for a new
+            // request. If the sender just stops sending data mid-request, we
+            // should still be abortable, but we are not... In this case, we
+            // will hang forever. But given that the sender is also in charge of
+            // driving the migration to completion, this is not a major concern.
+            // In the long run, it would be preferable to move I/O to
+            // asynchronous tasks to be able to handle aborts more gracefully.
+
+            let req = match Request::read_from(socket) {
+                Ok(req) => req,
+                Err(MigratableError::MigrateSocket(io_error))
+                    if io_error.kind() == ErrorKind::UnexpectedEof =>
+                {
+                    debug!("Connection closed by peer");
+                    return Ok(());
+                }
+                Err(e) => return Err(e),
+            };
+
+            if req.command() != Command::Memory {
+                return Err(MigratableError::MigrateReceive(anyhow!(
+                    "Dropping connection. Only Memory commands are allowed on additional connections, but got {:?}",
+                    req.command()
+                )));
+            }
+
+            vm_receive_memory(&req, socket, guest_memory)?;
+            Response::ok().write_to(socket)?;
+        }
+    }
+
     /// Starts a thread to accept incoming connections and handle them. These
     /// additional connections are used to receive additional memory regions
     /// during VM migration.
@@ -910,33 +969,17 @@ impl ReceiveAdditionalConnections {
             let mut threads: Vec<std::thread::JoinHandle<()>> = Vec::new();
             while let Ok(Some(mut socket)) = listener.abortable_accept(&terminate_fd) {
                 let guest_memory = guest_memory.clone();
+                let terminate_fd = terminate_fd.try_clone().unwrap();
 
                 // We handle errors locally and log them. Passing them along is
                 // painful with little value.
                 threads.push(std::thread::spawn(move || {
-                    loop {
-                        let req = match Request::read_from(&mut socket) {
-                            Ok(req) => req,
-                            Err(e) => {
-                                error!("Failed to read request: {}", e);
-                                break;
-                            }
-                        };
-
-                        if req.command() != Command::Memory {
-                            error!("Dropping connection. Only Memory commands are allowed on additional connections");
-                            break;
-                        }
-
-                        if let Err(e) = vm_receive_memory(&req, &mut socket, &guest_memory) {
-                            error!("Failed to receive memory: {}", e);
-                            break;
-                        }
-
-                        if let Err(e) = Response::ok().write_to(&mut socket) {
-                            error!("Failed to send response: {}", e);
-                            break;
-                        }
+                    if let Err(e) = Self::handle_requests(&mut socket, &terminate_fd, &guest_memory)
+                    {
+                        error!(
+                            "Failed to read more requests on additional receive connection: {}",
+                            e
+                        );
                     }
                 }));
             }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1215,6 +1215,15 @@ impl SendAdditionalConnections {
         let thread_len = self.threads.len();
         assert_eq!(thread_len, self.channels.len());
 
+        // In case, we didn't manage to establish additional connections, don't
+        // bother sending memory in chunks. This would just lower throughput,
+        // because we wait for a response after each chunk instead of sending
+        // everything in one go.
+        if thread_len == 0 {
+            vm_send_memory(&self.guest_memory, socket, table)?;
+            return Ok(());
+        }
+
         // The chunk size is chosen to be big enough so that even very fast
         // links need some milliseconds to send it.
         'next_partition: for chunk in table.partition(Self::CHUNK_SIZE) {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -51,7 +51,10 @@ use signal_hook::iterator::{Handle, Signals};
 use thiserror::Error;
 use tracer::trace_scoped;
 use vm_memory::bitmap::{AtomicBitmap, BitmapSlice};
-use vm_memory::{ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile};
+use vm_memory::{
+    GuestAddress, GuestAddressSpace, GuestMemory, ReadVolatile, VolatileMemoryError, VolatileSlice,
+    WriteVolatile,
+};
 use vm_migration::protocol::*;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
@@ -1217,10 +1220,37 @@ impl Vmm {
         T: Read + ReadVolatile,
     {
         // Read table
-        let table = MemoryRangeTable::read_from(socket, req.length())?;
+        let ranges = MemoryRangeTable::read_from(socket, req.length())?;
+        let mem = memory_manager.guest_memory().memory();
 
-        // And then read the memory itself
-        memory_manager.receive_memory_regions(&table, socket)?;
+        for range in ranges.regions() {
+            let mut offset: u64 = 0;
+            // Here we are manually handling the retry in case we can't the
+            // whole region at once because we can't use the implementation
+            // from vm-memory::GuestMemory of read_exact_from() as it is not
+            // following the correct behavior. For more info about this issue
+            // see: https://github.com/rust-vmm/vm-memory/issues/174
+            loop {
+                let bytes_read = mem
+                    .read_volatile_from(
+                        GuestAddress(range.gpa + offset),
+                        socket,
+                        (range.length - offset) as usize,
+                    )
+                    .map_err(|e| {
+                        MigratableError::MigrateReceive(anyhow!(
+                            "Error receiving memory from socket: {}",
+                            e
+                        ))
+                    })?;
+                offset += bytes_read as u64;
+
+                if offset == range.length {
+                    break;
+                }
+            }
+        }
+
         Ok(())
     }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -27,8 +27,8 @@ use std::os::unix::net::{UnixListener, UnixStream};
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::rc::Rc;
-use std::sync::mpsc::{Receiver, RecvError, SendError, Sender};
-use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{Receiver, RecvError, SendError, Sender, TrySendError};
+use std::sync::{Arc, Barrier, Mutex};
 #[cfg(not(target_arch = "riscv64"))]
 use std::time::{Duration, Instant};
 use std::{io, result, thread};
@@ -861,6 +861,11 @@ impl ReceiveAdditionalConnections {
                             error!("Failed to receive memory: {}", e);
                             break;
                         }
+
+                        if let Err(e) = Response::ok().write_to(&mut socket) {
+                            error!("Failed to send response: {}", e);
+                            break;
+                        }
                     }
                 }));
             }
@@ -928,11 +933,19 @@ impl ReceiveMigrationState {
     }
 }
 
+/// The different kinds of messages we can send to memory sending threads.
+#[derive(Debug)]
+enum SendMemoryThreadMessage {
+    Memory(Arc<MemoryRangeTable>),
+    Barrier(Arc<Barrier>),
+    Disconnect,
+}
+
 /// This struct keeps track of additional threads we use to send VM memory.
 struct SendAdditionalConnections {
     guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
     threads: Vec<thread::JoinHandle<()>>,
-    channels: Vec<std::sync::mpsc::Sender<MemoryRangeTable>>,
+    channels: Vec<std::sync::mpsc::SyncSender<SendMemoryThreadMessage>>,
 }
 
 /// Send memory from the given table.
@@ -958,6 +971,27 @@ fn vm_send_memory(
 }
 
 impl SendAdditionalConnections {
+    /// How many requests can be waiting to be sent for each connection. This
+    /// can be set to zero to disable buffering. Whether we need to buffer
+    /// requests is currently unclear. If this is set too high, some connections
+    /// might go unused, because work pools up on some connections.
+    const BUFFERED_REQUESTS_PER_THREAD: usize = 1;
+
+    /// The size of each chunk of memory to send.
+    ///
+    /// We want to make this large, because each chunk is acknowledged and we
+    /// wait for the ack before sending the next chunk. The challenge is that if
+    /// it is _too_ large, we become more sensitive to network issues, like
+    /// packet drops in individual connections, because large amounts of data
+    /// can pool when throughput on one connection is temporarily reduced.
+    ///
+    /// We can consider making this configurable, but a better network protocol
+    /// that doesn't require ACKs would be more efficient.
+    ///
+    /// The best-case throughput per connection can be estimated via:
+    /// effective_throughput = chunk_size / (chunk_size / throughput_per_connection + round_trip_time)
+    const CHUNK_SIZE: u64 = 64 /* MiB */ << 20;
+
     fn new(
         destination: &str,
         connections: NonZeroU32,
@@ -969,13 +1003,32 @@ impl SendAdditionalConnections {
         for _ in 0..(connections.get() - 1) {
             let socket = send_migration_socket(destination)?;
             let guest_mem = guest_mem.clone();
-            let (send, recv) = std::sync::mpsc::channel::<MemoryRangeTable>();
+            let (send, recv) = std::sync::mpsc::sync_channel::<SendMemoryThreadMessage>(
+                Self::BUFFERED_REQUESTS_PER_THREAD,
+            );
 
             let thread = thread::spawn(move || {
+                info!("Spawned thread to send VM memory.");
+
+                let mut total_sent = 0;
                 let mut socket = socket;
-                while let Ok(table) = recv.recv() {
-                    vm_send_memory(&guest_mem, &mut socket, &table).unwrap()
+
+                for msg in recv {
+                    match msg {
+                        SendMemoryThreadMessage::Memory(table) => {
+                            vm_send_memory(&guest_mem, &mut socket, &table).unwrap();
+                            total_sent +=
+                                table.ranges().iter().map(|range| range.length).sum::<u64>();
+                        }
+                        SendMemoryThreadMessage::Barrier(barrier) => {
+                            barrier.wait();
+                        }
+                        SendMemoryThreadMessage::Disconnect => {
+                            break;
+                        }
+                    }
                 }
+                info!("Sent {} MiB via additional connection.", total_sent >> 20);
             });
 
             threads.push(thread);
@@ -989,24 +1042,67 @@ impl SendAdditionalConnections {
         })
     }
 
+    /// Wait until all data that is in-flight has actually been sent and acknowledged.
+    fn wait_for_pending_data(&self) {
+        assert_eq!(self.channels.len(), self.threads.len());
+
+        // TODO We don't actually need the threads to block at the barrier. We
+        // can probably find a better implementation that involves less
+        // synchronization.
+
+        let barrier = Arc::new(Barrier::new(self.channels.len() + 1));
+
+        for channel in &self.channels {
+            channel
+                .send(SendMemoryThreadMessage::Barrier(barrier.clone()))
+                // The unwrap only fails fi
+                .unwrap();
+        }
+
+        barrier.wait();
+    }
+
     /// Send memory via all connections that we have. This may be just one.
     /// `socket` is the original socket that was used to connect to the
     /// destination.
+    ///
+    /// When this function returns, all memory has been sent and acknowledged.
     fn send_memory(
         &self,
         table: &MemoryRangeTable,
         socket: &mut SocketStream,
     ) -> std::result::Result<(), MigratableError> {
-        warn!("Not sending via multiple connections yet");
+        let thread_len = self.threads.len();
+        assert_eq!(thread_len, self.channels.len());
 
-        Request::memory(table.length()).write_to(socket).unwrap();
-        table.write_to(socket)?;
-        // And then the memory itself
-        send_memory_regions(&self.guest_memory, table, socket)?;
-        Response::read_from(socket)?.ok_or_abandon(
-            socket,
-            MigratableError::MigrateSend(anyhow!("Error during dirty memory migration")),
-        )?;
+        // The chunk size is chosen to be big enough so that even very fast
+        // links need some milliseconds to send it.
+        'next_partition: for chunk in table.partition(Self::CHUNK_SIZE) {
+            let chunk = Arc::new(chunk);
+
+            // Find the first free channel and send the chunk via it.
+            //
+            // TODO A better implementation wouldn't always start at the
+            // first thread, but go round-robin.
+            for channel in &self.channels {
+                match channel.try_send(SendMemoryThreadMessage::Memory(chunk.clone())) {
+                    Ok(()) => continue 'next_partition,
+                    Err(TrySendError::Full(_)) => {
+                        // Try next channel.
+                    }
+                    Err(TrySendError::Disconnected(_)) => {
+                        return Err(MigratableError::MigrateSend(anyhow!(
+                            "Sending thread died?"
+                        )));
+                    }
+                }
+            }
+
+            // Fallback to sending the chunk via the control connection.
+            vm_send_memory(&self.guest_memory, socket, &chunk)?;
+        }
+
+        self.wait_for_pending_data();
 
         Ok(())
     }
@@ -1014,12 +1110,16 @@ impl SendAdditionalConnections {
 
 impl Drop for SendAdditionalConnections {
     fn drop(&mut self) {
-        // Drop all channels, so the threads will exit.
-        self.channels.clear();
+        info!("Sending disconnect message to channels");
+        self.channels
+            .drain(..)
+            .for_each(|channel| channel.send(SendMemoryThreadMessage::Disconnect).unwrap());
 
+        info!("Waiting for threads to finish");
         self.threads
             .drain(..)
             .for_each(|thread| thread.join().unwrap());
+        info!("Threads finished");
     }
 }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -927,6 +927,56 @@ impl ReceiveMigrationState {
     }
 }
 
+/// Establishes a connection to a migration destination socket (TCP or UNIX).
+fn send_migration_socket(
+    destination_url: &str,
+) -> std::result::Result<SocketStream, MigratableError> {
+    if let Some(address) = destination_url.strip_prefix("tcp:") {
+        info!("Connecting to TCP socket at {}", address);
+
+        let socket = TcpStream::connect(address).map_err(|e| {
+            MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {}", e))
+        })?;
+
+        Ok(SocketStream::Tcp(socket))
+    } else if let Some(path) = destination_url.strip_prefix("unix:") {
+        info!("Connecting to UNIX socket at {:?}", path);
+
+        let socket = UnixStream::connect(path).map_err(|e| {
+            MigratableError::MigrateSend(anyhow!("Error connecting to UNIX socket: {}", e))
+        })?;
+
+        Ok(SocketStream::Unix(socket))
+    } else {
+        Err(MigratableError::MigrateSend(anyhow!(
+            "Invalid destination: {destination_url}"
+        )))
+    }
+}
+
+/// Creates a listener socket for receiving incoming migration connections (TCP or UNIX).
+fn receive_migration_listener(
+    receiver_url: &str,
+) -> std::result::Result<ReceiveListener, MigratableError> {
+    if let Some(address) = receiver_url.strip_prefix("tcp:") {
+        TcpListener::bind(address)
+            .map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error binding to TCP socket: {}", e))
+            })
+            .map(ReceiveListener::Tcp)
+    } else if let Some(path) = receiver_url.strip_prefix("unix:") {
+        UnixListener::bind(path)
+            .map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error binding to UNIX socket: {}", e))
+            })
+            .map(|listener| ReceiveListener::Unix(listener, Some(path.into())))
+    } else {
+        Err(MigratableError::MigrateSend(anyhow!(
+            "Invalid source: {receiver_url}"
+        )))
+    }
+}
+
 impl Vmm {
     pub const HANDLED_SIGNALS: [i32; 2] = [SIGTERM, SIGINT];
 
@@ -1394,56 +1444,6 @@ impl Vmm {
         Ok(())
     }
 
-    fn socket_url_to_path(url: &str) -> result::Result<PathBuf, MigratableError> {
-        url.strip_prefix("unix:")
-            .ok_or_else(|| {
-                MigratableError::MigrateSend(anyhow!("Could not extract path from URL: {}", url))
-            })
-            .map(|s| s.into())
-    }
-
-    fn send_migration_socket(
-        destination_url: &str,
-    ) -> std::result::Result<SocketStream, MigratableError> {
-        if let Some(address) = destination_url.strip_prefix("tcp:") {
-            info!("Connecting to TCP socket at {}", address);
-
-            let socket = TcpStream::connect(address).map_err(|e| {
-                MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {}", e))
-            })?;
-
-            Ok(SocketStream::Tcp(socket))
-        } else {
-            let path = Vmm::socket_url_to_path(destination_url)?;
-            info!("Connecting to UNIX socket at {:?}", path);
-
-            let socket = UnixStream::connect(&path).map_err(|e| {
-                MigratableError::MigrateSend(anyhow!("Error connecting to UNIX socket: {}", e))
-            })?;
-
-            Ok(SocketStream::Unix(socket))
-        }
-    }
-
-    fn receive_migration_listener(
-        receiver_url: &str,
-    ) -> std::result::Result<ReceiveListener, MigratableError> {
-        if let Some(address) = receiver_url.strip_prefix("tcp:") {
-            TcpListener::bind(address)
-                .map_err(|e| {
-                    MigratableError::MigrateReceive(anyhow!("Error binding to TCP socket: {}", e))
-                })
-                .map(ReceiveListener::Tcp)
-        } else {
-            let path = Vmm::socket_url_to_path(receiver_url)?;
-            UnixListener::bind(&path)
-                .map_err(|e| {
-                    MigratableError::MigrateReceive(anyhow!("Error binding to UNIX socket: {}", e))
-                })
-                .map(|listener| ReceiveListener::Unix(listener, Some(path)))
-        }
-    }
-
     // Send memory from the given table.
     // Returns true if there were dirty pages to send
     fn vm_send_memory(
@@ -1645,7 +1645,7 @@ impl Vmm {
         let mut s = MigrationState::new();
 
         // Set up the socket connection
-        let mut socket = Self::send_migration_socket(&send_data_migration.destination_url)?;
+        let mut socket = send_migration_socket(&send_data_migration.destination_url)?;
 
         // Start the migration
         Request::start().write_to(&mut socket)?;
@@ -2678,7 +2678,7 @@ impl RequestHandler for Vmm {
             receive_data_migration.receiver_url, &receive_data_migration.net_fds
         );
 
-        let mut listener = Vmm::receive_migration_listener(&receive_data_migration.receiver_url)?;
+        let mut listener = receive_migration_listener(&receive_data_migration.receiver_url)?;
         // Accept the connection and get the socket
         let mut socket = listener.accept().map_err(|e| {
             warn!("Failed to accept migration connection: {}", e);

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -762,6 +762,128 @@ impl ReceiveListener {
             }
         }
     }
+
+    fn try_clone(&self) -> std::result::Result<Self, std::io::Error> {
+        match self {
+            ReceiveListener::Tcp(listener) => listener.try_clone().map(ReceiveListener::Tcp),
+            ReceiveListener::Unix(listener, opt_path) => listener
+                .try_clone()
+                .map(|listener| ReceiveListener::Unix(listener, opt_path.clone())),
+        }
+    }
+}
+
+/// Handles a `Memory` request by writing its payload to the VM memory.
+fn vm_receive_memory<T>(
+    req: &Request,
+    socket: &mut T,
+    guest_mem: &GuestMemoryAtomic<GuestMemoryMmap>,
+) -> std::result::Result<(), MigratableError>
+where
+    T: Read + ReadVolatile,
+{
+    assert_eq!(req.command(), Command::Memory);
+
+    // Read table
+    let ranges = MemoryRangeTable::read_from(socket, req.length())?;
+    let mem = guest_mem.memory();
+
+    for range in ranges.regions() {
+        let mut offset: u64 = 0;
+        // Here we are manually handling the retry in case we can't the
+        // whole region at once because we can't use the implementation
+        // from vm-memory::GuestMemory of read_exact_from() as it is not
+        // following the correct behavior. For more info about this issue
+        // see: https://github.com/rust-vmm/vm-memory/issues/174
+        loop {
+            let bytes_read = mem
+                .read_volatile_from(
+                    GuestAddress(range.gpa + offset),
+                    socket,
+                    (range.length - offset) as usize,
+                )
+                .map_err(|e| {
+                    MigratableError::MigrateReceive(anyhow!(
+                        "Error receiving memory from socket: {}",
+                        e
+                    ))
+                })?;
+            offset += bytes_read as u64;
+
+            if offset == range.length {
+                break;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// We keep track of additional connections for receiving VM migration data
+/// here.
+struct ReceiveAdditionalConnections {
+    accept_thread: std::thread::JoinHandle<()>,
+}
+
+impl ReceiveAdditionalConnections {
+    /// Starts a thread to accept incoming connections and handle them. These
+    /// additional connections are used to receive additional memory regions
+    /// during VM migration.
+    fn new(
+        listener: ReceiveListener,
+        guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
+    ) -> std::result::Result<Self, std::io::Error> {
+        let accept_thread = std::thread::spawn(move || {
+            let mut listener = listener;
+            let mut threads: Vec<std::thread::JoinHandle<()>> = Vec::new();
+            while let Ok(mut socket) = listener.accept() {
+                let guest_memory = guest_memory.clone();
+
+                // We handle errors locally and log them. Passing them along is
+                // painful with little value.
+                threads.push(std::thread::spawn(move || {
+                    loop {
+                        let req = match Request::read_from(&mut socket) {
+                            Ok(req) => req,
+                            Err(e) => {
+                                error!("Failed to read request: {}", e);
+                                break;
+                            }
+                        };
+
+                        if req.command() != Command::Memory {
+                            error!("Dropping connection. Only Memory commands are allowed on additional connections");
+                            break;
+                        }
+
+                        if let Err(e) = vm_receive_memory(&req, &mut socket, &guest_memory) {
+                            error!("Failed to receive memory: {}", e);
+                            break;
+                        }
+                    }
+                }));
+            }
+
+            info!("Stopped accepting additional connections. Cleaning up threads.");
+            threads.into_iter().for_each(|thread| {
+                thread.join().unwrap();
+            });
+        });
+
+        Ok(Self { accept_thread })
+    }
+}
+
+impl Drop for ReceiveAdditionalConnections {
+    fn drop(&mut self) {
+        // TODO Here we should make sure to shut down the accept thread before
+        // joining it. This is currently not so easy, because we don't have a
+        // way to signal the thread to stop accepting connections.
+
+        if !self.accept_thread.is_finished() {
+            warn!("Accept thread is still running");
+        }
+    }
 }
 
 /// The receiver's state machine behind the migration protocol.
@@ -783,6 +905,7 @@ enum ReceiveMigrationState {
     Configured(
         Arc<Mutex<MemoryManager>>,
         GuestMemoryAtomic<GuestMemoryMmap>,
+        ReceiveAdditionalConnections,
     ),
 
     /// Memory is populated and we received the state. The VM is ready to go.
@@ -981,6 +1104,7 @@ impl Vmm {
     /// _not_ write any response to the socket.
     fn vm_receive_migration_step(
         &mut self,
+        listener: &ReceiveListener,
         socket: &mut SocketStream,
         state: ReceiveMigrationState,
         req: &Request,
@@ -1029,7 +1153,19 @@ impl Vmm {
                 }
 
                 let guest_memory = memory_manager.lock().unwrap().guest_memory();
-                Ok(Configured(memory_manager, guest_memory))
+                Ok(Configured(
+                    memory_manager,
+                    guest_memory.clone(),
+                    listener
+                        .try_clone()
+                        .and_then(|l| ReceiveAdditionalConnections::new(l, guest_memory))
+                        .map_err(|e| {
+                            MigratableError::MigrateReceive(anyhow!(
+                                "Failed to create receive additional connections: {}",
+                                e
+                            ))
+                        })?,
+                ))
             };
 
         let recv_memory_fd =
@@ -1061,17 +1197,23 @@ impl Vmm {
                 Command::Config => configure_vm(socket, HashMap::from_iter(memory_files)),
                 _ => invalid_command(),
             },
-            Configured(memory_manager, guest_memory) => match req.command() {
-                Command::Memory => {
-                    self.vm_receive_memory(req, socket, &guest_memory)?;
-                    Ok(Configured(memory_manager, guest_memory))
+            Configured(memory_manager, guest_memory, receive_additional_connections) => {
+                match req.command() {
+                    Command::Memory => {
+                        vm_receive_memory(req, socket, &guest_memory)?;
+                        Ok(Configured(
+                            memory_manager,
+                            guest_memory,
+                            receive_additional_connections,
+                        ))
+                    }
+                    Command::State => {
+                        self.vm_receive_state(req, socket, memory_manager)?;
+                        Ok(StateReceived)
+                    }
+                    _ => invalid_command(),
                 }
-                Command::State => {
-                    self.vm_receive_state(req, socket, memory_manager)?;
-                    Ok(StateReceived)
-                }
-                _ => invalid_command(),
-            },
+            }
             StateReceived => match req.command() {
                 Command::Complete => {
                     // The unwrap is safe, because the state machine makes sure we called
@@ -1248,50 +1390,6 @@ impl Vmm {
             MigratableError::MigrateReceive(anyhow!("Failed restoring the Vm: {}", e))
         })?;
         self.vm = Some(vm);
-
-        Ok(())
-    }
-
-    fn vm_receive_memory<T>(
-        &mut self,
-        req: &Request,
-        socket: &mut T,
-        guest_mem: &GuestMemoryAtomic<GuestMemoryMmap>,
-    ) -> std::result::Result<(), MigratableError>
-    where
-        T: Read + ReadVolatile,
-    {
-        // Read table
-        let ranges = MemoryRangeTable::read_from(socket, req.length())?;
-        let mem = guest_mem.memory();
-
-        for range in ranges.regions() {
-            let mut offset: u64 = 0;
-            // Here we are manually handling the retry in case we can't the
-            // whole region at once because we can't use the implementation
-            // from vm-memory::GuestMemory of read_exact_from() as it is not
-            // following the correct behavior. For more info about this issue
-            // see: https://github.com/rust-vmm/vm-memory/issues/174
-            loop {
-                let bytes_read = mem
-                    .read_volatile_from(
-                        GuestAddress(range.gpa + offset),
-                        socket,
-                        (range.length - offset) as usize,
-                    )
-                    .map_err(|e| {
-                        MigratableError::MigrateReceive(anyhow!(
-                            "Error receiving memory from socket: {}",
-                            e
-                        ))
-                    })?;
-                offset += bytes_read as u64;
-
-                if offset == range.length {
-                    break;
-                }
-            }
-        }
 
         Ok(())
     }
@@ -2603,6 +2701,7 @@ impl RequestHandler for Vmm {
             trace!("Command {:?} received", req.command());
 
             let (response, new_state) = match self.vm_receive_migration_step(
+                &listener,
                 &mut socket,
                 state,
                 &req,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1129,8 +1129,19 @@ impl SendAdditionalConnections {
         let mut threads = Vec::new();
         let mut channels = Vec::new();
 
-        for _ in 0..(connections.get() - 1) {
-            let socket = send_migration_socket(destination)?;
+        for n in 0..(connections.get() - 1) {
+            let socket = (match send_migration_socket(destination) {
+                Err(e) if n == 0 => {
+                    // If we encounter a problem on the first additional
+                    // connection, we just assume the other side doesn't support
+                    // multiple connections and carry on.
+                    info!(
+                        "Couldn't establish additional connections for sending VM memory: {e}, ignoring!"
+                    );
+                    break;
+                }
+                otherwise => otherwise,
+            })?;
             let guest_mem = guest_mem.clone();
             let (send, recv) = std::sync::mpsc::sync_channel::<SendMemoryThreadMessage>(
                 Self::BUFFERED_REQUESTS_PER_THREAD,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -52,8 +52,8 @@ use thiserror::Error;
 use tracer::trace_scoped;
 use vm_memory::bitmap::{AtomicBitmap, BitmapSlice};
 use vm_memory::{
-    GuestAddress, GuestAddressSpace, GuestMemory, ReadVolatile, VolatileMemoryError, VolatileSlice,
-    WriteVolatile,
+    GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, ReadVolatile,
+    VolatileMemoryError, VolatileSlice, WriteVolatile,
 };
 use vm_migration::protocol::*;
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
@@ -741,8 +741,15 @@ enum ReceiveMigrationState {
     /// We received file descriptors for memory. This can only happen on UNIX domain sockets.
     MemoryFdsReceived(Vec<(u32, File)>),
 
-    /// We received the VM configuration. We keep the memory configuration around to populate guest memory. From this point on, the sender can start sending memory updates.
-    Configured(Arc<Mutex<MemoryManager>>),
+    /// We received the VM configuration. We keep the memory configuration around to populate guest memory.
+    /// From this point on, the sender can start sending memory updates.
+    ///
+    /// While the memory manager can also be used to populate guest memory, we keep a direct reference to
+    /// the memory around to populate guest memory without having to acquire a lock.
+    Configured(
+        Arc<Mutex<MemoryManager>>,
+        GuestMemoryAtomic<GuestMemoryMmap>,
+    ),
 
     /// Memory is populated and we received the state. The VM is ready to go.
     StateReceived,
@@ -987,7 +994,8 @@ impl Vmm {
                     }
                 }
 
-                Ok(Configured(memory_manager))
+                let guest_memory = memory_manager.lock().unwrap().guest_memory();
+                Ok(Configured(memory_manager, guest_memory))
             };
 
         let recv_memory_fd =
@@ -1019,13 +1027,13 @@ impl Vmm {
                 Command::Config => configure_vm(socket, HashMap::from_iter(memory_files)),
                 _ => invalid_command(),
             },
-            Configured(memory_manager) => match req.command() {
+            Configured(memory_manager, guest_memory) => match req.command() {
                 Command::Memory => {
-                    self.vm_receive_memory(req, socket, &mut memory_manager.lock().unwrap())?;
-                    Ok(Configured(memory_manager))
+                    self.vm_receive_memory(req, socket, &guest_memory)?;
+                    Ok(Configured(memory_manager, guest_memory))
                 }
                 Command::State => {
-                    self.vm_receive_state(req, socket, memory_manager.clone())?;
+                    self.vm_receive_state(req, socket, memory_manager)?;
                     Ok(StateReceived)
                 }
                 _ => invalid_command(),
@@ -1214,14 +1222,14 @@ impl Vmm {
         &mut self,
         req: &Request,
         socket: &mut T,
-        memory_manager: &mut MemoryManager,
+        guest_mem: &GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> std::result::Result<(), MigratableError>
     where
         T: Read + ReadVolatile,
     {
         // Read table
         let ranges = MemoryRangeTable::read_from(socket, req.length())?;
-        let mem = memory_manager.guest_memory().memory();
+        let mem = guest_mem.memory();
 
         for range in ranges.regions() {
             let mut offset: u64 = 0;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -38,7 +38,7 @@ use vm_memory::guest_memory::FileOffset;
 use vm_memory::mmap::MmapRegionError;
 use vm_memory::{
     Address, Error as MmapError, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic,
-    GuestMemoryError, GuestMemoryRegion, GuestUsize, MmapRegion, ReadVolatile,
+    GuestMemoryError, GuestMemoryRegion, GuestUsize, MmapRegion,
 };
 use vm_migration::protocol::{MemoryRange, MemoryRangeTable};
 use vm_migration::{
@@ -2089,48 +2089,6 @@ impl MemoryManager {
         }
 
         debug!("coredump total bytes {}", total_bytes);
-        Ok(())
-    }
-
-    pub fn receive_memory_regions<F>(
-        &mut self,
-        ranges: &MemoryRangeTable,
-        fd: &mut F,
-    ) -> std::result::Result<(), MigratableError>
-    where
-        F: ReadVolatile,
-    {
-        let guest_memory = self.guest_memory();
-        let mem = guest_memory.memory();
-
-        for range in ranges.regions() {
-            let mut offset: u64 = 0;
-            // Here we are manually handling the retry in case we can't the
-            // whole region at once because we can't use the implementation
-            // from vm-memory::GuestMemory of read_exact_from() as it is not
-            // following the correct behavior. For more info about this issue
-            // see: https://github.com/rust-vmm/vm-memory/issues/174
-            loop {
-                let bytes_read = mem
-                    .read_volatile_from(
-                        GuestAddress(range.gpa + offset),
-                        fd,
-                        (range.length - offset) as usize,
-                    )
-                    .map_err(|e| {
-                        MigratableError::MigrateReceive(anyhow!(
-                            "Error receiving memory from socket: {}",
-                            e
-                        ))
-                    })?;
-                offset += bytes_read as u64;
-
-                if offset == range.length {
-                    break;
-                }
-            }
-        }
-
         Ok(())
     }
 }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -64,9 +64,7 @@ use tracer::trace_scoped;
 use vm_device::Bus;
 #[cfg(feature = "tdx")]
 use vm_memory::{Address, ByteValued, GuestMemoryRegion, ReadVolatile};
-use vm_memory::{
-    Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, WriteVolatile,
-};
+use vm_memory::{Bytes, GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic};
 use vm_migration::protocol::{MemoryRangeTable, Request, Response};
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, snapshot_from_id,
@@ -2604,46 +2602,8 @@ impl Vm {
         Ok(())
     }
 
-    pub fn send_memory_regions<F>(
-        &mut self,
-        ranges: &MemoryRangeTable,
-        fd: &mut F,
-    ) -> std::result::Result<(), MigratableError>
-    where
-        F: WriteVolatile,
-    {
-        let guest_memory = self.memory_manager.lock().as_ref().unwrap().guest_memory();
-        let mem = guest_memory.memory();
-
-        for range in ranges.regions() {
-            let mut offset: u64 = 0;
-            // Here we are manually handling the retry in case we can't the
-            // whole region at once because we can't use the implementation
-            // from vm-memory::GuestMemory of write_all_to() as it is not
-            // following the correct behavior. For more info about this issue
-            // see: https://github.com/rust-vmm/vm-memory/issues/174
-            loop {
-                let bytes_written = mem
-                    .write_volatile_to(
-                        GuestAddress(range.gpa + offset),
-                        fd,
-                        (range.length - offset) as usize,
-                    )
-                    .map_err(|e| {
-                        MigratableError::MigrateSend(anyhow!(
-                            "Error transferring memory to socket: {}",
-                            e
-                        ))
-                    })?;
-                offset += bytes_written as u64;
-
-                if offset == range.length {
-                    break;
-                }
-            }
-        }
-
-        Ok(())
+    pub fn guest_memory(&self) -> GuestMemoryAtomic<GuestMemoryMmap> {
+        self.memory_manager.lock().unwrap().guest_memory()
     }
 
     pub fn memory_range_table(&self) -> std::result::Result<MemoryRangeTable, MigratableError> {


### PR DESCRIPTION
# Summary

This PR implements VM migration using multiple TCP connections.

The send-migration HTTP command now accepts a `connections` parameter (defaults to 1) that specifies how many connections to use for migration. 

Ticket: https://github.com/cobaltcore-dev/cobaltcore/issues/205

# Design

If `connections` is larger than 1, the sender will attempt to establish additional TCP connections to the same migration destination. The main (initial) connection handles most of the migration protocol. Additional connections handle _only_ `Memory` commands for transferring chunks of VM memory.

We use a thread-per-connection model. This adds the burden of creating, keeping track of and tearing threads down. But given the I/O model of Cloud Hypervisor this seemed to be the only feasible option.

For each iteration of sending memory, the `MemoryTable` that describes dirty memory will be split into chunks of fixed size (`CHUNK_SIZE`). These chunks will then be distributed among the available threads in a round-robin fashion. Threads can have a configurable backlog of outstanding chunks to send (`BUFFERED_REQUESTS_PER_THREAD`). This is currently 1 to avoid accumulating too much backlog on connections that encountered throughput issues.

We still use the original request-response scheme. Since we don't pipeline requests, but always wait for the other side to acknowledge them, we have a fundamental limit on throughput that we can reach. The original code only expected one ACK for the whole dirty memory table. We now have one ACK per chunk.

I've come up with this formula of the upper bound of throughput per connection:

`effective_throughput = chunk_size / (chunk_size / throughput_per_connection + round_trip_time)`

This formula is also in the code. I've played around with this and with large enough chunks, the impact seems negligable, especially since we can scale up connections. Feel free to plug in your favorite numbers.

In a better world, we would pipeline requests and not wait for responses. The good thing: The sender is in full control over the parameters, so we can make them configurable if necessary. But I would rather keep this complexity from users.

# Noteworthy Issues

## New

- Teardown of threads will hang if the sender stops sending data on a connection. But then the whole VM migration will not succeed anyhow. This is difficult to fix without rewriting some of the I/O code and probably not worth it for now.

## Still There

- ~~The code scans the whole dirty bitmap with one thread with an unoptimized loop and then stores the result in a large vector. The dirty bitmap can reach hundreds of MB in size on huge instances. For lots of non-contiguous writes, the size of the resulting `MemoryTable` can be huge as well.~~ #36 
- The code only starts sending memory once the whole bitmap is scanned.

These issues give the VM time to mutate more memory and thus lengthen the time needed for migration.

# Noteworthy Changes in the Code

## More Consistent Error Handling

Previously, the protocol handling had some issues, such as not sending responses for unknown commands etc. Now we always send a response. Some errors resulted in error responses, some errors resulted in dying. This should all be consistent now and can be changed in one place.

What's still missing is to handle payloads for all migration commands. For now any payload bytes are ignored in the most inconvenient way (going out-of-sync between sender and receiver).

## State Machine for Receiver

Moved to #34.

You may ask where the additional connections come into play: When we enter the `Configured` state, the sender will establish more connections to send memory and tear them down, once we are done sending memory.

# Left to be done

- [x] Address first round of feedback
- [x] Fail gracefully if someone sends `connections: 0`
- [x] Split state machine into separate PR: #34
- [x] Merge #34 
- [x] Fail gracefully if the other end doesn't accept multiple connections
- [x] Update `src/api/openapi/cloud-hypervisor.yaml` for `connections` parameter 
- [ ] Add tests to the test suite
  - [ ] Test for multiple connections
  - [ ] Test for forward/backward compatibility? (maybe optional)
- [ ] Run test suite
  - [x] Regression tests (libvirt-tests, do we break usage that doesn't use multiple connections?)
  - [ ] With new tests
- [ ] Test on some big boxes with lots of guest RAM

