### PR TITLE
Support for live disk resizing

### DIFF
--- a/block/src/async_io.rs
+++ b/block/src/async_io.rs
@@ -18,6 +18,14 @@ pub enum DiskFileError {
     /// Failed creating a new AsyncIo.
     #[error("Failed creating a new AsyncIo")]
     NewAsyncIo(#[source] std::io::Error),
+
+    /// Unsupported operation.
+    #[error("Unsupported operation")]
+    Unsupported,
+
+    /// Resize failed
+    #[error("Resize failed")]
+    ResizeError,
 }
 
 pub type DiskFileResult<T> = std::result::Result<T, DiskFileError>;
@@ -61,6 +69,8 @@ pub trait DiskFile: Send {
     fn topology(&mut self) -> DiskTopology {
         DiskTopology::default()
     }
+    fn resize(&mut self, size: u64) -> DiskFileResult<()>;
+
     /// Returns the file descriptor of the underlying disk image file.
     ///
     /// The file descriptor is supposed to be used for `fcntl()` calls but no

--- a/block/src/fixed_vhd_async.rs
+++ b/block/src/fixed_vhd_async.rs
@@ -34,6 +34,10 @@ impl DiskFile for FixedVhdDiskAsync {
         ) as Box<dyn AsyncIo>)
     }
 
+    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
+        Err(DiskFileError::Unsupported)
+    }
+
     fn fd(&mut self) -> BorrowedDiskFd<'_> {
         BorrowedDiskFd::new(self.0.as_raw_fd())
     }

--- a/block/src/fixed_vhd_sync.rs
+++ b/block/src/fixed_vhd_sync.rs
@@ -34,6 +34,10 @@ impl DiskFile for FixedVhdDiskSync {
         ) as Box<dyn AsyncIo>)
     }
 
+    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
+        Err(DiskFileError::Unsupported)
+    }
+
     fn fd(&mut self) -> BorrowedDiskFd<'_> {
         BorrowedDiskFd::new(self.0.as_raw_fd())
     }

--- a/block/src/qcow_sync.rs
+++ b/block/src/qcow_sync.rs
@@ -41,6 +41,9 @@ impl DiskFile for QcowDiskSync {
     fn fd(&mut self) -> BorrowedDiskFd<'_> {
         BorrowedDiskFd::new(self.qcow_file.as_raw_fd())
     }
+    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
+        Err(DiskFileError::Unsupported)
+    }
 }
 
 pub struct QcowSync {

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -47,6 +47,10 @@ impl DiskFile for RawFileDisk {
         }
     }
 
+    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
+        Err(DiskFileError::Unsupported)
+    }
+
     fn fd(&mut self) -> BorrowedDiskFd<'_> {
         BorrowedDiskFd::new(self.file.as_raw_fd())
     }

--- a/block/src/raw_async.rs
+++ b/block/src/raw_async.rs
@@ -47,8 +47,17 @@ impl DiskFile for RawFileDisk {
         }
     }
 
-    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
-        Err(DiskFileError::Unsupported)
+    fn resize(&mut self, size: u64) -> DiskFileResult<()> {
+        let borrowed_fd = self.fd();
+        let raw_fd = borrowed_fd.as_raw_fd();
+
+        // SAFETY: FFI call into libc, trivially safe
+        let rc = unsafe { libc::ftruncate(raw_fd, size as libc::off_t) };
+        if rc == 0 {
+            Ok(())
+        } else {
+            Err(DiskFileError::ResizeError)
+        }
     }
 
     fn fd(&mut self) -> BorrowedDiskFd<'_> {

--- a/block/src/raw_async_aio.rs
+++ b/block/src/raw_async_aio.rs
@@ -50,6 +50,10 @@ impl DiskFile for RawFileDiskAio {
         }
     }
 
+    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
+        Err(DiskFileError::Unsupported)
+    }
+
     fn fd(&mut self) -> BorrowedDiskFd<'_> {
         BorrowedDiskFd::new(self.file.as_raw_fd())
     }

--- a/block/src/raw_sync.rs
+++ b/block/src/raw_sync.rs
@@ -47,6 +47,10 @@ impl DiskFile for RawFileDiskSync {
     fn fd(&mut self) -> BorrowedDiskFd<'_> {
         BorrowedDiskFd::new(self.file.as_raw_fd())
     }
+
+    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
+        Err(DiskFileError::Unsupported)
+    }
 }
 
 pub struct RawFileSync {

--- a/block/src/vhdx_sync.rs
+++ b/block/src/vhdx_sync.rs
@@ -38,6 +38,10 @@ impl DiskFile for VhdxDiskSync {
         )
     }
 
+    fn resize(&mut self, _size: u64) -> DiskFileResult<()> {
+        Err(DiskFileError::Unsupported)
+    }
+
     fn fd(&mut self) -> BorrowedDiskFd<'_> {
         BorrowedDiskFd::new(self.vhdx_file.as_raw_fd())
     }

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -320,6 +320,22 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
             )?;
             simple_api_command(socket, "PUT", "resize", Some(&resize)).map_err(Error::HttpApiClient)
         }
+        Some("resize-disk") => {
+            let resize_disk = resize_disk_config(
+                matches
+                    .subcommand_matches("resize-disk")
+                    .unwrap()
+                    .get_one::<String>("disk")
+                    .unwrap(),
+                matches
+                    .subcommand_matches("resize-disk")
+                    .unwrap()
+                    .get_one::<String>("size")
+                    .unwrap(),
+            )?;
+            simple_api_command(socket, "PUT", "resize-disk", Some(&resize_disk))
+                .map_err(Error::HttpApiClient)
+        }
         Some("resize-zone") => {
             let resize_zone = resize_zone_config(
                 matches
@@ -782,6 +798,18 @@ fn resize_config(
     Ok(serde_json::to_string(&resize).unwrap())
 }
 
+fn resize_disk_config(id: &str, size: &str) -> Result<String, Error> {
+    let resize_zone = vmm::api::VmResizeDiskData {
+        id: id.to_owned(),
+        desired_size: size
+            .parse::<ByteSized>()
+            .map_err(Error::InvalidMemorySize)?
+            .0,
+    };
+
+    Ok(serde_json::to_string(&resize_zone).unwrap())
+}
+
 fn resize_zone_config(id: &str, size: &str) -> Result<String, Error> {
     let resize_zone = vmm::api::VmResizeZoneData {
         id: id.to_owned(),
@@ -1048,6 +1076,20 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
                 Arg::new("memory")
                     .long("memory")
                     .help("New memory size in bytes (supports K/M/G suffix)")
+                    .num_args(1),
+            ),
+        Command::new("resize-disk")
+            .about("grows/shrinks an attached disk")
+            .arg(
+                Arg::new("disk")
+                    .long("disk")
+                    .help("disk identifier")
+                    .num_args(1),
+            )
+            .arg(
+                Arg::new("size")
+                    .long("size")
+                    .help("new disk size")
                     .num_args(1),
             ),
         Command::new("resize-zone")

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -135,7 +135,7 @@ struct BlockEpollHandler {
     queue: Queue,
     mem: GuestMemoryAtomic<GuestMemoryMmap>,
     disk_image: Box<dyn AsyncIo>,
-    disk_nsectors: u64,
+    disk_nsectors: Arc<AtomicU64>,
     interrupt_cb: Arc<dyn VirtioInterrupt>,
     serial: Vec<u8>,
     kill_evt: EventFd,
@@ -230,7 +230,7 @@ impl BlockEpollHandler {
 
             let result = request.execute_async(
                 desc_chain.memory(),
-                self.disk_nsectors,
+                self.disk_nsectors.load(Ordering::SeqCst),
                 self.disk_image.as_mut(),
                 &self.serial,
                 desc_chain.head_index() as u64,
@@ -631,7 +631,7 @@ pub struct Block {
     id: String,
     disk_image: Box<dyn DiskFile>,
     disk_path: PathBuf,
-    disk_nsectors: u64,
+    disk_nsectors: Arc<AtomicU64>,
     config: VirtioBlockConfig,
     writeback: Arc<AtomicBool>,
     counters: BlockCounters,
@@ -762,7 +762,7 @@ impl Block {
             id,
             disk_image,
             disk_path,
-            disk_nsectors,
+            disk_nsectors: Arc::new(AtomicU64::new(disk_nsectors)),
             config,
             writeback: Arc::new(AtomicBool::new(true)),
             counters: BlockCounters::default(),
@@ -852,7 +852,7 @@ impl Block {
     fn state(&self) -> BlockState {
         BlockState {
             disk_path: self.disk_path.to_str().unwrap().to_owned(),
-            disk_nsectors: self.disk_nsectors,
+            disk_nsectors: self.disk_nsectors.load(Ordering::SeqCst),
             avail_features: self.common.avail_features,
             acked_features: self.common.acked_features,
             config: self.config,
@@ -966,7 +966,7 @@ impl VirtioDevice for Block {
                         error!("failed to create new AsyncIo: {}", e);
                         ActivateError::BadActivate
                     })?,
-                disk_nsectors: self.disk_nsectors,
+                disk_nsectors: self.disk_nsectors.clone(),
                 interrupt_cb: interrupt_cb.clone(),
                 serial: self.serial.clone(),
                 kill_evt,

--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, Barrier};
 use std::{io, result};
 
 use anyhow::anyhow;
-use block::async_io::{AsyncIo, AsyncIoError, DiskFile};
+use block::async_io::{AsyncIo, AsyncIoError, DiskFile, DiskFileError};
 use block::fcntl::{LockError, LockGranularity, LockType, get_lock_state};
 use block::{
     ExecuteAsync, ExecuteError, Request, RequestType, VirtioBlockConfig, build_serial, fcntl,
@@ -93,6 +93,14 @@ pub enum Error {
         /// The path of the disk image.
         path: PathBuf,
     },
+    #[error("disk image size is not a multiple of {}", SECTOR_SIZE)]
+    InvalidSize,
+    #[error("Failed to pause/resume vcpus")]
+    FailedPauseResume(#[source] MigratableError),
+    #[error("Failed signal config interrupt")]
+    FailedSignalingConfigChange(#[source] io::Error),
+    #[error("Disk resize failed")]
+    FailedDiskResize(#[source] DiskFileError),
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -877,6 +885,34 @@ impl Block {
             }
         );
         self.writeback.store(writeback, Ordering::Release);
+    }
+
+    pub fn resize(&mut self, new_size: u64) -> Result<()> {
+        if !new_size.is_multiple_of(SECTOR_SIZE) {
+            return Err(Error::InvalidSize);
+        }
+
+        self.disk_image
+            .resize(new_size)
+            .map_err(Error::FailedDiskResize)?;
+
+        let nsectors = new_size / SECTOR_SIZE;
+
+        self.common.pause().map_err(Error::FailedPauseResume)?;
+
+        self.disk_nsectors.store(nsectors, Ordering::SeqCst);
+        self.config.capacity = nsectors;
+        self.state().disk_nsectors = nsectors;
+
+        self.common.resume().map_err(Error::FailedPauseResume)?;
+
+        if let Some(interrupt_cb) = self.common.interrupt_cb.as_ref() {
+            interrupt_cb
+                .trigger(VirtioInterruptType::Config)
+                .map_err(Error::FailedSignalingConfigChange)
+        } else {
+            Ok(())
+        }
     }
 
     #[cfg(fuzzing)]

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -44,7 +44,7 @@ use crate::api::{
     AddDisk, ApiAction, ApiError, ApiRequest, NetConfig, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem,
     VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmConfig, VmCounters, VmDelete, VmNmi, VmPause,
     VmPowerButton, VmReboot, VmReceiveMigration, VmReceiveMigrationData, VmRemoveDevice, VmResize,
-    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
+    VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::config::{RestoreConfig, RestoredNetConfig};
 use crate::cpu::Error as CpuError;
@@ -227,6 +227,7 @@ vm_action_put_handler_body!(VmAddVdpa);
 vm_action_put_handler_body!(VmAddVsock);
 vm_action_put_handler_body!(VmAddUserDevice);
 vm_action_put_handler_body!(VmRemoveDevice);
+vm_action_put_handler_body!(VmResizeDisk);
 vm_action_put_handler_body!(VmResizeZone);
 vm_action_put_handler_body!(VmSnapshot);
 vm_action_put_handler_body!(VmSendMigration);

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -29,7 +29,7 @@ use crate::api::VmCoredump;
 use crate::api::{
     AddDisk, ApiError, ApiRequest, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem, VmAddUserDevice,
     VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmDelete, VmNmi, VmPause, VmPowerButton, VmReboot,
-    VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeZone, VmRestore, VmResume,
+    VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore, VmResume,
     VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::landlock::Landlock;
@@ -248,6 +248,10 @@ pub static HTTP_ROUTES: LazyLock<HttpRoutes> = LazyLock::new(|| {
     r.routes.insert(
         endpoint!("/vm.resize"),
         Box::new(VmActionHandler::new(&VmResize)),
+    );
+    r.routes.insert(
+        endpoint!("/vm.resize-disk"),
+        Box::new(VmActionHandler::new(&VmResizeDisk)),
     );
     r.routes.insert(
         endpoint!("/vm.resize-zone"),

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -330,6 +330,8 @@ pub trait RequestHandler {
 
     fn vm_resize_zone(&mut self, id: String, desired_ram: u64) -> Result<(), VmError>;
 
+    fn vm_resize_disk(&mut self, id: String, desired_size: u64) -> Result<(), VmError>;
+
     fn vm_add_device(&mut self, device_cfg: DeviceConfig) -> Result<Option<Vec<u8>>, VmError>;
 
     fn vm_add_user_device(

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -133,6 +133,10 @@ pub enum ApiError {
     #[error("The VM could not be resized")]
     VmResize(#[source] VmError),
 
+    /// The disk could not be resized.
+    #[error("The disk could not be resized")]
+    VmResizeDisk(#[source] VmError),
+
     /// The memory zone could not be resized.
     #[error("The memory zone could not be resized")]
     VmResizeZone(#[source] VmError),
@@ -220,6 +224,12 @@ pub struct VmResizeData {
     pub desired_vcpus: Option<u32>,
     pub desired_ram: Option<u64>,
     pub desired_balloon: Option<u64>,
+}
+
+#[derive(Clone, Deserialize, Serialize, Default, Debug)]
+pub struct VmResizeDiskData {
+    pub id: String,
+    pub desired_size: u64,
 }
 
 #[derive(Clone, Deserialize, Serialize, Default, Debug)]
@@ -1133,6 +1143,44 @@ impl ApiAction for VmResize {
                     resize_data.desired_balloon,
                 )
                 .map_err(ApiError::VmResize)
+                .map(|_| ApiResponsePayload::Empty);
+
+            response_sender
+                .send(response)
+                .map_err(VmmError::ApiResponseSend)?;
+
+            Ok(false)
+        })
+    }
+
+    fn send(
+        &self,
+        api_evt: EventFd,
+        api_sender: Sender<ApiRequest>,
+        data: Self::RequestBody,
+    ) -> ApiResult<Self::ResponseBody> {
+        get_response_body(self, api_evt, api_sender, data)
+    }
+}
+
+pub struct VmResizeDisk;
+
+impl ApiAction for VmResizeDisk {
+    type RequestBody = VmResizeDiskData;
+    type ResponseBody = Option<Body>;
+
+    fn request(
+        &self,
+        resize_disk_data: Self::RequestBody,
+        response_sender: Sender<ApiResponse>,
+    ) -> ApiRequest {
+        Box::new(move |vmm| {
+            info!("API request event: VmResizeDisk {:?}", resize_disk_data);
+            println!("xxxxxx");
+
+            let response = vmm
+                .vm_resize_disk(resize_disk_data.id, resize_disk_data.desired_size)
+                .map_err(ApiError::VmResizeDisk)
                 .map(|_| ApiResponsePayload::Empty);
 
             response_sender

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -667,6 +667,10 @@ pub enum DeviceManagerError {
     /// Error adding fw_cfg to bus.
     #[error("Error adding fw_cfg to bus")]
     ErrorAddingFwCfgToBus(#[source] vm_device::BusError),
+
+    /// Disk resizing failed.
+    #[error("Disk resize error")]
+    DiskResizeError(#[source] virtio_devices::block::Error),
 }
 
 pub type DeviceManagerResult<T> = result::Result<T, DeviceManagerError>;
@@ -4913,6 +4917,18 @@ impl DeviceManager {
         }
 
         0
+    }
+
+    pub fn resize_disk(&mut self, device_id: &str, new_size: u64) -> DeviceManagerResult<()> {
+        for dev in &self.block_devices {
+            let mut disk = dev.lock().unwrap();
+            if disk.id() == device_id {
+                return disk
+                    .resize(new_size)
+                    .map_err(DeviceManagerError::DiskResizeError);
+            }
+        }
+        Err(DeviceManagerError::UnknownDeviceId(device_id.to_string()))
     }
 
     pub fn device_tree(&self) -> Arc<Mutex<DeviceTree>> {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2221,6 +2221,15 @@ impl RequestHandler for Vmm {
         }
     }
 
+    fn vm_resize_disk(&mut self, id: String, desired_size: u64) -> result::Result<(), VmError> {
+        self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
+
+        if let Some(ref mut vm) = self.vm {
+            return vm.resize_disk(id, desired_size);
+        }
+
+        Err(VmError::ResizeDisk)
+    }
     fn vm_resize_zone(&mut self, id: String, desired_ram: u64) -> result::Result<(), VmError> {
         self.vm_config.as_ref().ok_or(VmError::VmNotCreated)?;
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -245,6 +245,9 @@ pub enum Error {
     #[error("Failed resizing a memory zone")]
     ResizeZone,
 
+    #[error("Failed resizing a disk image")]
+    ResizeDisk,
+
     #[error("Cannot activate virtio devices")]
     ActivateVirtioDevices(#[source] DeviceManagerError),
 
@@ -1757,6 +1760,16 @@ impl Vm {
         }
 
         event!("vm", "resized");
+
+        Ok(())
+    }
+
+    pub fn resize_disk(&mut self, id: String, desired_size: u64) -> Result<()> {
+        self.device_manager
+            .lock()
+            .unwrap()
+            .resize_disk(&id, desired_size)
+            .map_err(Error::DeviceManager)?;
 
         Ok(())
     }


### PR DESCRIPTION
This MR adds support for live disk resizing for RAW images using `io_uring` Disk resizing is supported via `ch-remote` and REST API.