### PR TITLE
vmm: switch log level (not an error)

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -972,7 +972,7 @@ impl Vmm {
                         for net_config in vm_config.net.iter_mut().flatten() {
                             // update only if the net dev is backed by FDs
                             if net_config.id.as_ref() == Some(&net.id) && net_config.fds.is_some() {
-                                log::error!(
+                                log::debug!(
                                     "overwriting net fds: id={}, old={:?}, new={:?}",
                                     net.id,
                                     &net_config.fds,


### PR DESCRIPTION
Accidentally introduced by 530ebab2a7a0d3486948facbdbf4e50386d610bf