### PR TITLE
backport of QoL Improvements (cargo test, cargo clippy)

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -30,40 +30,40 @@ jobs:
           target: ${{ matrix.target }}
 
       - name: Build (default features)
-        run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor -- -D warnings
 
       - name: Build (kvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "kvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "kvm"  -- -D warnings
 
       - name: Build (default features + tdx)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --features "tdx" -- -D warnings
 
       - name: Build (default features + dbus_api)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "dbus_api" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --features "dbus_api" -- -D warnings
 
       - name: Build (default features + guest_debug)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "guest_debug" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --features "guest_debug" -- -D warnings
 
       - name: Build (default features + pvmemcontrol)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "pvmemcontrol" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --features "pvmemcontrol" -- -D warnings
 
       - name: Build (default features + fw_cfg)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "fw_cfg" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --features "fw_cfg" -- -D warnings
 
       - name: Build (default features + ivshmem)
-        run: cargo rustc --locked --bin cloud-hypervisor --features "ivshmem" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --features "ivshmem" -- -D warnings
 
       - name: Build (mshv)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv"  -- -D warnings
 
       - name: Build (sev_snp)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "sev_snp"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "sev_snp"  -- -D warnings
 
       - name: Build (igvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "igvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "igvm"  -- -D warnings
 
       - name: Build (mshv + kvm)
-        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv,kvm"  -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+        run: cargo rustc --locked --bin cloud-hypervisor --no-default-features --features "mshv,kvm"  -- -D warnings
 
       - name: Release Build (default features)
         run: cargo build --locked --all --release --target=${{ matrix.target }}

--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -50,7 +50,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --no-default-features --tests --examples --features "kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --no-default-features --tests --examples --features "kvm" -- -D warnings
 
       - name: Clippy (mshv)
         uses: houseabsolute/actions-rust-cross@v1
@@ -59,7 +59,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --no-default-features --tests --examples --features "mshv" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --no-default-features --tests --examples --features "mshv" -- -D warnings
 
       - name: Clippy (mshv + kvm)
         uses: houseabsolute/actions-rust-cross@v1
@@ -68,7 +68,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --no-default-features --tests --examples --features "mshv,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --no-default-features --tests --examples --features "mshv,kvm" -- -D warnings
 
       - name: Clippy (default features)
         uses: houseabsolute/actions-rust-cross@v1
@@ -77,7 +77,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --tests --examples -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --tests --examples -- -D warnings
 
       - name: Clippy (default features + guest_debug)
         uses: houseabsolute/actions-rust-cross@v1
@@ -86,7 +86,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --tests --examples --features "guest_debug" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --tests --examples --features "guest_debug" -- -D warnings
 
       - name: Clippy (default features + pvmemcontrol)
         uses: houseabsolute/actions-rust-cross@v1
@@ -95,7 +95,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --tests --examples --features "pvmemcontrol" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --tests --examples --features "pvmemcontrol" -- -D warnings
 
       - name: Clippy (default features + tracing)
         uses: houseabsolute/actions-rust-cross@v1
@@ -104,13 +104,13 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --tests --examples --features "tracing" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --tests --examples --features "tracing" -- -D warnings
       - name: Clippy (default features + fw_cfg)
         uses: actions-rs/cargo@v1
         with:
           use-cross: ${{ matrix.target != 'x86_64-unknown-linux-gnu' }}
           command: clippy
-          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "fw_cfg" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --target=${{ matrix.target }} --locked --all --all-targets --tests --examples --features "fw_cfg" -- -D warnings
 
       - name: Clippy (default features + ivshmem)
         uses: houseabsolute/actions-rust-cross@v1
@@ -119,7 +119,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --tests --examples --features "ivshmem" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --tests --examples --features "ivshmem" -- -D warnings
 
       - name: Clippy (sev_snp)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
@@ -129,7 +129,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --no-default-features --tests --examples --features "sev_snp" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --no-default-features --tests --examples --features "sev_snp" -- -D warnings
 
       - name: Clippy (igvm)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
@@ -139,7 +139,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --no-default-features --tests --examples --features "igvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --no-default-features --tests --examples --features "igvm" -- -D warnings
 
       - name: Clippy (kvm + tdx)
         if: ${{ matrix.target == 'x86_64-unknown-linux-gnu' }}
@@ -149,7 +149,7 @@ jobs:
           cross-version: 3e0957637b49b1bbced23ad909170650c5b70635
           toolchain: ${{ matrix.rust }}
           target: ${{ matrix.target }}
-          args: --locked --all --all-targets --no-default-features --tests --examples --features "tdx,kvm" -- -D warnings -D clippy::undocumented_unsafe_blocks -W clippy::assertions_on_result_states
+          args: --locked --all --all-targets --no-default-features --tests --examples --features "tdx,kvm" -- -D warnings
 
       - name: Check build did not modify any files
         run: test -z "$(git status --porcelain)"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -168,3 +168,7 @@ thiserror = "2.0.12"
 uuid = { version = "1.18.1" }
 wait-timeout = "0.2.1"
 zerocopy = { version = "0.8.26", default-features = false }
+
+[workspace.lints.rust]
+# `level = warn` is irrelevant here but mandatory for rustc/cargo
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(devcli_testenv)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,7 +177,17 @@ zerocopy = { version = "0.8.26", default-features = false }
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(devcli_testenv)'] }
 
 [workspace.lints.clippy]
-# Any clippy lint in alphabetical order, including lint groups:
+# Any clippy lint (group) in alphabetical order:
 # https://rust-lang.github.io/rust-clippy/master/index.html
+
+# Groups
+all = "deny"         # shorthand for the other groups but here for compleness
+complexity = "deny"
+correctness = "deny"
+perf = "deny"
+style = "deny"
+suspicious = "deny"
+
+# Individual Lints
 assertions_on_result_states = "deny"
 undocumented_unsafe_blocks = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,9 @@ sev_snp = ["igvm", "mshv", "vmm/sev_snp"]
 tdx = ["vmm/tdx"]
 tracing = ["tracer/tracing", "vmm/tracing"]
 
+[lints]
+workspace = true
+
 [workspace]
 members = [
   "api_client",
@@ -172,3 +175,9 @@ zerocopy = { version = "0.8.26", default-features = false }
 [workspace.lints.rust]
 # `level = warn` is irrelevant here but mandatory for rustc/cargo
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(devcli_testenv)'] }
+
+[workspace.lints.clippy]
+# Any clippy lint in alphabetical order, including lint groups:
+# https://rust-lang.github.io/rust-clippy/master/index.html
+assertions_on_result_states = "deny"
+undocumented_unsafe_blocks = "deny"

--- a/api_client/Cargo.toml
+++ b/api_client/Cargo.toml
@@ -7,3 +7,6 @@ version = "0.1.0"
 [dependencies]
 thiserror = { workspace = true }
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -27,3 +27,6 @@ vmm-sys-util = { workspace = true, features = ["with-serde"] }
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 fdt_parser = { version = "0.1.5", package = "fdt" }
 vm-fdt = { workspace = true }
+
+[lints]
+workspace = true

--- a/block/Cargo.toml
+++ b/block/Cargo.toml
@@ -28,3 +28,6 @@ vm-memory = { workspace = true, features = [
 ] }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -48,3 +48,6 @@ fw_cfg = ["arch/fw_cfg", "bitfield-struct", "linux-loader", "zerocopy"]
 ivshmem = []
 kvm = ["arch/kvm"]
 pvmemcontrol = []
+
+[lints]
+workspace = true

--- a/event_monitor/Cargo.toml
+++ b/event_monitor/Cargo.toml
@@ -9,3 +9,6 @@ flume = { workspace = true }
 libc = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -63,3 +63,6 @@ version = "1.21.0"
 
 [dev-dependencies]
 env_logger = { workspace = true }
+
+[lints]
+workspace = true

--- a/net_gen/Cargo.toml
+++ b/net_gen/Cargo.toml
@@ -7,3 +7,6 @@ version = "0.1.0"
 
 [dependencies]
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/net_util/Cargo.toml
+++ b/net_util/Cargo.toml
@@ -27,3 +27,6 @@ vmm-sys-util = { workspace = true }
 pnet = "0.35.0"
 pnet_datalink = "0.35.0"
 serde_json = { workspace = true }
+
+[lints]
+workspace = true

--- a/net_util/src/tap.rs
+++ b/net_util/src/tap.rs
@@ -563,6 +563,7 @@ impl AsRawFd for Tap {
 }
 
 #[cfg(test)]
+#[cfg(devcli_testenv)] // we need special permissions in the ENV to create Tap devices
 mod tests {
     use std::net::Ipv4Addr;
     use std::sync::{LazyLock, Mutex, mpsc};

--- a/option_parser/Cargo.toml
+++ b/option_parser/Cargo.toml
@@ -6,3 +6,6 @@ version = "0.1.0"
 
 [dependencies]
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/pci/Cargo.toml
+++ b/pci/Cargo.toml
@@ -29,3 +29,6 @@ vm-memory = { workspace = true, features = [
 ] }
 vm-migration = { path = "../vm-migration" }
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/performance-metrics/Cargo.toml
+++ b/performance-metrics/Cargo.toml
@@ -12,3 +12,6 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 test_infra = { path = "../test_infra" }
 thiserror = { workspace = true }
+
+[lints]
+workspace = true

--- a/rate_limiter/Cargo.toml
+++ b/rate_limiter/Cargo.toml
@@ -9,3 +9,6 @@ libc = { workspace = true }
 log = { workspace = true }
 thiserror = { workspace = true }
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/scripts/dev_cli.sh
+++ b/scripts/dev_cli.sh
@@ -47,6 +47,9 @@ CARGO_GIT_REGISTRY_DIR="${CLH_BUILD_DIR}/cargo_git_registry"
 # Full path to the cargo target dir on the host.
 CARGO_TARGET_DIR="${CLH_BUILD_DIR}/cargo_target"
 
+# Let tests know that the special environment is set up.
+RUSTFLAGS="${RUSTFLAGS} --cfg devcli_testenv"
+
 # Send a decorated message to stdout, followed by a new line
 #
 say() {

--- a/scripts/run_integration_tests_aarch64.sh
+++ b/scripts/run_integration_tests_aarch64.sh
@@ -190,7 +190,9 @@ if [ $RES -ne 0 ]; then
     exit 1
 fi
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
 
 cargo build --all --release --target "$BUILD_TARGET"
 

--- a/scripts/run_integration_tests_live_migration.sh
+++ b/scripts/run_integration_tests_live_migration.sh
@@ -83,7 +83,10 @@ PAGE_NUM=$((12288 * 1024 / HUGEPAGESIZE))
 echo "$PAGE_NUM" | sudo tee /proc/sys/vm/nr_hugepages
 sudo chmod a+rwX /dev/hugepages
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
+
 time cargo test $test_features "live_migration_parallel::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 

--- a/scripts/run_integration_tests_rate_limiter.sh
+++ b/scripts/run_integration_tests_rate_limiter.sh
@@ -55,7 +55,10 @@ fi
 
 cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
+
 time cargo test $test_features "rate_limiter::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
 RES=$?
 

--- a/scripts/run_integration_tests_vfio.sh
+++ b/scripts/run_integration_tests_vfio.sh
@@ -26,7 +26,10 @@ fi
 
 cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
+
 time cargo test "vfio::test_nvidia" -- --test-threads=1 ${test_binary_args[*]}
 RES=$?
 

--- a/scripts/run_integration_tests_windows_aarch64.sh
+++ b/scripts/run_integration_tests_windows_aarch64.sh
@@ -36,7 +36,9 @@ dmsetup mknodes
 dmsetup create windows-snapshot-base --table "0 $img_blk_size snapshot-origin /dev/mapper/windows-base"
 dmsetup mknodes
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
 
 cargo build --all --release --target "$BUILD_TARGET"
 

--- a/scripts/run_integration_tests_windows_x86_64.sh
+++ b/scripts/run_integration_tests_windows_x86_64.sh
@@ -41,7 +41,9 @@ dmsetup mknodes
 
 cargo build --features mshv --all --release --target "$BUILD_TARGET"
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
 
 # Only run with 1 thread to avoid tests interfering with one another because
 # Windows has a static IP configured

--- a/scripts/run_integration_tests_x86_64.sh
+++ b/scripts/run_integration_tests_x86_64.sh
@@ -177,14 +177,16 @@ ulimit -l unlimited
 # Set number of open descriptors high enough for VFIO tests to run
 ulimit -n 4096
 
+# Common configuration for every test run
 export RUST_BACKTRACE=1
+export RUSTFLAGS="$RUSTFLAGS"
+
 time cargo test --release --target "$BUILD_TARGET" $test_features "common_parallel::$test_filter" -- ${test_binary_args[*]}
 RES=$?
 
 # Run some tests in sequence since the result could be affected by other tests
 # running in parallel.
 if [ $RES -eq 0 ]; then
-    export RUST_BACKTRACE=1
     time cargo test --release --target "$BUILD_TARGET" $test_features "common_sequential::$test_filter" -- --test-threads=1 ${test_binary_args[*]}
     RES=$?
 fi
@@ -192,7 +194,6 @@ fi
 # Run tests on dbus_api
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,dbus_api" --all --release --target "$BUILD_TARGET"
-    export RUST_BACKTRACE=1
     # integration tests now do not reply on build feature "dbus_api"
     time cargo test $test_features "dbus_api::$test_filter" -- ${test_binary_args[*]}
     RES=$?
@@ -201,14 +202,12 @@ fi
 # Run tests on fw_cfg
 if [ $RES -eq 0 ]; then
     cargo build --features "mshv,fw_cfg" --all --release --target "$BUILD_TARGET"
-    export RUST_BACKTRACE=1
     time cargo test "fw_cfg::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
     RES=$?
 fi
 
 if [ $RES -eq 0 ]; then
     cargo build --features ivshmem --all --release --target "$BUILD_TARGET"
-    export RUST_BACKTRACE=1
     time cargo test $test_features "ivshmem::$test_filter" --target "$BUILD_TARGET" -- ${test_binary_args[*]}
     RES=$?
 fi

--- a/serial_buffer/Cargo.toml
+++ b/serial_buffer/Cargo.toml
@@ -3,3 +3,6 @@ authors = ["The Cloud Hypervisor Authors"]
 edition.workspace = true
 name = "serial_buffer"
 version = "0.1.0"
+
+[lints]
+workspace = true

--- a/test_infra/Cargo.toml
+++ b/test_infra/Cargo.toml
@@ -13,3 +13,6 @@ ssh2 = { version = "0.9.5", features = ["vendored-openssl"] }
 thiserror = { workspace = true }
 vmm-sys-util = { workspace = true }
 wait-timeout = { workspace = true }
+
+[lints]
+workspace = true

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 //
+#![cfg(devcli_testenv)]
 #![allow(clippy::undocumented_unsafe_blocks)]
 // When enabling the `mshv` feature, we skip quite some tests and
 // hence have known dead-code. This annotation silences dead-code

--- a/tpm/Cargo.toml
+++ b/tpm/Cargo.toml
@@ -12,3 +12,6 @@ log = { workspace = true }
 net_gen = { path = "../net_gen" }
 thiserror = { workspace = true }
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/tracer/Cargo.toml
+++ b/tracer/Cargo.toml
@@ -12,3 +12,6 @@ serde_json = { workspace = true }
 
 [features]
 tracing = []
+
+[lints]
+workspace = true

--- a/vhost_user_block/Cargo.toml
+++ b/vhost_user_block/Cargo.toml
@@ -19,3 +19,6 @@ virtio-bindings = { workspace = true }
 virtio-queue = { workspace = true }
 vm-memory = { workspace = true }
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/vhost_user_net/Cargo.toml
+++ b/vhost_user_net/Cargo.toml
@@ -19,3 +19,6 @@ vhost-user-backend = { workspace = true }
 virtio-bindings = { workspace = true }
 vm-memory = { workspace = true }
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -47,3 +47,6 @@ vm-memory = { workspace = true, features = [
 vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -14,3 +14,6 @@ vm-memory = { workspace = true }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]
 arch = { path = "../arch" }
+
+[lints]
+workspace = true

--- a/vm-device/Cargo.toml
+++ b/vm-device/Cargo.toml
@@ -16,3 +16,6 @@ thiserror = { workspace = true }
 vfio-ioctls = { workspace = true, default-features = false }
 vm-memory = { workspace = true, features = ["backend-mmap"] }
 vmm-sys-util = { workspace = true }
+
+[lints]
+workspace = true

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -11,3 +11,6 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 vm-memory = { workspace = true, features = ["backend-atomic", "backend-mmap"] }
+
+[lints]
+workspace = true

--- a/vm-virtio/Cargo.toml
+++ b/vm-virtio/Cargo.toml
@@ -14,3 +14,6 @@ vm-memory = { workspace = true, features = [
   "backend-bitmap",
   "backend-mmap",
 ] }
+
+[lints]
+workspace = true

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -96,3 +96,6 @@ vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { workspace = true, features = ["with-serde"] }
 zbus = { version = "5.7.1", optional = true }
 zerocopy = { workspace = true, features = ["alloc", "derive"] }
+
+[lints]
+workspace = true

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3236,7 +3236,8 @@ mod unit_tests {
             },
             console: ConsoleConfig {
                 file: None,
-                mode: ConsoleOutputMode::Tty,
+                // Caution: Don't use `Tty` to not mess with users terminal
+                mode: ConsoleOutputMode::Off,
                 iommu: false,
                 socket: None,
                 url: None,


### PR DESCRIPTION
This is a backport of **selected commits** of the latest QoL improvements (developer experience) from upstream:

- https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7487
- https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7482
- https://github.com/cloud-hypervisor/cloud-hypervisor/pull/7483

Once we have this, developers will be able to run

- `cargo clippy --workspace --features kvm` and
- `cargo test --workspace --features kvm`

for the first time ever - and it behaves as in CI.