### PR TITLE
Configurable PCI BDF Device IDs

### DIFF
--- a/option_parser/src/lib.rs
+++ b/option_parser/src/lib.rs
@@ -46,6 +46,8 @@ pub enum OptionParserError {
     Conversion(String /* field */, String /* value */),
     #[error("invalid value: {0}")]
     InvalidValue(String),
+    #[error("failed to convert {1}")]
+    NumberConversion(#[source] ParseIntError, String),
 }
 type OptionParserResult<T> = std::result::Result<T, OptionParserError>;
 
@@ -165,6 +167,41 @@ impl OptionParser {
             .get(option)
             .and_then(|v| v.value.as_ref())
             .is_some()
+    }
+
+    /// Parses the `addr` option of PCI devices and returns the PCI device as well as the function ID
+    ///
+    /// Returns a tuple consisting of the parsed IDs for device and function in this order. Returns an error if the
+    /// supplied `addr` values cannot be parsed to [`u8`]. The tuple might consist of two times [`None`] if `addr` was
+    /// not provided.
+    pub fn get_pci_device_function(
+        &self,
+    ) -> OptionParserResult<(Option<u8 /* Device ID */>, Option<u8 /* Function ID */>)> {
+        if let Some(addr_str) = self.get("addr") {
+            let (device_str, function_str) = addr_str
+                .split_once('.')
+                .ok_or(OptionParserError::InvalidValue(addr_str.to_owned()))?;
+
+            // We also accept hex number with `0x` prefix, but need to strip it before conversion in case it's present.
+            let device_str = device_str.strip_prefix("0x").unwrap_or(device_str);
+            let device_id = u8::from_str_radix(device_str, 16)
+                .map_err(|e| OptionParserError::NumberConversion(e, addr_str.to_owned()))?;
+
+            let function_str = function_str.strip_prefix("0x").unwrap_or(function_str);
+            let function_id = u8::from_str_radix(function_str, 16)
+                .map_err(|e| OptionParserError::NumberConversion(e, addr_str.to_owned()))?;
+
+            // Currently CHV only support single-function devices. Those are mapped to function ID 0 in all cases, so we
+            // disallow the assignment of any other function ID.
+            if function_id != 0 {
+                todo!(
+                    "Currently no multi function devices supported! Please use `0` as function ID."
+                );
+            }
+            Ok((Some(device_id), Some(function_id)))
+        } else {
+            Ok((None, None))
+        }
     }
 
     pub fn convert<T: Parseable>(&self, option: &str) -> OptionParserResult<Option<T>> {

--- a/pci/src/bus.rs
+++ b/pci/src/bus.rs
@@ -45,7 +45,7 @@ pub enum PciRootError {
     #[error("Invalid PCI device identifier provided")]
     InvalidPciDeviceSlot(usize),
     /// Valid PCI device identifier but already used.
-    #[error("Valid PCI device identifier but already used")]
+    #[error("Valid PCI device identifier but already used: {0}")]
     AlreadyInUsePciDeviceSlot(usize),
 }
 pub type Result<T> = std::result::Result<T, PciRootError>;
@@ -166,15 +166,42 @@ impl PciBus {
         Ok(())
     }
 
-    pub fn next_device_id(&mut self) -> Result<u32> {
-        for (idx, device_id) in self.device_ids.iter_mut().enumerate() {
-            if !(*device_id) {
-                *device_id = true;
-                return Ok(idx as u32);
+    /// Allocates a PCI device ID on the bus.
+    ///
+    /// - `id`: ID to allocate on the bus. If [`None`], the next free
+    ///   device ID on the bus is allocated, else the ID given is
+    ///   allocated
+    ///
+    /// ## Errors
+    /// * Returns [`PciRootError::AlreadyInUsePciDeviceSlot`] in case
+    ///   the ID requested is already allocated.
+    /// * Returns [`PciRootError::InvalidPciDeviceSlot`] in case the
+    ///   requested ID exceeds the maximum number of devices allowed per
+    ///   bus (see [`NUM_DEVICE_IDS`]).
+    /// * If `id` is [`None`]: Returns
+    ///   [`PciRootError::NoPciDeviceSlotAvailable`] if no free device
+    ///   slot is available on the bus.
+    pub fn allocate_device_id(&mut self, id: Option<u8>) -> Result<u32> {
+        if let Some(id) = id {
+            if (id as usize) < NUM_DEVICE_IDS {
+                if !self.device_ids[id as usize] {
+                    self.device_ids[id as usize] = true;
+                    Ok(id as u32)
+                } else {
+                    Err(PciRootError::AlreadyInUsePciDeviceSlot(id as usize))
+                }
+            } else {
+                Err(PciRootError::InvalidPciDeviceSlot(id as usize))
             }
+        } else {
+            for (idx, device_id) in self.device_ids.iter_mut().enumerate() {
+                if !(*device_id) {
+                    *device_id = true;
+                    return Ok(idx as u32);
+                }
+            }
+            Err(PciRootError::NoPciDeviceSlotAvailable)
         }
-
-        Err(PciRootError::NoPciDeviceSlotAvailable)
     }
 
     pub fn get_device_id(&mut self, id: usize) -> Result<()> {
@@ -483,4 +510,111 @@ fn parse_io_config_address(config_address: u32) -> (usize, usize, usize, usize) 
         shift_and_mask(config_address, FUNCTION_NUMBER_OFFSET, FUNCTION_NUMBER_MASK),
         shift_and_mask(config_address, REGISTER_NUMBER_OFFSET, REGISTER_NUMBER_MASK),
     )
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::error::Error;
+    use std::result::Result;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct MocRelocDevice;
+
+    impl DeviceRelocation for MocRelocDevice {
+        fn move_bar(
+            &self,
+            _old_base: u64,
+            _new_base: u64,
+            _len: u64,
+            _pci_dev: &mut dyn PciDevice,
+            _region_type: PciBarRegionType,
+        ) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+    }
+
+    fn setup_bus() -> PciBus {
+        let pci_root = PciRoot::new(None);
+        let moc_device_reloc = Arc::new(MocRelocDevice {});
+        PciBus::new(pci_root, moc_device_reloc)
+    }
+
+    #[test]
+    // Test to acquire all IDs that can be acquired
+    fn allocate_device_id_next_free() {
+        // The first address is occupied by the root
+        let mut bus = setup_bus();
+        for expected_id in 1..NUM_DEVICE_IDS {
+            assert_eq!(expected_id as u32, bus.allocate_device_id(None).unwrap());
+        }
+    }
+
+    #[test]
+    // Test that requesting specific ID work
+    fn allocate_device_id_request_id() -> Result<(), Box<dyn Error>> {
+        // The first address is occupied by the root
+        let mut bus = setup_bus();
+        let max_id = (NUM_DEVICE_IDS - 1).try_into()?;
+        assert_eq!(0x01_u32, bus.allocate_device_id(Some(0x01))?);
+        assert_eq!(0x10_u32, bus.allocate_device_id(Some(0x10))?);
+        assert_eq!(max_id as u32, bus.allocate_device_id(Some(max_id))?);
+        Ok(())
+    }
+
+    #[test]
+    // Test that gaps resulting from explicit allocations are filled by implicit ones,
+    // beginning with the first free slot
+    fn allocate_device_id_fills_gaps() -> Result<(), Box<dyn Error>> {
+        // The first address is occupied by the root
+        let mut bus = setup_bus();
+        assert_eq!(0x01_u32, bus.allocate_device_id(Some(0x01))?);
+        assert_eq!(0x03_u32, bus.allocate_device_id(Some(0x03))?);
+        assert_eq!(0x06_u32, bus.allocate_device_id(Some(0x06))?);
+        assert_eq!(0x02_u32, bus.allocate_device_id(None)?);
+        assert_eq!(0x04_u32, bus.allocate_device_id(None)?);
+        assert_eq!(0x05_u32, bus.allocate_device_id(None)?);
+        assert_eq!(0x07_u32, bus.allocate_device_id(None)?);
+        Ok(())
+    }
+
+    #[test]
+    // Test that requesting the same ID twice fails
+    fn allocate_device_id_request_id_twice_fails() -> Result<(), Box<dyn Error>> {
+        let mut bus = setup_bus();
+        let max_id = (NUM_DEVICE_IDS - 1).try_into()?;
+        bus.allocate_device_id(Some(max_id))?;
+        let _result = bus.allocate_device_id(Some(max_id));
+        assert!(matches!(
+            PciRootError::AlreadyInUsePciDeviceSlot(max_id.into()),
+            _result
+        ));
+        Ok(())
+    }
+
+    #[test]
+    // Test to request an invalid ID
+    fn allocate_device_id_request_invalid_id_fails() -> Result<(), Box<dyn Error>> {
+        let mut bus = setup_bus();
+        let max_id = (NUM_DEVICE_IDS + 1).try_into()?;
+        let _result = bus.allocate_device_id(Some(max_id));
+        assert!(matches!(
+            PciRootError::InvalidPciDeviceSlot(max_id.into()),
+            _result
+        ));
+        Ok(())
+    }
+
+    #[test]
+    // Test to acquire an ID when all IDs were already acquired
+    fn allocate_device_id_none_left() {
+        // The first address is occupied by the root
+        let mut bus = setup_bus();
+        for expected_id in 1..NUM_DEVICE_IDS {
+            assert_eq!(expected_id as u32, bus.allocate_device_id(None).unwrap());
+        }
+        let _result = bus.allocate_device_id(None);
+        assert!(matches!(PciRootError::NoPciDeviceSlotAvailable, _result));
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -993,6 +993,7 @@ mod unit_tests {
             rng: RngConfig {
                 src: PathBuf::from("/dev/urandom"),
                 iommu: false,
+                bdf_device: None,
             },
             balloon: None,
             fs: None,
@@ -1003,6 +1004,7 @@ mod unit_tests {
                 iommu: false,
                 socket: None,
                 url: None,
+                bdf_device: None,
             },
             console: ConsoleConfig {
                 file: None,
@@ -1010,6 +1012,7 @@ mod unit_tests {
                 iommu: false,
                 socket: None,
                 url: None,
+                bdf_device: None,
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1220,6 +1220,24 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--disk",
+                    "path=/path/to/disk/1,addr=15.0",
+                    "path=/path/to/disk/2",
+                ],
+                r#"{
+                    "payload": {"kernel": "/path/to/kernel"},
+                    "disks": [
+                        {"path": "/path/to/disk/1", "bdf_device": 21},
+                        {"path": "/path/to/disk/2"}
+                    ]
+                }"#,
+                true,
+            ),
+            (
+                vec![
+                    "cloud-hypervisor",
+                    "--kernel",
+                    "/path/to/kernel",
+                    "--disk",
                     "path=/path/to/disk/1",
                     "path=/path/to/disk/2",
                 ],
@@ -1425,6 +1443,20 @@ mod unit_tests {
                 }"#,
                 true,
             ),
+            (
+                vec![
+                    "cloud-hypervisor", "--kernel", "/path/to/kernel",
+                    "--net",
+                    "mac=12:34:56:78:90:ab,host_mac=34:56:78:90:ab:cd,tap=tap0,ip=1.2.3.4,mask=5.6.7.8,addr=08.0",
+                ],
+                r#"{
+                    "payload": {"kernel": "/path/to/kernel"},
+                    "net": [
+                        {"mac": "12:34:56:78:90:ab", "host_mac": "34:56:78:90:ab:cd", "tap": "tap0", "ip": "1.2.3.4", "mask": "5.6.7.8", "num_queues": 2, "queue_size": 256, "bdf_device": 8}
+                    ]
+                }"#,
+                true,
+            ),
             #[cfg(target_arch = "x86_64")]
             (
                 vec![
@@ -1496,11 +1528,11 @@ mod unit_tests {
                 "--kernel",
                 "/path/to/kernel",
                 "--rng",
-                "src=/path/to/entropy/source",
+                "src=/path/to/entropy/source,addr=11.0",
             ],
             r#"{
                 "payload": {"kernel": "/path/to/kernel"},
-                "rng": {"src": "/path/to/entropy/source"}
+                "rng": {"src": "/path/to/entropy/source", "bdf_device": 17}
             }"#,
             true,
         )]
@@ -1517,14 +1549,14 @@ mod unit_tests {
                     "cloud-hypervisor", "--kernel", "/path/to/kernel",
                     "--memory", "shared=true",
                     "--fs",
-                    "tag=virtiofs1,socket=/path/to/sock1",
+                    "tag=virtiofs1,socket=/path/to/sock1,addr=10.0",
                     "tag=virtiofs2,socket=/path/to/sock2",
                 ],
                 r#"{
                     "payload": {"kernel": "/path/to/kernel"},
                     "memory" : { "shared": true, "size": 536870912 },
                     "fs": [
-                        {"tag": "virtiofs1", "socket": "/path/to/sock1"},
+                        {"tag": "virtiofs1", "socket": "/path/to/sock1", "bdf_device": 16},
                         {"tag": "virtiofs2", "socket": "/path/to/sock2"}
                     ]
                 }"#,
@@ -1596,13 +1628,13 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--pmem",
-                    "file=/path/to/img/1,size=1G",
+                    "file=/path/to/img/1,size=1G,addr=1F.0",
                     "file=/path/to/img/2,size=2G",
                 ],
                 r#"{
                     "payload": {"kernel": "/path/to/kernel"},
                     "pmem": [
-                        {"file": "/path/to/img/1", "size": 1073741824},
+                        {"file": "/path/to/img/1", "size": 1073741824,"bdf_device": 31},
                         {"file": "/path/to/img/2", "size": 2147483648}
                     ]
                 }"#,
@@ -1880,13 +1912,13 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--vdpa",
-                    "path=/path/to/device/1",
+                    "path=/path/to/device/1,addr=18.0",
                     "path=/path/to/device/2,num_queues=2",
                 ],
                 r#"{
                     "payload": {"kernel": "/path/to/kernel"},
                     "vdpa": [
-                        {"path": "/path/to/device/1", "num_queues": 1},
+                        {"path": "/path/to/device/1", "num_queues": 1, "bdf_device": 24},
                         {"path": "/path/to/device/2", "num_queues": 2}
                     ]
                 }"#,
@@ -1925,11 +1957,11 @@ mod unit_tests {
                     "--kernel",
                     "/path/to/kernel",
                     "--vsock",
-                    "cid=123,socket=/path/to/sock/1",
+                    "cid=123,socket=/path/to/sock/1,addr=0F.0",
                 ],
                 r#"{
                     "payload": {"kernel": "/path/to/kernel"},
-                    "vsock": {"cid": 123, "socket": "/path/to/sock/1"}
+                    "vsock": {"cid": 123, "socket": "/path/to/sock/1", "bdf_device": 15}
                 }"#,
                 true,
             ),

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -3609,6 +3609,13 @@ mod tests {
                 ..disk_fixture()
             }
         );
+        assert_eq!(
+            DiskConfig::parse("path=/path/to_file,addr=15.0")?,
+            DiskConfig {
+                bdf_device: Some(21),
+                ..disk_fixture()
+            }
+        );
         Ok(())
     }
 
@@ -3698,6 +3705,14 @@ mod tests {
             }
         );
 
+        assert_eq!(
+            NetConfig::parse("mac=de:ad:be:ef:12:34,host_mac=12:34:de:ad:be:ef,addr=08.0")?,
+            NetConfig {
+                bdf_device: Some(8),
+                ..net_fixture()
+            }
+        );
+
         Ok(())
     }
 
@@ -3723,6 +3738,13 @@ mod tests {
             RngConfig::parse("iommu=on")?,
             RngConfig {
                 iommu: true,
+                ..Default::default()
+            }
+        );
+        assert_eq!(
+            RngConfig::parse("addr=10.0")?,
+            RngConfig {
+                bdf_device: Some(16),
                 ..Default::default()
             }
         );
@@ -3753,6 +3775,14 @@ mod tests {
             FsConfig {
                 num_queues: 4,
                 queue_size: 1024,
+                ..fs_fixture()
+            }
+        );
+
+        assert_eq!(
+            FsConfig::parse("tag=mytag,socket=/tmp/sock,addr=0F.0")?,
+            FsConfig {
+                bdf_device: Some(15),
                 ..fs_fixture()
             }
         );
@@ -3793,6 +3823,13 @@ mod tests {
             PmemConfig {
                 discard_writes: true,
                 iommu: true,
+                ..pmem_fixture()
+            }
+        );
+        assert_eq!(
+            PmemConfig::parse("file=/tmp/pmem,size=128M,addr=1F.0")?,
+            PmemConfig {
+                bdf_device: Some(31),
                 ..pmem_fixture()
             }
         );
@@ -3958,6 +3995,13 @@ mod tests {
                 ..vdpa_fixture()
             }
         );
+        assert_eq!(
+            VdpaConfig::parse("path=/dev/vhost-vdpa,addr=0A.0")?,
+            VdpaConfig {
+                bdf_device: Some(10),
+                ..vdpa_fixture()
+            }
+        );
         Ok(())
     }
 
@@ -3998,6 +4042,18 @@ mod tests {
                 id: None,
                 pci_segment: 0,
                 bdf_device: None,
+            }
+        );
+
+        assert_eq!(
+            VsockConfig::parse("socket=/tmp/sock,cid=3,iommu=on,addr=08.0")?,
+            VsockConfig {
+                cid: 3,
+                socket: PathBuf::from("/tmp/sock"),
+                iommu: true,
+                id: None,
+                pci_segment: 0,
+                bdf_device: Some(8),
             }
         );
         Ok(())
@@ -4077,6 +4133,7 @@ mod tests {
                     id: Some("net0".to_owned()),
                     num_queues: 2,
                     fds: Some(vec![-1, -1, -1, -1]),
+                    bdf_device: Some(15),
                     ..net_fixture()
                 },
                 NetConfig {

--- a/vmm/src/config.rs
+++ b/vmm/src/config.rs
@@ -175,6 +175,9 @@ pub enum Error {
     /// Failed Parsing FwCfgItem config
     #[error("Error parsing --fw-cfg-config items")]
     ParseFwCfgItem(#[source] OptionParserError),
+    /// Failed parsing addr option
+    #[error("Error parsing --addr")]
+    ParsePciAddr(#[source] OptionParserError),
 }
 
 #[derive(Debug, PartialEq, Eq, Error)]
@@ -1077,7 +1080,7 @@ impl DiskConfig {
          ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,\
          id=<device_id>,pci_segment=<segment_id>,rate_limit_group=<group_id>,\
          queue_affinity=<list_of_queue_indices_with_their_associated_cpuset>,\
-         serial=<serial_number>";
+         serial=<serial_number>,addr=<DD.F>";
 
     pub fn parse(disk: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1102,7 +1105,8 @@ impl DiskConfig {
             .add("pci_segment")
             .add("serial")
             .add("rate_limit_group")
-            .add("queue_affinity");
+            .add("queue_affinity")
+            .add("addr");
         parser.parse(disk).map_err(Error::ParseDisk)?;
 
         let path = parser.get("path").map(PathBuf::from);
@@ -1214,6 +1218,10 @@ impl DiskConfig {
             None
         };
 
+        let (bdf_device, _bdf_function) = parser
+            .get_pci_device_function()
+            .map_err(Error::ParsePciAddr)?;
+
         Ok(DiskConfig {
             path,
             readonly,
@@ -1231,6 +1239,7 @@ impl DiskConfig {
             pci_segment,
             serial,
             queue_affinity,
+            bdf_device,
         })
     }
 
@@ -1302,7 +1311,7 @@ impl NetConfig {
     vhost_user=<vhost_user_enable>,socket=<vhost_user_socket_path>,vhost_mode=client|server,\
     bw_size=<bytes>,bw_one_time_burst=<bytes>,bw_refill_time=<ms>,\
     ops_size=<io_ops>,ops_one_time_burst=<io_ops>,ops_refill_time=<ms>,pci_segment=<segment_id>\
-    offload_tso=on|off,offload_ufo=on|off,offload_csum=on|off\"";
+    offload_tso=on|off,offload_ufo=on|off,offload_csum=on|off,addr=DD.F\"";
 
     pub fn parse(net: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1331,7 +1340,8 @@ impl NetConfig {
             .add("ops_size")
             .add("ops_one_time_burst")
             .add("ops_refill_time")
-            .add("pci_segment");
+            .add("pci_segment")
+            .add("addr");
         parser.parse(net).map_err(Error::ParseNetwork)?;
 
         let tap = parser.get("tap");
@@ -1447,6 +1457,10 @@ impl NetConfig {
             None
         };
 
+        let (bdf_device, _bdf_function) = parser
+            .get_pci_device_function()
+            .map_err(Error::ParsePciAddr)?;
+
         let config = NetConfig {
             tap,
             ip,
@@ -1467,6 +1481,7 @@ impl NetConfig {
             offload_tso,
             offload_ufo,
             offload_csum,
+            bdf_device,
         };
         Ok(config)
     }
@@ -1531,7 +1546,7 @@ impl NetConfig {
 impl RngConfig {
     pub fn parse(rng: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
-        parser.add("src").add("iommu");
+        parser.add("src").add("iommu").add("addr");
         parser.parse(rng).map_err(Error::ParseRng)?;
 
         let src = PathBuf::from(
@@ -1545,19 +1560,27 @@ impl RngConfig {
             .unwrap_or(Toggle(false))
             .0;
 
-        Ok(RngConfig { src, iommu })
+        let (bdf_device, _bdf_function) = parser
+            .get_pci_device_function()
+            .map_err(Error::ParsePciAddr)?;
+
+        Ok(RngConfig {
+            src,
+            iommu,
+            bdf_device,
+        })
     }
 }
 
 impl BalloonConfig {
     pub const SYNTAX: &'static str = "Balloon parameters \"size=<balloon_size>,deflate_on_oom=on|off,\
-        free_page_reporting=on|off\"";
+        free_page_reporting=on|off,addr=<DD.F>\"";
 
     pub fn parse(balloon: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
         parser.add("size");
         parser.add("deflate_on_oom");
-        parser.add("free_page_reporting");
+        parser.add("free_page_reporting").add("addr");
         parser.parse(balloon).map_err(Error::ParseBalloon)?;
 
         let size = parser
@@ -1578,10 +1601,15 @@ impl BalloonConfig {
             .unwrap_or(Toggle(false))
             .0;
 
+        let (bdf_device, _bdf_function) = parser
+            .get_pci_device_function()
+            .map_err(Error::ParsePciAddr)?;
+
         Ok(BalloonConfig {
             size,
             deflate_on_oom,
             free_page_reporting,
+            bdf_device,
         })
     }
 }
@@ -1589,7 +1617,8 @@ impl BalloonConfig {
 impl FsConfig {
     pub const SYNTAX: &'static str = "virtio-fs parameters \
     \"tag=<tag_name>,socket=<socket_path>,num_queues=<number_of_queues>,\
-    queue_size=<size_of_each_queue>,id=<device_id>,pci_segment=<segment_id>\"";
+    queue_size=<size_of_each_queue>,id=<device_id>,pci_segment=<segment_id>,\
+    addr=<DD.F>\"";
 
     pub fn parse(fs: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1599,7 +1628,8 @@ impl FsConfig {
             .add("num_queues")
             .add("socket")
             .add("id")
-            .add("pci_segment");
+            .add("pci_segment")
+            .add("addr");
         parser.parse(fs).map_err(Error::ParseFileSystem)?;
 
         let tag = parser.get("tag").ok_or(Error::ParseFsTagMissing)?;
@@ -1624,6 +1654,10 @@ impl FsConfig {
             .map_err(Error::ParseFileSystem)?
             .unwrap_or_default();
 
+        let (bdf_device, _bdf_function) = parser
+            .get_pci_device_function()
+            .map_err(Error::ParsePciAddr)?;
+
         Ok(FsConfig {
             tag,
             socket,
@@ -1631,6 +1665,7 @@ impl FsConfig {
             queue_size,
             id,
             pci_segment,
+            bdf_device,
         })
     }
 
@@ -1756,7 +1791,7 @@ impl FwCfgItem {
 impl PmemConfig {
     pub const SYNTAX: &'static str = "Persistent memory parameters \
     \"file=<backing_file_path>,size=<persistent_memory_size>,iommu=on|off,\
-    discard_writes=on|off,id=<device_id>,pci_segment=<segment_id>\"";
+    discard_writes=on|off,id=<device_id>,pci_segment=<segment_id>,addr=<DD.F>\"";
 
     pub fn parse(pmem: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -1766,7 +1801,8 @@ impl PmemConfig {
             .add("iommu")
             .add("discard_writes")
             .add("id")
-            .add("pci_segment");
+            .add("pci_segment")
+            .add("addr");
         parser.parse(pmem).map_err(Error::ParsePersistentMemory)?;
 
         let file = PathBuf::from(parser.get("file").ok_or(Error::ParsePmemFileMissing)?);
@@ -1790,6 +1826,10 @@ impl PmemConfig {
             .map_err(Error::ParsePersistentMemory)?
             .unwrap_or_default();
 
+        let (bdf_device, _bdf_function) = parser
+            .get_pci_device_function()
+            .map_err(Error::ParsePciAddr)?;
+
         Ok(PmemConfig {
             file,
             size,
@@ -1797,6 +1837,7 @@ impl PmemConfig {
             discard_writes,
             id,
             pci_segment,
+            bdf_device,
         })
     }
 
@@ -1829,7 +1870,8 @@ impl ConsoleConfig {
             .add("file")
             .add("iommu")
             .add("tcp")
-            .add("socket");
+            .add("socket")
+            .add("addr");
         parser.parse(console).map_err(Error::ParseConsole)?;
 
         let mut file: Option<PathBuf> = default_consoleconfig_file();
@@ -1877,12 +1919,17 @@ impl ConsoleConfig {
             .unwrap_or(Toggle(false))
             .0;
 
+        let (bdf_device, _bdf_function) = parser
+            .get_pci_device_function()
+            .map_err(Error::ParsePciAddr)?;
+
         Ok(Self {
             file,
             mode,
             iommu,
             socket,
             url,
+            bdf_device,
         })
     }
 }
@@ -1942,7 +1989,8 @@ impl DebugConsoleConfig {
 }
 
 impl DeviceConfig {
-    pub const SYNTAX: &'static str = "Direct device assignment parameters \"path=<device_path>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>\"";
+    pub const SYNTAX: &'static str = "Direct device assignment parameters \"\
+    path=<device_path>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>\"";
 
     pub fn parse(device: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2046,7 +2094,7 @@ impl UserDeviceConfig {
 impl VdpaConfig {
     pub const SYNTAX: &'static str = "vDPA device \
         \"path=<device_path>,num_queues=<number_of_queues>,iommu=on|off,\
-        id=<device_id>,pci_segment=<segment_id>\"";
+        id=<device_id>,pci_segment=<segment_id>,addr=<DD.F>\"";
 
     pub fn parse(vdpa: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2055,7 +2103,8 @@ impl VdpaConfig {
             .add("num_queues")
             .add("iommu")
             .add("id")
-            .add("pci_segment");
+            .add("pci_segment")
+            .add("addr");
         parser.parse(vdpa).map_err(Error::ParseVdpa)?;
 
         let path = parser
@@ -2077,12 +2126,17 @@ impl VdpaConfig {
             .map_err(Error::ParseVdpa)?
             .unwrap_or_default();
 
+        let (bdf_device, _bdf_function) = parser
+            .get_pci_device_function()
+            .map_err(Error::ParsePciAddr)?;
+
         Ok(VdpaConfig {
             path,
             num_queues,
             iommu,
             id,
             pci_segment,
+            bdf_device,
         })
     }
 
@@ -2106,7 +2160,8 @@ impl VdpaConfig {
 
 impl VsockConfig {
     pub const SYNTAX: &'static str = "Virtio VSOCK parameters \
-        \"cid=<context_id>,socket=<socket_path>,iommu=on|off,id=<device_id>,pci_segment=<segment_id>\"";
+        \"cid=<context_id>,socket=<socket_path>,iommu=on|off,id=<device_id>,\
+        pci_segment=<segment_id>,addr=<DD.F>\"";
 
     pub fn parse(vsock: &str) -> Result<Self> {
         let mut parser = OptionParser::new();
@@ -2115,7 +2170,8 @@ impl VsockConfig {
             .add("cid")
             .add("iommu")
             .add("id")
-            .add("pci_segment");
+            .add("pci_segment")
+            .add("addr");
         parser.parse(vsock).map_err(Error::ParseVsock)?;
 
         let socket = parser
@@ -2137,12 +2193,17 @@ impl VsockConfig {
             .map_err(Error::ParseVsock)?
             .unwrap_or_default();
 
+        let (bdf_device, _bdf_function) = parser
+            .get_pci_device_function()
+            .map_err(Error::ParsePciAddr)?;
+
         Ok(VsockConfig {
             cid,
             socket,
             iommu,
             id,
             pci_segment,
+            bdf_device,
         })
     }
 
@@ -3453,6 +3514,7 @@ mod tests {
             pci_segment: 0,
             serial: None,
             queue_affinity: None,
+            bdf_device: None,
         }
     }
 
@@ -3571,6 +3633,7 @@ mod tests {
             offload_tso: true,
             offload_ufo: true,
             offload_csum: true,
+            bdf_device: None,
         }
     }
 
@@ -3653,6 +3716,7 @@ mod tests {
             RngConfig {
                 src: PathBuf::from("/dev/random"),
                 iommu: true,
+                bdf_device: None,
             }
         );
         assert_eq!(
@@ -3673,6 +3737,7 @@ mod tests {
             queue_size: 1024,
             id: None,
             pci_segment: 0,
+            bdf_device: None,
         }
     }
 
@@ -3703,6 +3768,7 @@ mod tests {
             discard_writes: false,
             id: None,
             pci_segment: 0,
+            bdf_device: None,
         }
     }
 
@@ -3746,6 +3812,7 @@ mod tests {
                 file: None,
                 socket: None,
                 url: None,
+                bdf_device: None,
             }
         );
         assert_eq!(
@@ -3756,6 +3823,7 @@ mod tests {
                 file: None,
                 socket: None,
                 url: None,
+                bdf_device: None,
             }
         );
         assert_eq!(
@@ -3766,6 +3834,7 @@ mod tests {
                 file: None,
                 socket: None,
                 url: None,
+                bdf_device: None,
             }
         );
         assert_eq!(
@@ -3776,6 +3845,7 @@ mod tests {
                 file: None,
                 socket: None,
                 url: None,
+                bdf_device: None,
             }
         );
         assert_eq!(
@@ -3786,6 +3856,7 @@ mod tests {
                 file: Some(PathBuf::from("/tmp/console")),
                 socket: None,
                 url: None,
+                bdf_device: None,
             }
         );
         assert_eq!(
@@ -3796,6 +3867,7 @@ mod tests {
                 file: None,
                 socket: None,
                 url: None,
+                bdf_device: None,
             }
         );
         assert_eq!(
@@ -3806,6 +3878,7 @@ mod tests {
                 file: Some(PathBuf::from("/tmp/console")),
                 socket: None,
                 url: None,
+                bdf_device: None,
             }
         );
         assert_eq!(
@@ -3816,6 +3889,7 @@ mod tests {
                 file: None,
                 socket: Some(PathBuf::from("/tmp/serial.sock")),
                 url: None,
+                bdf_device: None,
             }
         );
         Ok(())
@@ -3867,6 +3941,7 @@ mod tests {
             iommu: false,
             id: None,
             pci_segment: 0,
+            bdf_device: None,
         }
     }
 
@@ -3911,6 +3986,7 @@ mod tests {
                 iommu: false,
                 id: None,
                 pci_segment: 0,
+                bdf_device: None,
             }
         );
         assert_eq!(
@@ -3921,6 +3997,7 @@ mod tests {
                 iommu: true,
                 id: None,
                 pci_segment: 0,
+                bdf_device: None,
             }
         );
         Ok(())
@@ -4173,6 +4250,7 @@ mod tests {
             rng: RngConfig {
                 src: PathBuf::from("/dev/urandom"),
                 iommu: false,
+                bdf_device: None,
             },
             balloon: None,
             fs: None,
@@ -4183,6 +4261,7 @@ mod tests {
                 iommu: false,
                 socket: None,
                 url: None,
+                bdf_device: None,
             },
             console: ConsoleConfig {
                 file: None,
@@ -4190,6 +4269,7 @@ mod tests {
                 iommu: false,
                 socket: None,
                 url: None,
+                bdf_device: None,
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),
@@ -4485,6 +4565,7 @@ mod tests {
             id: None,
             iommu: true,
             pci_segment: 1,
+            bdf_device: None,
         });
         still_valid_config.validate().unwrap();
 
@@ -4561,6 +4642,7 @@ mod tests {
             id: None,
             iommu: false,
             pci_segment: 1,
+            bdf_device: None,
         });
         assert_eq!(
             invalid_config.validate(),

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -4786,7 +4786,7 @@ impl DeviceManager {
             handle.id.clone(),
             handle.pci_segment,
             handle.dma_handler,
-            None,
+            handle.bdf_device,
         )?;
 
         // Update the PCIU bitmap

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -896,6 +896,7 @@ struct MetaVirtioDevice {
     iommu: bool,
     id: String,
     pci_segment: u16,
+    bdf_device: Option<u8>,
     dma_handler: Option<Arc<dyn ExternalDmaMapping>>,
 }
 
@@ -1632,6 +1633,7 @@ impl DeviceManager {
                     handle.id,
                     handle.pci_segment,
                     handle.dma_handler,
+                    handle.bdf_device,
                 )?;
 
                 if handle.iommu {
@@ -1660,7 +1662,8 @@ impl DeviceManager {
             }
 
             if let Some(iommu_device) = iommu_device {
-                let dev_id = self.add_virtio_pci_device(iommu_device, &None, iommu_id, 0, None)?;
+                let dev_id =
+                    self.add_virtio_pci_device(iommu_device, &None, iommu_id, 0, None, None)?;
                 self.iommu_attached_devices = Some((dev_id, iommu_attached_devices));
             }
         }
@@ -2372,6 +2375,7 @@ impl DeviceManager {
             id: id.clone(),
             pci_segment: 0,
             dma_handler: None,
+            bdf_device: None,
         });
 
         // Fill the device tree with a new node. In case of restore, we
@@ -2819,6 +2823,7 @@ impl DeviceManager {
             id,
             pci_segment: disk_cfg.pci_segment,
             dma_handler: None,
+            bdf_device: disk_cfg.bdf_device,
         })
     }
 
@@ -2995,6 +3000,7 @@ impl DeviceManager {
             id,
             pci_segment: net_cfg.pci_segment,
             dma_handler: None,
+            bdf_device: net_cfg.bdf_device,
         })
     }
 
@@ -3040,6 +3046,7 @@ impl DeviceManager {
                 id: id.clone(),
                 pci_segment: 0,
                 dma_handler: None,
+                bdf_device: None,
             });
 
             // Fill the device tree with a new node. In case of restore, we
@@ -3101,6 +3108,7 @@ impl DeviceManager {
                 id,
                 pci_segment: fs_cfg.pci_segment,
                 dma_handler: None,
+                bdf_device: fs_cfg.bdf_device,
             })
         } else {
             Err(DeviceManagerError::NoVirtioFsSock)
@@ -3289,6 +3297,7 @@ impl DeviceManager {
             id,
             pci_segment: pmem_cfg.pci_segment,
             dma_handler: None,
+            bdf_device: pmem_cfg.bdf_device,
         })
     }
 
@@ -3360,6 +3369,7 @@ impl DeviceManager {
             id,
             pci_segment: vsock_cfg.pci_segment,
             dma_handler: None,
+            bdf_device: vsock_cfg.bdf_device,
         })
     }
 
@@ -3416,6 +3426,7 @@ impl DeviceManager {
                     id: memory_zone_id.clone(),
                     pci_segment: 0,
                     dma_handler: None,
+                    bdf_device: None,
                 });
 
                 // Fill the device tree with a new node. In case of restore, we
@@ -3442,7 +3453,7 @@ impl DeviceManager {
         let pci_segment_id = 0x0_u16;
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&id, pci_segment_id)?;
+            self.pci_resources(&id, pci_segment_id, None)?;
 
         info!("Creating pvmemcontrol device: id = {}", id);
         let (pvmemcontrol_pci_device, pvmemcontrol_bus_device) =
@@ -3503,6 +3514,7 @@ impl DeviceManager {
                 id: id.clone(),
                 pci_segment: 0,
                 dma_handler: None,
+                bdf_device: balloon_config.bdf_device,
             });
 
             self.device_tree
@@ -3542,6 +3554,7 @@ impl DeviceManager {
             id: id.clone(),
             pci_segment: 0,
             dma_handler: None,
+            bdf_device: None,
         });
 
         self.device_tree
@@ -3600,6 +3613,7 @@ impl DeviceManager {
             id,
             pci_segment: vdpa_cfg.pci_segment,
             dma_handler: Some(vdpa_mapping),
+            bdf_device: vdpa_cfg.bdf_device,
         })
     }
 
@@ -3686,7 +3700,7 @@ impl DeviceManager {
         };
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&vfio_name, device_cfg.pci_segment)?;
+            self.pci_resources(&vfio_name, device_cfg.pci_segment, None)?;
 
         let mut needs_dma_mapping = false;
 
@@ -3923,7 +3937,7 @@ impl DeviceManager {
         };
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&vfio_user_name, device_cfg.pci_segment)?;
+            self.pci_resources(&vfio_user_name, device_cfg.pci_segment, None)?;
 
         let legacy_interrupt_group =
             if let Some(legacy_interrupt_manager) = &self.legacy_interrupt_manager {
@@ -4035,6 +4049,7 @@ impl DeviceManager {
         virtio_device_id: String,
         pci_segment_id: u16,
         dma_handler: Option<Arc<dyn ExternalDmaMapping>>,
+        bdf_device: Option<u8>,
     ) -> DeviceManagerResult<PciBdf> {
         let id = format!("{VIRTIO_PCI_DEVICE_NAME_PREFIX}-{virtio_device_id}");
 
@@ -4043,7 +4058,7 @@ impl DeviceManager {
         node.children = vec![virtio_device_id.clone()];
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&id, pci_segment_id)?;
+            self.pci_resources(&id, pci_segment_id, bdf_device)?;
 
         // Update the existing virtio node by setting the parent.
         if let Some(node) = self.device_tree.lock().unwrap().get_mut(&virtio_device_id) {
@@ -4180,7 +4195,7 @@ impl DeviceManager {
         info!("Creating pvpanic device {}", id);
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&id, pci_segment_id)?;
+            self.pci_resources(&id, pci_segment_id, None)?;
 
         let snapshot = snapshot_from_id(self.snapshot.as_ref(), id.as_str());
 
@@ -4218,7 +4233,7 @@ impl DeviceManager {
         info!("Creating ivshmem device {}", id);
 
         let (pci_segment_id, pci_device_bdf, resources) =
-            self.pci_resources(&id, pci_segment_id)?;
+            self.pci_resources(&id, pci_segment_id, None)?;
         let snapshot = snapshot_from_id(self.snapshot.as_ref(), id.as_str());
 
         let ivshmem_ops = Arc::new(Mutex::new(IvshmemHandler {
@@ -4263,6 +4278,7 @@ impl DeviceManager {
         &self,
         id: &str,
         pci_segment_id: u16,
+        pci_device_id: Option<u8>,
     ) -> DeviceManagerResult<(u16, PciBdf, Option<Vec<Resource>>)> {
         // Look for the id in the device tree. If it can be found, that means
         // the device is being restored, otherwise it's created from scratch.
@@ -4290,7 +4306,7 @@ impl DeviceManager {
             (pci_segment_id, pci_device_bdf, resources)
         } else {
             let pci_device_bdf =
-                self.pci_segments[pci_segment_id as usize].allocate_device_bdf(None)?;
+                self.pci_segments[pci_segment_id as usize].allocate_device_bdf(pci_device_id)?;
 
             (pci_segment_id, pci_device_bdf, None)
         })
@@ -4770,6 +4786,7 @@ impl DeviceManager {
             handle.id.clone(),
             handle.pci_segment,
             handle.dma_handler,
+            None,
         )?;
 
         // Update the PCIU bitmap

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -9,7 +9,7 @@
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 //
 
-use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::fs::{File, OpenOptions};
 use std::io::{self, IsTerminal, Seek, SeekFrom, stdout};
 use std::num::Wrapping;
@@ -982,7 +982,7 @@ pub struct DeviceManager {
     cpu_manager: Arc<Mutex<CpuManager>>,
 
     // The virtio devices on the system
-    virtio_devices: Vec<MetaVirtioDevice>,
+    virtio_devices: VecDeque<MetaVirtioDevice>,
 
     /// All disks. Needed for locking and unlocking the images.
     block_devices: Vec<Arc<Mutex<Block>>>,
@@ -1321,7 +1321,7 @@ impl DeviceManager {
             config,
             memory_manager,
             cpu_manager,
-            virtio_devices: Vec::new(),
+            virtio_devices: VecDeque::new(),
             block_devices: vec![],
             bus_devices: Vec::new(),
             device_id_cnt,
@@ -2368,15 +2368,21 @@ impl DeviceManager {
         )
         .map_err(DeviceManagerError::CreateVirtioConsole)?;
         let virtio_console_device = Arc::new(Mutex::new(virtio_console_device));
-        self.virtio_devices.push(MetaVirtioDevice {
+        let device = MetaVirtioDevice {
             virtio_device: Arc::clone(&virtio_console_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
             iommu: console_config.iommu,
             id: id.clone(),
             pci_segment: 0,
             dma_handler: None,
-            bdf_device: None,
-        });
+            bdf_device: console_config.bdf_device,
+        };
+
+        if console_config.bdf_device.is_some() {
+            self.virtio_devices.push_front(device);
+        } else {
+            self.virtio_devices.push_back(device);
+        }
 
         // Fill the device tree with a new node. In case of restore, we
         // know there is nothing to do, so we can simply override the
@@ -2832,7 +2838,11 @@ impl DeviceManager {
         if let Some(disk_list_cfg) = &mut block_devices {
             for disk_cfg in disk_list_cfg.iter_mut() {
                 let device = self.make_virtio_block_device(disk_cfg, false)?;
-                self.virtio_devices.push(device);
+                if disk_cfg.bdf_device.is_some() {
+                    self.virtio_devices.push_front(device);
+                } else {
+                    self.virtio_devices.push_back(device);
+                }
             }
         }
         self.config.lock().unwrap().disks = block_devices;
@@ -3010,7 +3020,11 @@ impl DeviceManager {
         if let Some(net_list_cfg) = &mut net_devices {
             for net_cfg in net_list_cfg.iter_mut() {
                 let device = self.make_virtio_net_device(net_cfg)?;
-                self.virtio_devices.push(device);
+                if net_cfg.bdf_device.is_some() {
+                    self.virtio_devices.push_front(device);
+                } else {
+                    self.virtio_devices.push_back(device);
+                }
             }
         }
         self.config.lock().unwrap().net = net_devices;
@@ -3039,15 +3053,20 @@ impl DeviceManager {
                 )
                 .map_err(DeviceManagerError::CreateVirtioRng)?,
             ));
-            self.virtio_devices.push(MetaVirtioDevice {
+            let device = MetaVirtioDevice {
                 virtio_device: Arc::clone(&virtio_rng_device)
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
                 iommu: rng_config.iommu,
                 id: id.clone(),
                 pci_segment: 0,
                 dma_handler: None,
-                bdf_device: None,
-            });
+                bdf_device: rng_config.bdf_device,
+            };
+            if rng_config.bdf_device.is_some() {
+                self.virtio_devices.push_front(device);
+            } else {
+                self.virtio_devices.push_back(device);
+            }
 
             // Fill the device tree with a new node. In case of restore, we
             // know there is nothing to do, so we can simply override the
@@ -3120,7 +3139,11 @@ impl DeviceManager {
         if let Some(fs_list_cfg) = &mut fs_devices {
             for fs_cfg in fs_list_cfg.iter_mut() {
                 let device = self.make_virtio_fs_device(fs_cfg)?;
-                self.virtio_devices.push(device);
+                if fs_cfg.bdf_device.is_some() {
+                    self.virtio_devices.push_front(device);
+                } else {
+                    self.virtio_devices.push_back(device);
+                }
             }
         }
         self.config.lock().unwrap().fs = fs_devices;
@@ -3307,7 +3330,11 @@ impl DeviceManager {
         if let Some(pmem_list_cfg) = &mut pmem_devices {
             for pmem_cfg in pmem_list_cfg.iter_mut() {
                 let device = self.make_virtio_pmem_device(pmem_cfg)?;
-                self.virtio_devices.push(device);
+                if pmem_cfg.bdf_device.is_some() {
+                    self.virtio_devices.push_front(device);
+                } else {
+                    self.virtio_devices.push_back(device);
+                }
             }
         }
         self.config.lock().unwrap().pmem = pmem_devices;
@@ -3377,7 +3404,11 @@ impl DeviceManager {
         let mut vsock = self.config.lock().unwrap().vsock.clone();
         if let Some(vsock_cfg) = &mut vsock {
             let device = self.make_virtio_vsock_device(vsock_cfg)?;
-            self.virtio_devices.push(device);
+            if vsock_cfg.bdf_device.is_some() {
+                self.virtio_devices.push_front(device);
+            } else {
+                self.virtio_devices.push_back(device);
+            }
         }
         self.config.lock().unwrap().vsock = vsock;
 
@@ -3419,7 +3450,7 @@ impl DeviceManager {
 
                 self.virtio_mem_devices.push(Arc::clone(&virtio_mem_device));
 
-                self.virtio_devices.push(MetaVirtioDevice {
+                self.virtio_devices.push_back(MetaVirtioDevice {
                     virtio_device: Arc::clone(&virtio_mem_device)
                         as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
                     iommu: false,
@@ -3507,7 +3538,7 @@ impl DeviceManager {
 
             self.balloon = Some(virtio_balloon_device.clone());
 
-            self.virtio_devices.push(MetaVirtioDevice {
+            let device = MetaVirtioDevice {
                 virtio_device: Arc::clone(&virtio_balloon_device)
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
                 iommu: false,
@@ -3515,7 +3546,13 @@ impl DeviceManager {
                 pci_segment: 0,
                 dma_handler: None,
                 bdf_device: balloon_config.bdf_device,
-            });
+            };
+
+            if balloon_config.bdf_device.is_some() {
+                self.virtio_devices.push_front(device);
+            } else {
+                self.virtio_devices.push_back(device);
+            }
 
             self.device_tree
                 .lock()
@@ -3547,7 +3584,7 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::CreateVirtioWatchdog)?,
         ));
-        self.virtio_devices.push(MetaVirtioDevice {
+        self.virtio_devices.push_back(MetaVirtioDevice {
             virtio_device: Arc::clone(&virtio_watchdog_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
             iommu: false,
@@ -3623,7 +3660,11 @@ impl DeviceManager {
         if let Some(vdpa_list_cfg) = &mut vdpa_devices {
             for vdpa_cfg in vdpa_list_cfg.iter_mut() {
                 let device = self.make_vdpa_device(vdpa_cfg)?;
-                self.virtio_devices.push(device);
+                if vdpa_cfg.bdf_device.is_some() {
+                    self.virtio_devices.push_front(device);
+                } else {
+                    self.virtio_devices.push_back(device);
+                }
             }
         }
         self.config.lock().unwrap().vdpa = vdpa_devices;
@@ -4772,7 +4813,7 @@ impl DeviceManager {
         // Add the virtio device to the device manager list. This is important
         // as the list is used to notify virtio devices about memory updates
         // for instance.
-        self.virtio_devices.push(handle.clone());
+        self.virtio_devices.push_back(handle.clone());
 
         let mapping: Option<Arc<IommuMapping>> = if handle.iommu {
             self.iommu_mapping.clone()

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -467,7 +467,7 @@ pub enum DeviceManagerError {
 
     /// Failed to find an available PCI device ID.
     #[error("Failed to find an available PCI device ID")]
-    NextPciDeviceId(#[source] pci::PciRootError),
+    AllocatePciDeviceId(#[source] pci::PciRootError),
 
     /// Could not reserve the PCI device ID.
     #[error("Could not reserve the PCI device ID")]
@@ -4289,7 +4289,8 @@ impl DeviceManager {
 
             (pci_segment_id, pci_device_bdf, resources)
         } else {
-            let pci_device_bdf = self.pci_segments[pci_segment_id as usize].next_device_bdf()?;
+            let pci_device_bdf =
+                self.pci_segments[pci_segment_id as usize].allocate_device_bdf(None)?;
 
             (pci_segment_id, pci_device_bdf, None)
         })

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1406,8 +1406,6 @@ impl DeviceManager {
     ) -> DeviceManagerResult<()> {
         trace_scoped!("create_devices");
 
-        let mut virtio_devices: Vec<MetaVirtioDevice> = Vec::new();
-
         self.cpu_manager
             .lock()
             .unwrap()
@@ -1458,12 +1456,8 @@ impl DeviceManager {
 
         self.original_termios_opt = original_termios_opt;
 
-        self.console = self.add_console_devices(
-            &legacy_interrupt_manager,
-            &mut virtio_devices,
-            console_info,
-            console_resize_pipe,
-        )?;
+        self.console =
+            self.add_console_devices(&legacy_interrupt_manager, console_info, console_resize_pipe)?;
 
         #[cfg(not(target_arch = "riscv64"))]
         if let Some(tpm) = self.config.clone().lock().unwrap().tpm.as_ref() {
@@ -1473,11 +1467,8 @@ impl DeviceManager {
         }
         self.legacy_interrupt_manager = Some(legacy_interrupt_manager);
 
-        virtio_devices.append(&mut self.make_virtio_devices()?);
-
-        self.add_pci_devices(virtio_devices.clone())?;
-
-        self.virtio_devices = virtio_devices;
+        self.make_virtio_devices()?;
+        self.add_pci_devices()?;
 
         // Add pvmemcontrol if required
         #[cfg(feature = "pvmemcontrol")]
@@ -1586,10 +1577,7 @@ impl DeviceManager {
     }
 
     #[allow(unused_variables)]
-    fn add_pci_devices(
-        &mut self,
-        virtio_devices: Vec<MetaVirtioDevice>,
-    ) -> DeviceManagerResult<()> {
+    fn add_pci_devices(&mut self) -> DeviceManagerResult<()> {
         let iommu_id = String::from(IOMMU_DEVICE_NAME);
 
         let iommu_address_width_bits =
@@ -1631,7 +1619,7 @@ impl DeviceManager {
 
         let mut iommu_attached_devices = Vec::new();
         {
-            for handle in virtio_devices {
+            for handle in self.virtio_devices.clone() {
                 let mapping: Option<Arc<IommuMapping>> = if handle.iommu {
                     self.iommu_mapping.clone()
                 } else {
@@ -2319,7 +2307,6 @@ impl DeviceManager {
 
     fn add_virtio_console_device(
         &mut self,
-        virtio_devices: &mut Vec<MetaVirtioDevice>,
         console_fd: ConsoleOutput,
         resize_pipe: Option<Arc<File>>,
     ) -> DeviceManagerResult<Option<Arc<virtio_devices::ConsoleResizer>>> {
@@ -2378,7 +2365,7 @@ impl DeviceManager {
         )
         .map_err(DeviceManagerError::CreateVirtioConsole)?;
         let virtio_console_device = Arc::new(Mutex::new(virtio_console_device));
-        virtio_devices.push(MetaVirtioDevice {
+        self.virtio_devices.push(MetaVirtioDevice {
             virtio_device: Arc::clone(&virtio_console_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
             iommu: console_config.iommu,
@@ -2411,7 +2398,6 @@ impl DeviceManager {
     fn add_console_devices(
         &mut self,
         interrupt_manager: &Arc<dyn InterruptManager<GroupConfig = LegacyIrqGroupConfig>>,
-        virtio_devices: &mut Vec<MetaVirtioDevice>,
         console_info: Option<ConsoleInfo>,
         console_resize_pipe: Option<Arc<File>>,
     ) -> DeviceManagerResult<Arc<Console>> {
@@ -2480,11 +2466,8 @@ impl DeviceManager {
             }
         }
 
-        let console_resizer = self.add_virtio_console_device(
-            virtio_devices,
-            console_info.console_main_fd,
-            console_resize_pipe,
-        )?;
+        let console_resizer =
+            self.add_virtio_console_device(console_info.console_main_fd, console_resize_pipe)?;
 
         Ok(Arc::new(Console { console_resizer }))
     }
@@ -2542,35 +2525,33 @@ impl DeviceManager {
         Ok(())
     }
 
-    fn make_virtio_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices: Vec<MetaVirtioDevice> = Vec::new();
-
+    fn make_virtio_devices(&mut self) -> DeviceManagerResult<()> {
         // Create "standard" virtio devices (net/block/rng)
-        devices.append(&mut self.make_virtio_block_devices()?);
-        devices.append(&mut self.make_virtio_net_devices()?);
-        devices.append(&mut self.make_virtio_rng_devices()?);
+        self.make_virtio_block_devices()?;
+        self.make_virtio_net_devices()?;
+        self.make_virtio_rng_devices()?;
 
         // Add virtio-fs if required
-        devices.append(&mut self.make_virtio_fs_devices()?);
+        self.make_virtio_fs_devices()?;
 
         // Add virtio-pmem if required
-        devices.append(&mut self.make_virtio_pmem_devices()?);
+        self.make_virtio_pmem_devices()?;
 
         // Add virtio-vsock if required
-        devices.append(&mut self.make_virtio_vsock_devices()?);
+        self.make_virtio_vsock_devices()?;
 
-        devices.append(&mut self.make_virtio_mem_devices()?);
+        self.make_virtio_mem_devices()?;
 
         // Add virtio-balloon if required
-        devices.append(&mut self.make_virtio_balloon_devices()?);
+        self.make_virtio_balloon_devices()?;
 
         // Add virtio-watchdog device
-        devices.append(&mut self.make_virtio_watchdog_devices()?);
+        self.make_virtio_watchdog_devices()?;
 
         // Add vDPA devices if required
-        devices.append(&mut self.make_vdpa_devices()?);
+        self.make_vdpa_devices()?;
 
-        Ok(devices)
+        Ok(())
     }
 
     // Cache whether aio is supported to avoid checking for very block device
@@ -2841,18 +2822,17 @@ impl DeviceManager {
         })
     }
 
-    fn make_virtio_block_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
-
+    fn make_virtio_block_devices(&mut self) -> DeviceManagerResult<()> {
         let mut block_devices = self.config.lock().unwrap().disks.clone();
         if let Some(disk_list_cfg) = &mut block_devices {
             for disk_cfg in disk_list_cfg.iter_mut() {
-                devices.push(self.make_virtio_block_device(disk_cfg, false)?);
+                let device = self.make_virtio_block_device(disk_cfg, false)?;
+                self.virtio_devices.push(device);
             }
         }
         self.config.lock().unwrap().disks = block_devices;
 
-        Ok(devices)
+        Ok(())
     }
 
     fn make_virtio_net_device(
@@ -3019,22 +2999,20 @@ impl DeviceManager {
     }
 
     /// Add virto-net and vhost-user-net devices
-    fn make_virtio_net_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
+    fn make_virtio_net_devices(&mut self) -> DeviceManagerResult<()> {
         let mut net_devices = self.config.lock().unwrap().net.clone();
         if let Some(net_list_cfg) = &mut net_devices {
             for net_cfg in net_list_cfg.iter_mut() {
-                devices.push(self.make_virtio_net_device(net_cfg)?);
+                let device = self.make_virtio_net_device(net_cfg)?;
+                self.virtio_devices.push(device);
             }
         }
         self.config.lock().unwrap().net = net_devices;
 
-        Ok(devices)
+        Ok(())
     }
 
-    fn make_virtio_rng_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
-
+    fn make_virtio_rng_devices(&mut self) -> DeviceManagerResult<()> {
         // Add virtio-rng if required
         let rng_config = self.config.lock().unwrap().rng.clone();
         if let Some(rng_path) = rng_config.src.to_str() {
@@ -3055,7 +3033,7 @@ impl DeviceManager {
                 )
                 .map_err(DeviceManagerError::CreateVirtioRng)?,
             ));
-            devices.push(MetaVirtioDevice {
+            self.virtio_devices.push(MetaVirtioDevice {
                 virtio_device: Arc::clone(&virtio_rng_device)
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
                 iommu: rng_config.iommu,
@@ -3073,7 +3051,7 @@ impl DeviceManager {
                 .insert(id.clone(), device_node!(id, virtio_rng_device));
         }
 
-        Ok(devices)
+        Ok(())
     }
 
     fn make_virtio_fs_device(
@@ -3129,18 +3107,17 @@ impl DeviceManager {
         }
     }
 
-    fn make_virtio_fs_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
-
+    fn make_virtio_fs_devices(&mut self) -> DeviceManagerResult<()> {
         let mut fs_devices = self.config.lock().unwrap().fs.clone();
         if let Some(fs_list_cfg) = &mut fs_devices {
             for fs_cfg in fs_list_cfg.iter_mut() {
-                devices.push(self.make_virtio_fs_device(fs_cfg)?);
+                let device = self.make_virtio_fs_device(fs_cfg)?;
+                self.virtio_devices.push(device);
             }
         }
         self.config.lock().unwrap().fs = fs_devices;
 
-        Ok(devices)
+        Ok(())
     }
 
     fn make_virtio_pmem_device(
@@ -3315,18 +3292,18 @@ impl DeviceManager {
         })
     }
 
-    fn make_virtio_pmem_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
+    fn make_virtio_pmem_devices(&mut self) -> DeviceManagerResult<()> {
         // Add virtio-pmem if required
         let mut pmem_devices = self.config.lock().unwrap().pmem.clone();
         if let Some(pmem_list_cfg) = &mut pmem_devices {
             for pmem_cfg in pmem_list_cfg.iter_mut() {
-                devices.push(self.make_virtio_pmem_device(pmem_cfg)?);
+                let device = self.make_virtio_pmem_device(pmem_cfg)?;
+                self.virtio_devices.push(device);
             }
         }
         self.config.lock().unwrap().pmem = pmem_devices;
 
-        Ok(devices)
+        Ok(())
     }
 
     fn make_virtio_vsock_device(
@@ -3386,21 +3363,18 @@ impl DeviceManager {
         })
     }
 
-    fn make_virtio_vsock_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
-
+    fn make_virtio_vsock_devices(&mut self) -> DeviceManagerResult<()> {
         let mut vsock = self.config.lock().unwrap().vsock.clone();
         if let Some(vsock_cfg) = &mut vsock {
-            devices.push(self.make_virtio_vsock_device(vsock_cfg)?);
+            let device = self.make_virtio_vsock_device(vsock_cfg)?;
+            self.virtio_devices.push(device);
         }
         self.config.lock().unwrap().vsock = vsock;
 
-        Ok(devices)
+        Ok(())
     }
 
-    fn make_virtio_mem_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
-
+    fn make_virtio_mem_devices(&mut self) -> DeviceManagerResult<()> {
         let mm = self.memory_manager.clone();
         let mut mm = mm.lock().unwrap();
         for (memory_zone_id, memory_zone) in mm.memory_zones_mut().iter_mut() {
@@ -3435,7 +3409,7 @@ impl DeviceManager {
 
                 self.virtio_mem_devices.push(Arc::clone(&virtio_mem_device));
 
-                devices.push(MetaVirtioDevice {
+                self.virtio_devices.push(MetaVirtioDevice {
                     virtio_device: Arc::clone(&virtio_mem_device)
                         as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
                     iommu: false,
@@ -3454,7 +3428,7 @@ impl DeviceManager {
             }
         }
 
-        Ok(devices)
+        Ok(())
     }
 
     #[cfg(feature = "pvmemcontrol")]
@@ -3499,9 +3473,7 @@ impl DeviceManager {
         Ok((pvmemcontrol_bus_device, pvmemcontrol_pci_device))
     }
 
-    fn make_virtio_balloon_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
-
+    fn make_virtio_balloon_devices(&mut self) -> DeviceManagerResult<()> {
         if let Some(balloon_config) = &self.config.lock().unwrap().balloon {
             let id = String::from(BALLOON_DEVICE_NAME);
             info!("Creating virtio-balloon device: id = {}", id);
@@ -3524,7 +3496,7 @@ impl DeviceManager {
 
             self.balloon = Some(virtio_balloon_device.clone());
 
-            devices.push(MetaVirtioDevice {
+            self.virtio_devices.push(MetaVirtioDevice {
                 virtio_device: Arc::clone(&virtio_balloon_device)
                     as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
                 iommu: false,
@@ -3539,14 +3511,12 @@ impl DeviceManager {
                 .insert(id.clone(), device_node!(id, virtio_balloon_device));
         }
 
-        Ok(devices)
+        Ok(())
     }
 
-    fn make_virtio_watchdog_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
-
+    fn make_virtio_watchdog_devices(&mut self) -> DeviceManagerResult<()> {
         if !self.config.lock().unwrap().watchdog {
-            return Ok(devices);
+            return Ok(());
         }
 
         let id = String::from(WATCHDOG_DEVICE_NAME);
@@ -3565,7 +3535,7 @@ impl DeviceManager {
             )
             .map_err(DeviceManagerError::CreateVirtioWatchdog)?,
         ));
-        devices.push(MetaVirtioDevice {
+        self.virtio_devices.push(MetaVirtioDevice {
             virtio_device: Arc::clone(&virtio_watchdog_device)
                 as Arc<Mutex<dyn virtio_devices::VirtioDevice>>,
             iommu: false,
@@ -3579,7 +3549,7 @@ impl DeviceManager {
             .unwrap()
             .insert(id.clone(), device_node!(id, virtio_watchdog_device));
 
-        Ok(devices)
+        Ok(())
     }
 
     fn make_vdpa_device(
@@ -3633,18 +3603,18 @@ impl DeviceManager {
         })
     }
 
-    fn make_vdpa_devices(&mut self) -> DeviceManagerResult<Vec<MetaVirtioDevice>> {
-        let mut devices = Vec::new();
+    fn make_vdpa_devices(&mut self) -> DeviceManagerResult<()> {
         // Add vdpa if required
         let mut vdpa_devices = self.config.lock().unwrap().vdpa.clone();
         if let Some(vdpa_list_cfg) = &mut vdpa_devices {
             for vdpa_cfg in vdpa_list_cfg.iter_mut() {
-                devices.push(self.make_vdpa_device(vdpa_cfg)?);
+                let device = self.make_vdpa_device(vdpa_cfg)?;
+                self.virtio_devices.push(device);
             }
         }
         self.config.lock().unwrap().vdpa = vdpa_devices;
 
-        Ok(devices)
+        Ok(())
     }
 
     fn next_device_name(&mut self, prefix: &str) -> DeviceManagerResult<String> {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3475,6 +3475,7 @@ mod unit_tests {
             rng: RngConfig {
                 src: PathBuf::from("/dev/urandom"),
                 iommu: false,
+                bdf_device: None,
             },
             balloon: None,
             fs: None,
@@ -3485,6 +3486,7 @@ mod unit_tests {
                 iommu: false,
                 socket: None,
                 url: None,
+                bdf_device: None,
             },
             console: ConsoleConfig {
                 file: None,
@@ -3493,6 +3495,7 @@ mod unit_tests {
                 iommu: false,
                 socket: None,
                 url: None,
+                bdf_device: None,
             },
             #[cfg(target_arch = "x86_64")]
             debug_console: DebugConsoleConfig::default(),

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -163,15 +163,22 @@ impl PciSegment {
         )
     }
 
-    pub(crate) fn next_device_bdf(&self) -> DeviceManagerResult<PciBdf> {
+    /// Allocates a device BDF on this PCI segment
+    ///
+    /// - `device_id`: Device ID to request for BDF allocation
+    ///
+    /// ## Errors
+    /// * [`DeviceManagerError::AllocatePciDeviceId`] if device ID
+    ///   allocation on the bus fails.
+    pub(crate) fn allocate_device_bdf(&self, device_id: Option<u8>) -> DeviceManagerResult<PciBdf> {
         Ok(PciBdf::new(
             self.id,
             0,
             self.pci_bus
                 .lock()
                 .unwrap()
-                .next_device_id()
-                .map_err(DeviceManagerError::NextPciDeviceId)? as u8,
+                .allocate_device_id(device_id)
+                .map_err(DeviceManagerError::AllocatePciDeviceId)? as u8,
             0,
         ))
     }

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -163,7 +163,7 @@ impl PciSegment {
         )
     }
 
-    /// Allocates a device BDF on this PCI segment
+    /// Allocates a device BDF on this PCI segment.
     ///
     /// - `device_id`: Device ID to request for BDF allocation
     ///
@@ -207,6 +207,65 @@ impl PciSegment {
         }
 
         Ok(())
+    }
+
+    #[cfg(test)]
+    /// Creates a PciSegment without the need for an [`AddressManager`]
+    /// for testing purpose.
+    ///
+    /// An [`AddressManager`] would otherwise be required to create
+    /// [`PciBus`] instances. Instead, we use any struct that implements
+    /// [`DeviceRelocation`] to instantiate a [`PciBus`].
+    pub(crate) fn new_without_address_manager(
+        id: u16,
+        numa_node: u32,
+        mem32_allocator: Arc<Mutex<AddressAllocator>>,
+        mem64_allocator: Arc<Mutex<AddressAllocator>>,
+        pci_irq_slots: &[u8; 32],
+        device_reloc: Arc<dyn DeviceRelocation>,
+    ) -> DeviceManagerResult<Self> {
+        let pci_root = PciRoot::new(None);
+        let pci_bus = Arc::new(Mutex::new(PciBus::new(pci_root, device_reloc.clone())));
+
+        let pci_config_mmio = Arc::new(Mutex::new(PciConfigMmio::new(Arc::clone(&pci_bus))));
+        let mmio_config_address =
+            layout::PCI_MMCONFIG_START.0 + layout::PCI_MMIO_CONFIG_SIZE_PER_SEGMENT * id as u64;
+
+        let start_of_mem32_area = mem32_allocator.lock().unwrap().base().0;
+        let end_of_mem32_area = mem32_allocator.lock().unwrap().end().0;
+
+        let start_of_mem64_area = mem64_allocator.lock().unwrap().base().0;
+        let end_of_mem64_area = mem64_allocator.lock().unwrap().end().0;
+
+        let segment = PciSegment {
+            id,
+            pci_bus,
+            pci_config_mmio,
+            mmio_config_address,
+            proximity_domain: numa_node,
+            pci_devices_up: 0,
+            pci_devices_down: 0,
+            #[cfg(target_arch = "x86_64")]
+            pci_config_io: None,
+            mem32_allocator,
+            mem64_allocator,
+            start_of_mem32_area,
+            end_of_mem32_area,
+            start_of_mem64_area,
+            end_of_mem64_area,
+            pci_irq_slots: *pci_irq_slots,
+        };
+
+        info!(
+            "Adding PCI segment: id={}, PCI MMIO config address: 0x{:x}, mem32 area [0x{:x}-0x{:x}, mem64 area [0x{:x}-0x{:x}",
+            segment.id,
+            segment.mmio_config_address,
+            segment.start_of_mem32_area,
+            segment.end_of_mem32_area,
+            segment.start_of_mem64_area,
+            segment.end_of_mem64_area
+        );
+        Ok(segment)
     }
 }
 
@@ -478,5 +537,98 @@ impl Aml for PciSegment {
             pci_dsdt_inner_data,
         )
         .to_aml_bytes(sink)
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::result::Result;
+
+    use vm_memory::GuestAddress;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct MocRelocDevice;
+    impl DeviceRelocation for MocRelocDevice {
+        fn move_bar(
+            &self,
+            _old_base: u64,
+            _new_base: u64,
+            _len: u64,
+            _pci_dev: &mut dyn pci::PciDevice,
+            _region_type: pci::PciBarRegionType,
+        ) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+    }
+
+    fn setup() -> PciSegment {
+        let guest_addr = 0_u64;
+        let guest_size = 0x1000_usize;
+        let allocator_1 = Arc::new(Mutex::new(
+            AddressAllocator::new(GuestAddress(guest_addr), guest_size as u64).unwrap(),
+        ));
+        let allocator_2 = Arc::new(Mutex::new(
+            AddressAllocator::new(GuestAddress(guest_addr), guest_size as u64).unwrap(),
+        ));
+        let moc_device_reloc = Arc::new(MocRelocDevice {});
+        let arr = [0_u8; 32];
+
+        PciSegment::new_without_address_manager(
+            0,
+            0,
+            allocator_1,
+            allocator_2,
+            &arr,
+            moc_device_reloc,
+        )
+        .unwrap()
+    }
+
+    #[test]
+    // Test the default bdf for a segment with an empty bus (except for the root device)
+    fn allocate_device_bdf_default() {
+        // The first address is occupied by the root
+        let segment = setup();
+        let bdf = segment.allocate_device_bdf(None).unwrap();
+        assert_eq!(bdf.segment(), segment.id);
+        assert_eq!(bdf.bus(), 0);
+        assert_eq!(bdf.device(), 1);
+        assert_eq!(bdf.function(), 0);
+    }
+
+    #[test]
+    // Test to acquire a bdf with s specific device ID
+    fn allocate_device_bdf_fixed_device_id() {
+        // The first address is occupied by the root
+        let expect_device_id = 0x10_u8;
+        let segment = setup();
+        let bdf = segment.allocate_device_bdf(Some(expect_device_id)).unwrap();
+        assert_eq!(bdf.segment(), segment.id);
+        assert_eq!(bdf.bus(), 0);
+        assert_eq!(bdf.device(), expect_device_id);
+        assert_eq!(bdf.function(), 0);
+    }
+
+    #[test]
+    // Test to acquire a bdf with invalid device id, one already
+    // taken and the other being greater then the number of allowed
+    // devices per bus.
+    fn allocate_device_bdf_invalid_device_id() {
+        // The first address is occupied by the root
+        let already_taken_device_id = 0x0_u8;
+        let overflow_device_id = 0xff_u8;
+        let segment = setup();
+        let bdf_res = segment.allocate_device_bdf(Some(already_taken_device_id));
+        assert!(matches!(
+            bdf_res,
+            Err(DeviceManagerError::AllocatePciDeviceId(_))
+        ));
+        let bdf_res = segment.allocate_device_bdf(Some(overflow_device_id));
+        assert!(matches!(
+            bdf_res,
+            Err(DeviceManagerError::AllocatePciDeviceId(_))
+        ));
     }
 }

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -276,6 +276,8 @@ pub struct DiskConfig {
     pub serial: Option<String>,
     #[serde(default)]
     pub queue_affinity: Option<Vec<VirtQueueAffinity>>,
+    #[serde(default)]
+    pub bdf_device: Option<u8>,
 }
 
 impl ApplyLandlock for DiskConfig {
@@ -341,6 +343,8 @@ pub struct NetConfig {
     pub offload_ufo: bool,
     #[serde(default = "default_netconfig_true")]
     pub offload_csum: bool,
+    #[serde(default)]
+    pub bdf_device: Option<u8>,
 }
 
 pub fn default_netconfig_true() -> bool {
@@ -401,6 +405,8 @@ pub struct RngConfig {
     pub src: PathBuf,
     #[serde(default)]
     pub iommu: bool,
+    #[serde(default)]
+    pub bdf_device: Option<u8>,
 }
 
 pub const DEFAULT_RNG_SOURCE: &str = "/dev/urandom";
@@ -410,6 +416,7 @@ impl Default for RngConfig {
         RngConfig {
             src: PathBuf::from(DEFAULT_RNG_SOURCE),
             iommu: false,
+            bdf_device: None,
         }
     }
 }
@@ -431,6 +438,8 @@ pub struct BalloonConfig {
     /// Option to enable free page reporting from the guest.
     #[serde(default)]
     pub free_page_reporting: bool,
+    #[serde(default)]
+    pub bdf_device: Option<u8>,
 }
 
 #[cfg(feature = "pvmemcontrol")]
@@ -449,6 +458,8 @@ pub struct FsConfig {
     pub id: Option<String>,
     #[serde(default)]
     pub pci_segment: u16,
+    #[serde(default)]
+    pub bdf_device: Option<u8>,
 }
 
 pub fn default_fsconfig_num_queues() -> usize {
@@ -479,6 +490,8 @@ pub struct PmemConfig {
     pub id: Option<String>,
     #[serde(default)]
     pub pci_segment: u16,
+    #[serde(default)]
+    pub bdf_device: Option<u8>,
 }
 
 impl ApplyLandlock for PmemConfig {
@@ -509,6 +522,9 @@ pub struct ConsoleConfig {
     pub iommu: bool,
     pub socket: Option<PathBuf>,
     pub url: Option<String>,
+    /// PCI BDF to attach the console in the guest to
+    #[serde(default)]
+    pub bdf_device: Option<u8>,
 }
 
 pub fn default_consoleconfig_file() -> Option<PathBuf> {
@@ -614,6 +630,8 @@ pub struct VdpaConfig {
     pub id: Option<String>,
     #[serde(default)]
     pub pci_segment: u16,
+    #[serde(default)]
+    pub bdf_device: Option<u8>,
 }
 
 pub fn default_vdpaconfig_num_queues() -> usize {
@@ -637,6 +655,8 @@ pub struct VsockConfig {
     pub id: Option<String>,
     #[serde(default)]
     pub pci_segment: u16,
+    #[serde(default)]
+    pub bdf_device: Option<u8>,
 }
 
 impl ApplyLandlock for VsockConfig {
@@ -859,6 +879,7 @@ pub fn default_serial() -> ConsoleConfig {
         iommu: false,
         socket: None,
         url: None,
+        bdf_device: None,
     }
 }
 
@@ -869,6 +890,7 @@ pub fn default_console() -> ConsoleConfig {
         iommu: false,
         socket: None,
         url: None,
+        bdf_device: None,
     }
 }
 


### PR DESCRIPTION
Related to https://github.com/cobaltcore-dev/cobaltcore/issues/287.

# Configurable BDF Design

## Background
Configurable PCI BDF (Bus, Device, Function) allows for choosing the address that a guest can see a PCI device. Qemu, for example, implements the `addr` option for the `device` argument. The `addr` argument allows defining the device and function part of a device's BDF in the form `addr=DD.F`, where `D` denotes a device ID in the range of [0..32] and `F` a function ID in a range of [0..7]. Qemu denotes the bus number with the option `busnr`, where a valid expression is `busnr=pci.2` to denote the second PCI bus, for example. [0]

With a series of pull requests, we try to mimic the command-line interface of Qemu and introduce new command line parameters to CHV, where applicable to similarly achieve configurable BDFs.

An example of a BDF for Bus=1, Device=3, and Function=5 is `1:03.5`. [1] 

## Current status
CHV allows defining multiple PCI domains via the `pci_segments` option. For all PCI segments, CHV creates a dedicated host bridge. Via the option argument `pci_segment`, one can define to which domain a device is added.

Other than that, CHV currently has no support to influence what exact BDF is assigned to a device, other than the order in which devices are specified in the VM configuration. This is done by calling the `next_device_bdf` function of the
struct `PciSegment` for each PCI device to create. `next_device_bdf` returns the a BDF with the following free device ID and a fixed function ID of 0. `PciSegment` queries the underlying `PciBus` to obtain the following device ID, which we also must modify.

Currently, there is no support for multi-function devices in CHV.

## Proposed changes
We split the configurable BDF feature into separate PRs with the goals defined in The following subsections.

The BAR address allocation is able to handle the changes listed below. So I don't expect the need for changes there.

### 1. Definition of Device IDs
To define a device ID, we first must implement some notion for specifying them via the API or command line. For this, we introduce the `addr` option argument, similar to Qemu. The expected format is `addr=DD` with `DD` being in the range
of [0..32]. This argument is stored in a device's configuration and must be propagated to `next_device_bdf`. This function will be replaced by `specific_device_bdf` to allow for specifying a concrete device identifier. The steps for implementing configurable device IDs are as follows: 
- [x] Introduce function `allocate_device_id` to struct `PciBus` to reserve a device ID, depending on the argument given. If no device ID is specified, use the current mechanism to obtain an ID. This replaces `next_device_id`. 
- [x] Introduce function `allocate_device_bdf` to struct `PciSegment` to allocate a BDF depending on function parameters. If no device parameter is specified, fall back to the algorithm currently used by `next_device_bdf`. Replaces `next_device_bdf`.
- [x] Introduce `addr` parameter to all forms of VirtIo device configurations
 and adjust parsers
- [x] Add unit tests covering `allocate_device_id` in `PciBus`
- [x] Add unit tests covering `allocate_device_bdf` in `PciSegment`
- [x] Add unit tests covering the new argument and its parsing

## References
[0] https://qemu-project.gitlab.io/qemu/system/device-emulation.html#device-buses

[1] https://wiki.xenproject.org/wiki/Bus:Device.Function_(BDF)_Notation