### PR TITLE
encrypted live migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,6 +265,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -277,6 +300,26 @@ dependencies = [
  "object",
  "rustc-demangle",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.9.4",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.13.0",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -354,7 +397,18 @@ version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
+]
+
+[[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
 ]
 
 [[package]]
@@ -368,6 +422,17 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
 
 [[package]]
 name = "clap"
@@ -414,6 +479,7 @@ dependencies = [
  "log",
  "net_util",
  "option_parser",
+ "rustls",
  "seccompiler",
  "serde_json",
  "signal-hook",
@@ -426,6 +492,15 @@ dependencies = [
  "vmm-sys-util",
  "wait-timeout",
  "zbus",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -556,7 +631,7 @@ dependencies = [
  "lazy_static",
  "mintex",
  "parking_lot",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "serde",
  "serde_json",
  "thousands",
@@ -582,6 +657,12 @@ dependencies = [
  "redox_users",
  "windows-sys 0.60.2",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -725,6 +806,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1019,6 +1106,15 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1054,6 +1150,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.3",
+ "libc",
 ]
 
 [[package]]
@@ -1111,6 +1217,16 @@ name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
 
 [[package]]
 name = "libredox"
@@ -1215,6 +1331,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1433,16 @@ name = "no-std-net"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43794a0ace135be66a25d3ae77d41b91615fb68ae937f904090203e81f755b65"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "num-traits"
@@ -1650,6 +1782,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1789,6 +1931,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.15",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1799,6 +1955,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustix"
@@ -1824,6 +1986,42 @@ dependencies = [
  "libc",
  "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a9586e9ee2b4f8fab52a0048ca7334d7024eef48e2cb9407e3497bb7cab7fa7"
+dependencies = [
+ "aws-lc-rs",
+ "log",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+dependencies = [
+ "aws-lc-rs",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
@@ -1992,6 +2190,12 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -2173,6 +2377,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "utf8parse"
@@ -2402,7 +2612,8 @@ name = "vm-migration"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "itertools",
+ "itertools 0.14.0",
+ "rustls",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -2591,6 +2802,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
@@ -2922,6 +3139,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,7 @@ hypervisor = { path = "hypervisor" }
 libc = { workspace = true }
 log = { workspace = true, features = ["std"] }
 option_parser = { path = "option_parser" }
+rustls = { workspace = true }
 seccompiler = { workspace = true }
 serde_json = { workspace = true }
 signal-hook = { workspace = true }
@@ -165,6 +166,7 @@ flume = "0.11.1"
 itertools = "0.14.0"
 libc = "0.2.167"
 log = "0.4.22"
+rustls = "0.23.34"
 signal-hook = "0.3.18"
 thiserror = "2.0.12"
 uuid = { version = "1.18.1" }

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -11,6 +11,7 @@ use std::io::Read;
 use std::marker::PhantomData;
 use std::num::NonZeroU32;
 use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
 use std::process;
 
 use api_client::{
@@ -491,7 +492,8 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .subcommand_matches("send-migration")
                     .unwrap()
                     .get_one::<String>("send_migration_config")
-                    .unwrap(),
+                    .unwrap()
+                    .to_owned(),
                 matches
                     .subcommand_matches("send-migration")
                     .unwrap()
@@ -513,6 +515,11 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .copied()
                     .and_then(NonZeroU32::new)
                     .unwrap_or(NonZeroU32::new(1).unwrap()),
+                matches
+                    .subcommand_matches("send-migration")
+                    .unwrap()
+                    .get_one::<PathBuf>("tls_dir")
+                    .cloned(),
             );
             simple_api_command(socket, "PUT", "send-migration", Some(&send_migration_data))
                 .map_err(Error::HttpApiClient)
@@ -523,7 +530,13 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .subcommand_matches("receive-migration")
                     .unwrap()
                     .get_one::<String>("receive_migration_config")
-                    .unwrap(),
+                    .unwrap()
+                    .to_owned(),
+                matches
+                    .subcommand_matches("receive_migration")
+                    .unwrap()
+                    .get_one::<PathBuf>("tls_dir")
+                    .cloned(),
             );
             simple_api_command(
                 socket,
@@ -930,32 +943,35 @@ fn coredump_config(destination_url: &str) -> String {
     serde_json::to_string(&coredump_config).unwrap()
 }
 
-fn receive_migration_data(url: &str) -> String {
+fn receive_migration_data(url: String, tls_dir: Option<PathBuf>) -> String {
     let receive_migration_data = vmm::api::VmReceiveMigrationData {
-        receiver_url: url.to_owned(),
+        receiver_url: url,
         tcp_serial_url: None,
         // Only FDs transmitted via an SCM_RIGHTS UNIX Domain Socket message
         // are valid. Transmitting specific FD nums via the HTTP API is
         // almost always invalid.
         net_fds: None,
+        tls_dir,
     };
 
     serde_json::to_string(&receive_migration_data).unwrap()
 }
 
 fn send_migration_data(
-    url: &str,
+    url: String,
     local: bool,
     downtime: u64,
     migration_timeout: u64,
     connections: NonZeroU32,
+    tls_dir: Option<PathBuf>,
 ) -> String {
     let send_migration_data = vmm::api::VmSendMigrationData {
-        destination_url: url.to_owned(),
+        destination_url: url,
         local,
         downtime,
         migration_timeout,
         connections,
+        tls_dir,
     };
 
     serde_json::to_string(&send_migration_data).unwrap()

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -7,6 +7,7 @@ version = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 itertools = { workspace = true }
+rustls = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -11,6 +11,7 @@ use crate::protocol::MemoryRangeTable;
 
 mod bitpos_iterator;
 pub mod protocol;
+pub mod tls;
 
 #[derive(Error, Debug)]
 pub enum MigratableError {
@@ -52,6 +53,9 @@ pub enum MigratableError {
 
     #[error("Failed to release a disk lock")]
     UnlockError(#[source] anyhow::Error),
+
+    #[error("TLS error")]
+    Tls(#[from] tls::TlsError),
 }
 
 /// A Pausable component can be paused and resumed.

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -46,12 +46,40 @@ pub enum TlsStream {
     Server(StreamOwned<ServerConnection, TcpStream>),
 }
 
+// The TLS-Stream objects cannot read or write volatile, thus we need a buffer
+// between the VolatileSlice and the TLS stream (see ReadVolatile and
+// WriteVolatile implementations below). Allocating this buffer in these
+// function calls would make it very slow, thus we tie the buffer to the stream
+// with this wrapper.
+pub struct TlsStreamWrapper {
+    stream: TlsStream,
+    // Used only in ReadVolatile and WriteVolatile
+    buf: Vec<u8>,
+}
+
+static MAX_CHUNK: usize = 1024 * 64;
+
+impl TlsStreamWrapper {
+    pub fn new(stream: TlsStream) -> Self {
+        Self {
+            stream,
+            buf: Vec::new(),
+        }
+    }
+}
+
 impl Read for TlsStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
             TlsStream::Client(s) => s.read(buf),
             TlsStream::Server(s) => s.read(buf),
         }
+    }
+}
+
+impl Read for TlsStreamWrapper {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        Read::read(&mut self.stream, buf)
     }
 }
 
@@ -70,38 +98,81 @@ impl Write for TlsStream {
     }
 }
 
+impl Write for TlsStreamWrapper {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Write::write(&mut self.stream, buf)
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        Write::flush(&mut self.stream)
+    }
+}
+
 // Reading from or writing to these FDs would break the connection, because
 // those reads or writes wouldn't go through rustls. But the FD is used to wait
 // until it becomes readable.
-impl AsFd for TlsStream {
+impl AsFd for TlsStreamWrapper {
     fn as_fd(&self) -> BorrowedFd<'_> {
-        match self {
+        match &self.stream {
             TlsStream::Client(s) => s.get_ref().as_fd(),
             TlsStream::Server(s) => s.get_ref().as_fd(),
         }
     }
 }
 
-impl ReadVolatile for TlsStream {
+impl ReadVolatile for TlsStreamWrapper {
     fn read_volatile<B: BitmapSlice>(
         &mut self,
         vs: &mut VolatileSlice<B>,
     ) -> std::result::Result<usize, VolatileMemoryError> {
-        let mut tmp = vec![0u8; vs.len()];
-        let n = Read::read(self, &mut tmp[..]).unwrap();
-        vs.copy_from(&tmp[..n]);
+        let len = vs.len().min(MAX_CHUNK);
+
+        if len == 0 {
+            return Ok(0);
+        }
+
+        if self.buf.len() < len {
+            self.buf.resize(len, 0);
+        }
+
+        let buf = &mut self.buf[..len];
+        let n =
+            Read::read(&mut self.stream, &mut buf[..len]).map_err(VolatileMemoryError::IOError)?;
+
+        if n == 0 {
+            return Ok(0);
+        }
+
+        vs.copy_from(&buf[..n]);
+        self.buf.clear();
+
         Ok(n)
     }
 }
 
-impl WriteVolatile for TlsStream {
+impl WriteVolatile for TlsStreamWrapper {
     fn write_volatile<B: BitmapSlice>(
         &mut self,
         vs: &VolatileSlice<B>,
     ) -> std::result::Result<usize, VolatileMemoryError> {
-        let mut tmp = vec![0u8; vs.len()];
-        let n = vs.copy_to(&mut tmp[..]);
-        let n = Write::write(self, &tmp[..n]).unwrap();
+        let len = vs.len().min(MAX_CHUNK);
+        if len == 0 {
+            return Ok(0);
+        }
+
+        if self.buf.len() < len {
+            self.buf.resize(len, 0);
+        }
+
+        let buf = &mut self.buf[..len];
+        let n = vs.copy_to(&mut buf[..len]);
+
+        if n == 0 {
+            return Ok(0);
+        }
+
+        let n = Write::write(&mut self.stream, &buf[..n]).map_err(VolatileMemoryError::IOError)?;
+        self.buf.clear();
+
         Ok(n)
     }
 }
@@ -130,7 +201,10 @@ impl TlsConnectionWrapper {
         Self { config }
     }
 
-    pub fn wrap(&self, socket: TcpStream) -> std::result::Result<TlsStream, MigratableError> {
+    pub fn wrap(
+        &self,
+        socket: TcpStream,
+    ) -> std::result::Result<TlsStreamWrapper, MigratableError> {
         let conn = ServerConnection::new(self.config.clone()).map_err(TlsError::RustlsError)?;
 
         let mut tls = StreamOwned::new(conn, socket);
@@ -146,7 +220,7 @@ impl TlsConnectionWrapper {
             }
         }
 
-        Ok(TlsStream::Server(tls))
+        Ok(TlsStreamWrapper::new(TlsStream::Server(tls)))
     }
 }
 

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -9,8 +9,10 @@ use std::path::Path;
 use std::sync::Arc;
 
 use rustls::pki_types::pem::PemObject;
-use rustls::pki_types::{CertificateDer, InvalidDnsNameError, ServerName};
-use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+use rustls::pki_types::{CertificateDer, InvalidDnsNameError, PrivateKeyDer, ServerName};
+use rustls::{
+    ClientConfig, ClientConnection, RootCertStore, ServerConfig, ServerConnection, StreamOwned,
+};
 use thiserror::Error;
 use vm_memory::bitmap::BitmapSlice;
 use vm_memory::io::{ReadVolatile, WriteVolatile};
@@ -41,12 +43,14 @@ pub enum TlsError {
 #[derive(Debug)]
 pub enum TlsStream {
     Client(StreamOwned<ClientConnection, TcpStream>),
+    Server(StreamOwned<ServerConnection, TcpStream>),
 }
 
 impl Read for TlsStream {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         match self {
             TlsStream::Client(s) => s.read(buf),
+            TlsStream::Server(s) => s.read(buf),
         }
     }
 }
@@ -55,11 +59,13 @@ impl Write for TlsStream {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         match self {
             TlsStream::Client(s) => s.write(buf),
+            TlsStream::Server(s) => s.write(buf),
         }
     }
     fn flush(&mut self) -> io::Result<()> {
         match self {
             TlsStream::Client(s) => s.flush(),
+            TlsStream::Server(s) => s.flush(),
         }
     }
 }
@@ -71,6 +77,7 @@ impl AsFd for TlsStream {
     fn as_fd(&self) -> BorrowedFd<'_> {
         match self {
             TlsStream::Client(s) => s.get_ref().as_fd(),
+            TlsStream::Server(s) => s.get_ref().as_fd(),
         }
     }
 }
@@ -96,6 +103,50 @@ impl WriteVolatile for TlsStream {
         let n = vs.copy_to(&mut tmp[..]);
         let n = Write::write(self, &tmp[..n]).unwrap();
         Ok(n)
+    }
+}
+
+// A small wrapper to be put into ReceiveListener::Tls. It carries the
+// TLS-Config and creates a TlsStream after the TcpConnection accepted a
+// connection.
+#[derive(Debug, Clone)]
+pub struct TlsConnectionWrapper {
+    config: Arc<ServerConfig>,
+}
+
+impl TlsConnectionWrapper {
+    pub fn new(cert_dir: &Path) -> Self {
+        let certs = CertificateDer::pem_file_iter(cert_dir.join("server-cert.pem"))
+            .unwrap()
+            .map(|cert| cert.unwrap())
+            .collect();
+        let key = PrivateKeyDer::from_pem_file(cert_dir.join("server-key.pem")).unwrap();
+        let config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .map_err(TlsError::RustlsError)
+            .unwrap();
+        let config = Arc::new(config);
+        Self { config }
+    }
+
+    pub fn wrap(&self, socket: TcpStream) -> std::result::Result<TlsStream, MigratableError> {
+        let conn = ServerConnection::new(self.config.clone()).map_err(TlsError::RustlsError)?;
+
+        let mut tls = StreamOwned::new(conn, socket);
+        while tls.conn.is_handshaking() {
+            let (rd, wr) = tls
+                .conn
+                .complete_io(&mut tls.sock)
+                .map_err(TlsError::RustlsIoError)?;
+            if rd == 0 && wr == 0 {
+                Err(TlsError::HandshakeError(
+                    "EOF during TLS handshake".to_string(),
+                ))?;
+            }
+        }
+
+        Ok(TlsStream::Server(tls))
     }
 }
 

--- a/vm-migration/src/tls.rs
+++ b/vm-migration/src/tls.rs
@@ -1,0 +1,136 @@
+// Copyright © 2025 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+use std::io::{self, Read, Write};
+use std::net::TcpStream;
+use std::os::fd::{AsFd, BorrowedFd};
+use std::path::Path;
+use std::sync::Arc;
+
+use rustls::pki_types::pem::PemObject;
+use rustls::pki_types::{CertificateDer, InvalidDnsNameError, ServerName};
+use rustls::{ClientConfig, ClientConnection, RootCertStore, StreamOwned};
+use thiserror::Error;
+use vm_memory::bitmap::BitmapSlice;
+use vm_memory::io::{ReadVolatile, WriteVolatile};
+use vm_memory::{VolatileMemoryError, VolatileSlice};
+
+use crate::MigratableError;
+
+#[derive(Error, Debug)]
+pub enum TlsError {
+    #[error(
+        "The provided input could not be parsed because it is not a syntactically-valid DNS Name."
+    )]
+    InvalidDnsName(#[source] InvalidDnsNameError),
+
+    #[error("Rustls protocol error")]
+    RustlsError(#[from] rustls::Error),
+
+    #[error("Rustls protocol IO error")]
+    RustlsIoError(#[from] std::io::Error),
+
+    #[error("Error during TLS handshake: {0}")]
+    HandshakeError(String),
+}
+
+// This TlsStream will be later encapsulated in a SocketStream. Thus it has to
+// implement the same traits. It is important that we never directly read from
+// or write to the TcpStream encapsulated in StreamOwned.
+#[derive(Debug)]
+pub enum TlsStream {
+    Client(StreamOwned<ClientConnection, TcpStream>),
+}
+
+impl Read for TlsStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            TlsStream::Client(s) => s.read(buf),
+        }
+    }
+}
+
+impl Write for TlsStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        match self {
+            TlsStream::Client(s) => s.write(buf),
+        }
+    }
+    fn flush(&mut self) -> io::Result<()> {
+        match self {
+            TlsStream::Client(s) => s.flush(),
+        }
+    }
+}
+
+// Reading from or writing to these FDs would break the connection, because
+// those reads or writes wouldn't go through rustls. But the FD is used to wait
+// until it becomes readable.
+impl AsFd for TlsStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        match self {
+            TlsStream::Client(s) => s.get_ref().as_fd(),
+        }
+    }
+}
+
+impl ReadVolatile for TlsStream {
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        vs: &mut VolatileSlice<B>,
+    ) -> std::result::Result<usize, VolatileMemoryError> {
+        let mut tmp = vec![0u8; vs.len()];
+        let n = Read::read(self, &mut tmp[..]).unwrap();
+        vs.copy_from(&tmp[..n]);
+        Ok(n)
+    }
+}
+
+impl WriteVolatile for TlsStream {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        vs: &VolatileSlice<B>,
+    ) -> std::result::Result<usize, VolatileMemoryError> {
+        let mut tmp = vec![0u8; vs.len()];
+        let n = vs.copy_to(&mut tmp[..]);
+        let n = Write::write(self, &tmp[..n]).unwrap();
+        Ok(n)
+    }
+}
+
+pub fn client_stream(
+    socket: TcpStream,
+    cert_dir: &Path,
+    hostname: &str,
+) -> std::result::Result<StreamOwned<ClientConnection, TcpStream>, MigratableError> {
+    let mut root_store = RootCertStore::empty();
+    root_store.add_parsable_certificates(
+        CertificateDer::pem_file_iter(cert_dir.join("ca-cert.pem"))
+            .expect("Cannot open CA file")
+            .map(|result| result.unwrap()),
+    );
+    let config = ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    let config = Arc::new(config);
+    let server_name =
+        ServerName::try_from(hostname.to_string()).map_err(TlsError::InvalidDnsName)?;
+    let conn = ClientConnection::new(config.clone(), server_name.clone())
+        .map_err(TlsError::RustlsError)?;
+
+    let mut tls = StreamOwned::new(conn, socket);
+    while tls.conn.is_handshaking() {
+        let (rd, wr) = tls
+            .conn
+            .complete_io(&mut tls.sock)
+            .map_err(TlsError::RustlsIoError)?;
+        if rd == 0 && wr == 0 {
+            Err(TlsError::HandshakeError(
+                "EOF during TLS handshake".to_string(),
+            ))?;
+        }
+    }
+
+    Ok(tls)
+}

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -35,6 +35,7 @@ pub mod http;
 
 use std::io;
 use std::num::NonZeroU32;
+use std::path::PathBuf;
 use std::sync::mpsc::{RecvError, SendError, Sender, channel};
 
 use micro_http::Body;
@@ -265,6 +266,9 @@ pub struct VmReceiveMigrationData {
     pub tcp_serial_url: Option<String>,
     /// Map with new network FDs on the new host.
     pub net_fds: Option<Vec<RestoredNetConfig>>,
+    /// Directory containing the TLS server certificate (server-cert.pem) and TLS server key (server-key.pem).
+    #[serde(default)]
+    pub tls_dir: Option<PathBuf>,
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug)]
@@ -287,6 +291,9 @@ pub struct VmSendMigrationData {
     /// The number of parallel connections for migration
     #[serde(default = "default_connections")]
     pub connections: NonZeroU32,
+    /// Directory containing the TLS root CA certificate (ca-cert.pem)
+    #[serde(default)]
+    pub tls_dir: Option<PathBuf>,
 }
 
 // Default value for downtime the same as qemu.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -58,7 +58,7 @@ use vm_memory::{
     VolatileMemoryError, VolatileSlice, WriteVolatile,
 };
 use vm_migration::protocol::*;
-use vm_migration::tls::{TlsConnectionWrapper, TlsStream};
+use vm_migration::tls::{TlsConnectionWrapper, TlsStream, TlsStreamWrapper};
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, tls,
 };
@@ -269,7 +269,7 @@ impl From<u64> for EpollDispatch {
 enum SocketStream {
     Unix(UnixStream),
     Tcp(TcpStream),
-    Tls(TlsStream),
+    Tls(Box<TlsStreamWrapper>),
 }
 
 impl Read for SocketStream {
@@ -925,7 +925,7 @@ impl ReceiveListener {
             }
             ReceiveListener::Tls(listener, conn) => listener.accept().map(|(socket, _)| {
                 conn.wrap(socket)
-                    .map(SocketStream::Tls)
+                    .map(|s| SocketStream::Tls(Box::new(s)))
                     .map_err(std::io::Error::other)
             })?,
         }
@@ -1408,7 +1408,9 @@ fn send_migration_socket(
                     .map(|(host, _)| host)
                     .unwrap_or(address),
             )?;
-            Ok(SocketStream::Tls(TlsStream::Client(tls_stream)))
+            Ok(SocketStream::Tls(Box::new(TlsStreamWrapper::new(
+                TlsStream::Client(tls_stream),
+            ))))
         }
     } else if let Some(path) = &send_data_migration.destination_url.strip_prefix("unix:") {
         info!("Connecting to UNIX socket at {:?}", path);

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -303,15 +303,6 @@ impl AsFd for SocketStream {
     }
 }
 
-impl AsRawFd for SocketStream {
-    fn as_raw_fd(&self) -> RawFd {
-        match self {
-            SocketStream::Unix(s) => s.as_raw_fd(),
-            SocketStream::Tcp(s) => s.as_raw_fd(),
-        }
-    }
-}
-
 impl ReadVolatile for SocketStream {
     fn read_volatile<B: BitmapSlice>(
         &mut self,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -59,6 +59,7 @@ use vm_memory::{
     VolatileMemoryError, VolatileSlice, WriteVolatile,
 };
 use vm_migration::protocol::*;
+use vm_migration::tls::{TlsConnectionWrapper, TlsStream};
 use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::unblock_signal;
@@ -267,6 +268,7 @@ impl From<u64> for EpollDispatch {
 enum SocketStream {
     Unix(UnixStream),
     Tcp(TcpStream),
+    Tls(TlsStream),
 }
 
 impl Read for SocketStream {
@@ -274,6 +276,7 @@ impl Read for SocketStream {
         match self {
             SocketStream::Unix(stream) => stream.read(buf),
             SocketStream::Tcp(stream) => stream.read(buf),
+            SocketStream::Tls(stream) => stream.read(buf),
         }
     }
 }
@@ -283,6 +286,7 @@ impl Write for SocketStream {
         match self {
             SocketStream::Unix(stream) => stream.write(buf),
             SocketStream::Tcp(stream) => stream.write(buf),
+            SocketStream::Tls(stream) => stream.write(buf),
         }
     }
 
@@ -290,6 +294,7 @@ impl Write for SocketStream {
         match self {
             SocketStream::Unix(stream) => stream.flush(),
             SocketStream::Tcp(stream) => stream.flush(),
+            SocketStream::Tls(stream) => stream.flush(),
         }
     }
 }
@@ -299,6 +304,7 @@ impl AsFd for SocketStream {
         match self {
             SocketStream::Unix(s) => s.as_fd(),
             SocketStream::Tcp(s) => s.as_fd(),
+            SocketStream::Tls(s) => s.as_fd(),
         }
     }
 }
@@ -311,6 +317,7 @@ impl ReadVolatile for SocketStream {
         match self {
             SocketStream::Unix(s) => s.read_volatile(buf),
             SocketStream::Tcp(s) => s.read_volatile(buf),
+            SocketStream::Tls(s) => s.read_volatile(buf),
         }
     }
 
@@ -321,6 +328,7 @@ impl ReadVolatile for SocketStream {
         match self {
             SocketStream::Unix(s) => s.read_exact_volatile(buf),
             SocketStream::Tcp(s) => s.read_exact_volatile(buf),
+            SocketStream::Tls(s) => s.read_exact_volatile(buf),
         }
     }
 }
@@ -333,6 +341,7 @@ impl WriteVolatile for SocketStream {
         match self {
             SocketStream::Unix(s) => s.write_volatile(buf),
             SocketStream::Tcp(s) => s.write_volatile(buf),
+            SocketStream::Tls(s) => s.write_volatile(buf),
         }
     }
 
@@ -343,6 +352,7 @@ impl WriteVolatile for SocketStream {
         match self {
             SocketStream::Unix(s) => s.write_all_volatile(buf),
             SocketStream::Tcp(s) => s.write_all_volatile(buf),
+            SocketStream::Tls(s) => s.write_all_volatile(buf),
         }
     }
 }
@@ -876,6 +886,7 @@ fn wait_for_readable(
 enum ReceiveListener {
     Tcp(TcpListener),
     Unix(UnixListener, Option<PathBuf>),
+    Tls(TcpListener, TlsConnectionWrapper),
 }
 
 impl AsFd for ReceiveListener {
@@ -883,6 +894,7 @@ impl AsFd for ReceiveListener {
         match self {
             ReceiveListener::Tcp(listener) => listener.as_fd(),
             ReceiveListener::Unix(listener, _) => listener.as_fd(),
+            ReceiveListener::Tls(listener, _) => listener.as_fd(),
         }
     }
 }
@@ -910,6 +922,11 @@ impl ReceiveListener {
 
                 Ok(socket)
             }
+            ReceiveListener::Tls(listener, conn) => listener.accept().map(|(socket, _)| {
+                conn.wrap(socket)
+                    .map(SocketStream::Tls)
+                    .map_err(std::io::Error::other)
+            })?,
         }
     }
 
@@ -929,6 +946,9 @@ impl ReceiveListener {
             ReceiveListener::Unix(listener, opt_path) => listener
                 .try_clone()
                 .map(|listener| ReceiveListener::Unix(listener, opt_path.clone())),
+            ReceiveListener::Tls(listener, conn) => listener
+                .try_clone()
+                .map(|listener| ReceiveListener::Tls(listener, conn.clone())),
         }
     }
 }
@@ -2165,6 +2185,11 @@ impl Vmm {
                     vm.send_memory_fds(unix_socket)?;
                 }
                 SocketStream::Tcp(_tcp_socket) => {
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "--local option is not supported with TCP sockets",
+                    )));
+                }
+                SocketStream::Tls(_tls_socket) => {
                     return Err(MigratableError::MigrateSend(anyhow!(
                         "--local option is not supported with TCP sockets",
                     )));

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -21,7 +21,6 @@ use std::collections::HashMap;
 use std::fs::File;
 use std::io::{ErrorKind, Read, Write, stdout};
 use std::net::{TcpListener, TcpStream};
-use std::num::NonZeroU32;
 use std::os::fd::{AsFd, BorrowedFd};
 use std::os::unix::io::{AsRawFd, FromRawFd, RawFd};
 use std::os::unix::net::{UnixListener, UnixStream};
@@ -60,7 +59,9 @@ use vm_memory::{
 };
 use vm_migration::protocol::*;
 use vm_migration::tls::{TlsConnectionWrapper, TlsStream};
-use vm_migration::{Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable};
+use vm_migration::{
+    Migratable, MigratableError, Pausable, Snapshot, Snapshottable, Transportable, tls,
+};
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::unblock_signal;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
@@ -1233,15 +1234,15 @@ impl SendAdditionalConnections {
     const CHUNK_SIZE: u64 = 64 /* MiB */ << 20;
 
     fn new(
-        destination: &str,
-        connections: NonZeroU32,
+        send_data_migration: &VmSendMigrationData,
         guest_mem: &GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> std::result::Result<Self, MigratableError> {
         let mut threads = Vec::new();
         let mut channels = Vec::new();
 
-        for n in 0..(connections.get() - 1) {
-            let socket = (match send_migration_socket(destination) {
+        let additional_connections = send_data_migration.connections.get() - 1;
+        for n in 0..(additional_connections) {
+            let socket = (match send_migration_socket(send_data_migration) {
                 Err(e) if n == 0 => {
                     // If we encounter a problem on the first additional
                     // connection, we just assume the other side doesn't support
@@ -1385,17 +1386,31 @@ impl Drop for SendAdditionalConnections {
 
 /// Establishes a connection to a migration destination socket (TCP or UNIX).
 fn send_migration_socket(
-    destination_url: &str,
+    send_data_migration: &VmSendMigrationData,
 ) -> std::result::Result<SocketStream, MigratableError> {
-    if let Some(address) = destination_url.strip_prefix("tcp:") {
+    if let Some(address) = send_data_migration.destination_url.strip_prefix("tcp:") {
         info!("Connecting to TCP socket at {}", address);
 
         let socket = TcpStream::connect(address).map_err(|e| {
             MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {}", e))
         })?;
 
-        Ok(SocketStream::Tcp(socket))
-    } else if let Some(path) = destination_url.strip_prefix("unix:") {
+        if send_data_migration.tls_dir.is_none() {
+            Ok(SocketStream::Tcp(socket))
+        } else {
+            info!("Live Migration will be encrypted using TLS.");
+            // The address may still contain a port. I think we should build something more robust to also handle IPv6.
+            let tls_stream = tls::client_stream(
+                socket,
+                send_data_migration.tls_dir.as_ref().unwrap(),
+                address
+                    .split_once(':')
+                    .map(|(host, _)| host)
+                    .unwrap_or(address),
+            )?;
+            Ok(SocketStream::Tls(TlsStream::Client(tls_stream)))
+        }
+    } else if let Some(path) = &send_data_migration.destination_url.strip_prefix("unix:") {
         info!("Connecting to UNIX socket at {:?}", path);
 
         let socket = UnixStream::connect(path).map_err(|e| {
@@ -1405,22 +1420,30 @@ fn send_migration_socket(
         Ok(SocketStream::Unix(socket))
     } else {
         Err(MigratableError::MigrateSend(anyhow!(
-            "Invalid destination: {destination_url}"
+            "Invalid destination: {}",
+            send_data_migration.destination_url
         )))
     }
 }
 
 /// Creates a listener socket for receiving incoming migration connections (TCP or UNIX).
 fn receive_migration_listener(
-    receiver_url: &str,
+    receiver_data_migration: &VmReceiveMigrationData,
 ) -> std::result::Result<ReceiveListener, MigratableError> {
-    if let Some(address) = receiver_url.strip_prefix("tcp:") {
-        TcpListener::bind(address)
-            .map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error binding to TCP socket: {}", e))
-            })
-            .map(ReceiveListener::Tcp)
-    } else if let Some(path) = receiver_url.strip_prefix("unix:") {
+    if let Some(address) = receiver_data_migration.receiver_url.strip_prefix("tcp:") {
+        let listener = TcpListener::bind(address).map_err(|e| {
+            MigratableError::MigrateReceive(anyhow!("Error binding to TCP socket: {}", e))
+        })?;
+
+        if receiver_data_migration.tls_dir.is_none() {
+            Ok(ReceiveListener::Tcp(listener))
+        } else {
+            Ok(ReceiveListener::Tls(
+                listener,
+                TlsConnectionWrapper::new(receiver_data_migration.tls_dir.as_ref().unwrap()),
+            ))
+        }
+    } else if let Some(path) = receiver_data_migration.receiver_url.strip_prefix("unix:") {
         UnixListener::bind(path)
             .map_err(|e| {
                 MigratableError::MigrateReceive(anyhow!("Error binding to UNIX socket: {}", e))
@@ -1428,7 +1451,8 @@ fn receive_migration_listener(
             .map(|listener| ReceiveListener::Unix(listener, Some(path.into())))
     } else {
         Err(MigratableError::MigrateSend(anyhow!(
-            "Invalid source: {receiver_url}"
+            "Invalid source: {}",
+            receiver_data_migration.receiver_url
         )))
     }
 }
@@ -2055,11 +2079,7 @@ impl Vmm {
         s: &mut MigrationState,
         send_data_migration: &VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
-        let mem_send = SendAdditionalConnections::new(
-            &send_data_migration.destination_url,
-            send_data_migration.connections,
-            &vm.guest_memory(),
-        )?;
+        let mem_send = SendAdditionalConnections::new(send_data_migration, &vm.guest_memory())?;
 
         // Start logging dirty pages
         vm.start_dirty_log()?;
@@ -2140,7 +2160,7 @@ impl Vmm {
         let mut s = MigrationState::new();
 
         // Set up the socket connection
-        let mut socket = send_migration_socket(&send_data_migration.destination_url)?;
+        let mut socket = send_migration_socket(&send_data_migration)?;
 
         // Start the migration
         Request::start().write_to(&mut socket)?;
@@ -3319,7 +3339,7 @@ impl RequestHandler for Vmm {
             receive_data_migration.receiver_url, &receive_data_migration.net_fds
         );
 
-        let mut listener = receive_migration_listener(&receive_data_migration.receiver_url)?;
+        let mut listener = receive_migration_listener(&receive_data_migration)?;
         // Accept the connection and get the socket
         let mut socket = listener.accept().map_err(|e| {
             warn!("Failed to accept migration connection: {}", e);


### PR DESCRIPTION
This MR adds the possibility to encrypt the live migration with TLS.

I added new TLS variants to the `SocketStream` and `ReceiveListener`, so it should be more or less transparent. To enable the TLS encryption, the necessary parameters must be provided via `send-migration` and `receive-migration`.

I took inspiration from Qemu (https://www.qemu.org/docs/master/system/tls.html). `send-migration` and `receive-migration` both expect a path to a directory that contains the necessary certificates and keys. The names of the certificates and keys are hard coded. The TLS client (the side that does a `send-migration`) expects a `ca-cert.pem` file in the directory; the TLS server expects a `server-cert.pem` and a `server-key.pem`.

I tested everything using our libvirt-tests and it worked (although I did not verify that the data was really encrypted, so far I trust rustls).

## Todo

- [ ] update documentation
