### PR TITLE
Add Support for Migration Statistics API Call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -521,6 +521,7 @@ dependencies = [
  "tpm",
  "tracer",
  "vm-memory",
+ "vm-migration",
  "vmm",
  "vmm-sys-util",
  "wait-timeout",

--- a/cloud-hypervisor/Cargo.toml
+++ b/cloud-hypervisor/Cargo.toml
@@ -36,6 +36,7 @@ thiserror = { workspace = true }
 tpm = { path = "../tpm" }
 tracer = { path = "../tracer" }
 vm-memory = { workspace = true }
+vm-migration = { path = "../vm-migration" }
 vmm = { path = "../vmm" }
 vmm-sys-util = { workspace = true }
 zbus = { version = "5.7.1", optional = true }

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -13,15 +13,18 @@ use std::num::NonZeroU32;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use std::process;
+use std::thread::sleep;
+use std::time::Duration;
 
 use api_client::{
-    Error as ApiClientError, simple_api_command, simple_api_command_with_fds,
-    simple_api_full_command,
+    Error as ApiClientError, StatusCode, simple_api_command, simple_api_command_with_fds,
+    simple_api_full_command, simple_api_full_command_and_response,
 };
 use clap::{Arg, ArgAction, ArgMatches, Command};
-use log::error;
+use log::{error, info};
 use option_parser::{ByteSized, ByteSizedParseError};
 use thiserror::Error;
+use vm_migration::progress::{MigrationProgress, MigrationState};
 use vmm::config::RestoreConfig;
 use vmm::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, UserDeviceConfig, VdpaConfig,
@@ -491,6 +494,14 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                 .map_err(Error::HttpApiClient)
         }
         Some("send-migration") => {
+            let just_dispatch = matches
+                .subcommand_matches("send-migration")
+                .unwrap()
+                .get_one::<bool>("dispatch")
+                .cloned()
+                .unwrap_or(false);
+            let wait_for_migration = !just_dispatch;
+
             let send_migration_data = send_migration_data(
                 matches
                     .subcommand_matches("send-migration")
@@ -524,9 +535,69 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .unwrap()
                     .get_one::<PathBuf>("tls-dir")
                     .cloned(),
+                wait_for_migration,
             );
+
             simple_api_command(socket, "PUT", "send-migration", Some(&send_migration_data))
-                .map_err(Error::HttpApiClient)
+                .map_err(Error::HttpApiClient)?;
+
+            if !wait_for_migration {
+                return Ok(());
+            }
+            loop {
+                let response = simple_api_full_command_and_response(
+                    socket,
+                    "GET",
+                    "vm.migration-progress",
+                    None,
+                )
+                .map_err(Error::HttpApiClient)?
+                // should have response
+                .ok_or(Error::HttpApiClient(ApiClientError::ServerResponse(
+                    StatusCode::Ok,
+                    None,
+                )))?;
+
+                // This is guaranteed by the SendMigration call
+                assert_ne!(
+                    response, "null",
+                    "migration progress should be there immediately when the migration was dispatched"
+                );
+
+                let progress = serde_json::from_slice::<MigrationProgress>(response.as_bytes())
+                    .map_err(|e| {
+                        error!("failed to parse response as MigrationProgress: {e}");
+                        Error::HttpApiClient(ApiClientError::ServerResponse(
+                            StatusCode::Ok,
+                            Some(response),
+                        ))
+                    })?;
+
+                match progress.state {
+                    MigrationState::Cancelled { .. } => {
+                        info!("Migration was cancelled");
+                        break;
+                    }
+                    MigrationState::Failed {
+                        error_msg,
+                        error_msg_debug,
+                    } => {
+                        error!("Migration failed! {error_msg}\n{error_msg_debug}");
+                        break;
+                    }
+                    MigrationState::Finished { .. } => {
+                        info!("Migration finished successfully. Shutting down Cloud Hypervisor");
+                        simple_api_full_command(socket, "PUT", "vmm.shutdown", None)
+                            .map_err(Error::HttpApiClient)?;
+                        break;
+                    }
+                    MigrationState::Ongoing { .. } => {
+                        sleep(Duration::from_millis(50));
+                        continue;
+                    }
+                }
+            }
+            Ok(())
         }
         Some("receive-migration") => {
             let receive_migration_data = receive_migration_data(
@@ -966,6 +1037,7 @@ fn send_migration_data(
     migration_timeout: u64,
     connections: NonZeroU32,
     tls_dir: Option<PathBuf>,
+    keep_alive: bool,
 ) -> String {
     let send_migration_data = vmm::api::VmSendMigrationData {
         destination_url: url,
@@ -974,8 +1046,7 @@ fn send_migration_data(
         migration_timeout,
         connections,
         tls_dir,
-        // In next commit, we fix this properly.
-        keep_alive: false,
+        keep_alive,
     };
 
     serde_json::to_string(&send_migration_data).unwrap()
@@ -1165,6 +1236,12 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
                     .num_args(1)
                     .value_parser(clap::value_parser!(u32))
                     .default_value("1"),
+            )
+            .arg(
+                Arg::new("dispatch")
+                    .long("dispatch")
+                    .help("just dispatch the migration without waiting for it to finish")
+                    .num_args(0),
             )
             .arg(
                 Arg::new("downtime-ms")

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -303,6 +303,8 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
         Some("shutdown") => {
             simple_api_command(socket, "PUT", "shutdown", None).map_err(Error::HttpApiClient)
         }
+        Some("migration-progress") => simple_api_command(socket, "GET", "migration-progress", None)
+            .map_err(Error::HttpApiClient),
         Some("nmi") => simple_api_command(socket, "PUT", "nmi", None).map_err(Error::HttpApiClient),
         Some("resize") => {
             let resize = resize_config(
@@ -1073,6 +1075,7 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
             .arg(Arg::new("path").index(1).default_value("-")),
         Command::new("delete").about("Delete a VM"),
         Command::new("info").about("Info on the VM"),
+        Command::new("migration-progress"),
         Command::new("nmi").about("Trigger NMI"),
         Command::new("pause").about("Pause the VM"),
         Command::new("ping").about("Ping the VMM to check for API server availability"),

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -974,6 +974,8 @@ fn send_migration_data(
         migration_timeout,
         connections,
         tls_dir,
+        // In next commit, we fix this properly.
+        keep_alive: false,
     };
 
     serde_json::to_string(&send_migration_data).unwrap()

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -9,9 +9,11 @@ use thiserror::Error;
 
 use crate::protocol::MemoryRangeTable;
 
-mod bitpos_iterator;
+pub mod progress;
 pub mod protocol;
 pub mod tls;
+
+mod bitpos_iterator;
 
 #[derive(Error, Debug)]
 pub enum MigratableError {

--- a/vm-migration/src/progress.rs
+++ b/vm-migration/src/progress.rs
@@ -1,0 +1,564 @@
+// Copyright © 2025 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Module for reporting status and progress of live migrations.
+//!
+//! The main export is [`MigrationProgress`].
+//!
+//! # Motivation
+//!
+//! Monitoring a live-migration is important for debugging of cloud deployments,
+//! for cloud monitoring in general, and for network optimization, such as
+//! verifying the throughput for the migration is as high as expected.
+//!
+//! It also helps to analyze the downtime of VMs and see how much pressure a
+//! guest is putting on its memory (by writing), which is slowing down
+//! migrations.
+
+use std::error::Error;
+use std::fmt;
+use std::fmt::Display;
+use std::num::NonZeroU32;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[derive(
+    Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum TransportationMode {
+    Local,
+    Tcp { connections: NonZeroU32, tls: bool },
+}
+
+/// Carries information about the transmission of the VM's memory.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    PartialOrd,
+    Ord,
+    PartialEq,
+    Eq,
+    Hash,
+    serde::Serialize,
+    serde::Deserialize,
+)]
+pub struct MemoryTransmissionInfo {
+    /// The memory iteration (only in precopy mode).
+    pub memory_iteration: u64,
+    /// Memory bytes per second.
+    pub memory_transmission_bps: u64,
+    /// The total size of the VMs memory in bytes.
+    pub memory_bytes_total: u64,
+    /// The total size of transmitted bytes.
+    pub memory_bytes_transmitted: u64,
+    /// The amount of remaining bytes for this iteration.
+    pub memory_bytes_remaining_iteration: u64,
+    /// The amount of transmitted 4k pages.
+    pub memory_pages_4k_transmitted: u64,
+    /// The amount of remaining 4k pages for this iteration.
+    pub memory_pages_4k_remaining_iteration: u64,
+    /// The amount of constant pages for that we could take a shortcut.
+    /// Pages where all bits are either zero or one.
+    pub memory_pages_constant_count: u64,
+    /// Current memory dirty rate in pages per seconds (pps).
+    pub memory_dirty_rate_pps: u64,
+}
+
+/// The different phases of an ongoing ([`MigrationState::Ongoing`]) migration
+/// (good case).
+///
+/// The states correspond to the [live-migration protocol].
+///
+/// [live-migration protocol]: super::protocol
+#[derive(
+    Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum MigrationStateOngoingPhase {
+    /// The migration starts. Handshake and transfer of VM config.
+    Starting,
+    /// Transfer of memory FDs.
+    ///
+    /// Only used for local migrations.
+    MemoryFds,
+    /// Transfer of VM memory in precopy mode.
+    ///
+    /// Not used for local migrations.
+    MemoryPrecopy,
+    // TODO eventually add MemoryPostcopy here
+    /// The VM migration is completing. This means the last chunks of memory
+    /// are transmitted as well as the final VM state (vCPUs, devices).
+    Completing,
+}
+
+impl Display for MigrationStateOngoingPhase {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Starting => write!(f, "starting"),
+            Self::MemoryFds => write!(f, "memory FDs"),
+            Self::MemoryPrecopy => write!(f, "memory (precopy)"),
+            Self::Completing => write!(f, "completing"),
+        }
+    }
+}
+
+/// The different states of a migration, covering steady progress and failure.
+#[derive(
+    Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum MigrationState {
+    /// The migration has been cancelled.
+    Cancelled {},
+    /// The migration has failed.
+    Failed {
+        /// Stringified error.
+        error_msg: String,
+        /// Debug-stringified error.
+        error_msg_debug: String,
+        // TODO this is very tricky because I need clone()
+        // error: Box<dyn Error>,
+    },
+    /// The migration has finished successfully.
+    Finished {},
+    /// The migration is ongoing.
+    Ongoing {
+        phase: MigrationStateOngoingPhase,
+        /// Percent in range `0..=100`.
+        vcpu_throttle_percent: u8,
+    },
+}
+
+impl Display for MigrationState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MigrationState::Cancelled { .. } => write!(f, "{}", self.state_name()),
+            MigrationState::Failed { error_msg, .. } => {
+                write!(f, "{}: {error_msg}", self.state_name())
+            }
+            MigrationState::Finished { .. } => write!(f, "{}", self.state_name()),
+            MigrationState::Ongoing {
+                phase,
+                vcpu_throttle_percent,
+            } => write!(
+                f,
+                "{}: phase={phase}, vcpu_throttle={vcpu_throttle_percent}",
+                self.state_name()
+            ),
+        }
+    }
+}
+
+impl MigrationState {
+    fn state_name(&self) -> &'static str {
+        match self {
+            MigrationState::Cancelled { .. } => "cancelled",
+            MigrationState::Failed { .. } => "failed",
+            MigrationState::Finished { .. } => "finished",
+            MigrationState::Ongoing { .. } => "ongoing",
+        }
+    }
+}
+
+/// Returns the current UNIX timestamp in ms.
+fn current_unix_timestamp_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("should be valid duration")
+        .as_millis() as u64
+}
+
+/// Holds a snapshot of progress and status information for an ongoing live
+/// migration, or the last snapshot of a canceled or aborted migration.
+///
+/// This type carries insightful information for every step of the
+/// [live-migration protocol] in a way that makes it easy for API users to
+/// parse the data with ease while retaining all important information.
+///
+/// [live-migration protocol]: super::protocol
+#[derive(
+    Clone, Debug, PartialOrd, Ord, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub struct MigrationProgress {
+    /// UNIX timestamp of the start of the live-migration process in ms.
+    pub timestamp_begin_ms: u64,
+    /// UNIX timestamp of the current snapshot in ms.
+    pub timestamp_snapshot_ms: u64,
+    /// Relative timestamp since the beginning of the migration in ms.
+    pub timestamp_snapshot_relative_ms: u64,
+    /// Configured target downtime.
+    pub downtime_configured_ms: u64,
+    /// Currently estimated (computed) downtime given the remaining
+    /// transmissions and the bandwidth.
+    ///
+    /// If this is `0`, the downtime could not yet be calculated.
+    pub downtime_estimated_ms: u64,
+    /// Requested transportation mode.
+    pub transportation_mode: TransportationMode,
+    /// Snapshot of the current phase.
+    pub state: MigrationState,
+    /// Latest [`MemoryTransmissionInfo`] info, if any.
+    ///
+    /// The most interesting phase is when current state is
+    /// [`MigrationState::Ongoing`] and [`MigrationStateOngoingPhase::MemoryPrecopy`]
+    /// as this value will be updated frequently.
+    pub memory_transmission_info: MemoryTransmissionInfo,
+}
+
+impl MigrationProgress {
+    /// Creates new progress in a valid init state.
+    ///
+    /// This progress must be updated using any of:
+    /// - [`Self::update`]
+    /// - [`Self::mark_as_finished`]
+    /// - [`Self::mark_as_failed`]
+    /// - [`Self::mark_as_cancelled`]
+    pub fn new(transportation_mode: TransportationMode, target_downtime: Duration) -> Self {
+        let timestamp = current_unix_timestamp_ms();
+        Self {
+            timestamp_begin_ms: timestamp,
+            timestamp_snapshot_ms: timestamp,
+            timestamp_snapshot_relative_ms: 0,
+            downtime_configured_ms: target_downtime.as_millis() as u64,
+            downtime_estimated_ms: 0,
+            transportation_mode,
+            state: MigrationState::Ongoing {
+                phase: MigrationStateOngoingPhase::Starting,
+                vcpu_throttle_percent: 0,
+            },
+            memory_transmission_info: MemoryTransmissionInfo::default(),
+        }
+    }
+
+    /// Updates the state of an ongoing migration.
+    ///
+    /// Only updates new values that are provided via `Some`.
+    ///
+    /// # Arguments
+    ///
+    /// - `new_phase`: The current [`MigrationStateOngoingPhase`].
+    /// - `new_memory_transmission_info`: If `Some`, the current [`MemoryTransmissionInfo`].
+    /// - `new_cpu_throttle_percent`: If `Some`, the current value of the vCPU throttle percentage.
+    ///   Must be in range `0..=100`.
+    /// - `new_estimated_downtime`: If `Some`, the latest expected (calculated) downtime.
+    pub fn update(
+        &mut self,
+        new_phase: MigrationStateOngoingPhase,
+        new_memory_transmission_info: Option<MemoryTransmissionInfo>,
+        new_cpu_throttle_percent: Option<u8>,
+        new_estimated_downtime: Option<Duration>,
+    ) {
+        if let Some(percent) = new_cpu_throttle_percent {
+            assert!(percent <= 100);
+        }
+
+        if let Some(downtime) = new_estimated_downtime {
+            self.downtime_estimated_ms = u64::try_from(downtime.as_millis()).unwrap();
+        } else {
+            // This is better than showing `0` and it is likely close to the final actual downtime.
+            self.downtime_estimated_ms = self.downtime_configured_ms;
+        }
+
+        match &self.state {
+            MigrationState::Ongoing {
+                phase: _old_phase,
+                vcpu_throttle_percent: old_vcpu_throttle_percent,
+            } => {
+                self.timestamp_snapshot_ms = current_unix_timestamp_ms();
+                self.timestamp_snapshot_relative_ms =
+                    self.timestamp_snapshot_ms - self.timestamp_begin_ms;
+
+                self.memory_transmission_info =
+                    new_memory_transmission_info.unwrap_or(self.memory_transmission_info);
+                self.state = MigrationState::Ongoing {
+                    phase: new_phase,
+                    vcpu_throttle_percent: new_cpu_throttle_percent
+                        .unwrap_or(*old_vcpu_throttle_percent),
+                };
+            }
+            illegal => {
+                // panic is fine as we have a logic error here, nothing that was caused by a user.
+                panic!(
+                    "illegal state transition: {} -> ongoing",
+                    illegal.state_name(),
+                );
+            }
+        }
+    }
+
+    /// Sets the underlying state to [`MigrationState::Cancelled`] and
+    /// updates all corresponding metadata.
+    ///
+    /// After this state change, the object is supposed to be handled as immutable.
+    ///
+    /// # Panics
+    ///
+    /// If the current state is not [`MigrationState::Ongoing`], this function panics.
+    pub fn mark_as_cancelled(&mut self) {
+        if !matches!(self.state, MigrationState::Ongoing { .. }) {
+            panic!(
+                "illegal state transition: {} -> cancelled",
+                self.state.state_name()
+            );
+        }
+        self.timestamp_snapshot_ms = current_unix_timestamp_ms();
+        self.timestamp_snapshot_relative_ms = self.timestamp_snapshot_ms - self.timestamp_begin_ms;
+        self.state = MigrationState::Cancelled {};
+    }
+
+    /// Sets the underlying state to [`MigrationState::Failed`] and
+    /// updates all corresponding metadata.
+    ///
+    /// After this state change, the object is supposed to be handled as immutable.
+    ///
+    /// # Panics
+    ///
+    /// If the current state is not [`MigrationState::Ongoing`], this function panics.
+    pub fn mark_as_failed(&mut self, error: &dyn Error) {
+        if !matches!(self.state, MigrationState::Ongoing { .. }) {
+            panic!(
+                "illegal state transition: {} -> failed",
+                self.state.state_name()
+            );
+        }
+        self.timestamp_snapshot_ms = current_unix_timestamp_ms();
+        self.timestamp_snapshot_relative_ms = self.timestamp_snapshot_ms - self.timestamp_begin_ms;
+        self.state = MigrationState::Failed {
+            error_msg: format!("{error}",),
+            error_msg_debug: format!("{error:?}",),
+        };
+    }
+
+    /// Sets the underlying state to [`MigrationState::Finished`] and
+    /// updates all corresponding metadata.
+    ///
+    /// After this state change, the object is supposed to be handled as immutable.
+    ///
+    /// # Panics
+    ///
+    /// If the current state is not [`MigrationState::Ongoing`], this function panics.
+    pub fn mark_as_finished(&mut self) {
+        if !matches!(self.state, MigrationState::Ongoing { .. }) {
+            panic!(
+                "illegal state transition: {} -> finished",
+                self.state.state_name()
+            );
+        }
+        self.timestamp_snapshot_ms = current_unix_timestamp_ms();
+        self.timestamp_snapshot_relative_ms = self.timestamp_snapshot_ms - self.timestamp_begin_ms;
+        self.state = MigrationState::Finished {};
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::thread;
+
+    use super::*;
+
+    fn tcp_mode() -> TransportationMode {
+        TransportationMode::Tcp {
+            connections: NonZeroU32::new(2).unwrap(),
+            tls: true,
+        }
+    }
+
+    #[test]
+    fn new_initializes_valid_state() {
+        let target = Duration::from_millis(150);
+        let progress = MigrationProgress::new(tcp_mode(), target);
+
+        assert_eq!(progress.timestamp_snapshot_ms, progress.timestamp_begin_ms);
+        assert_eq!(progress.timestamp_snapshot_relative_ms, 0);
+        assert_eq!(progress.downtime_configured_ms, 150);
+        assert_eq!(progress.downtime_estimated_ms, 0);
+
+        match progress.state {
+            MigrationState::Ongoing {
+                phase,
+                vcpu_throttle_percent,
+            } => {
+                assert_eq!(phase, MigrationStateOngoingPhase::Starting);
+                assert_eq!(vcpu_throttle_percent, 0);
+            }
+            _ => panic!("expected Ongoing state"),
+        }
+
+        assert_eq!(
+            progress.memory_transmission_info,
+            MemoryTransmissionInfo::default()
+        );
+    }
+
+    #[test]
+    fn update_changes_phase_and_preserves_previous_values() {
+        let mut progress =
+            MigrationProgress::new(TransportationMode::Local, Duration::from_millis(200));
+
+        let initial_timestamp = progress.timestamp_snapshot_ms;
+
+        thread::sleep(Duration::from_millis(1));
+
+        progress.update(MigrationStateOngoingPhase::MemoryPrecopy, None, None, None);
+
+        match progress.state {
+            MigrationState::Ongoing {
+                phase,
+                vcpu_throttle_percent,
+            } => {
+                assert_eq!(phase, MigrationStateOngoingPhase::MemoryPrecopy);
+                assert_eq!(vcpu_throttle_percent, 0); // unchanged
+            }
+            _ => panic!("expected Ongoing"),
+        }
+
+        assert!(progress.timestamp_snapshot_ms >= initial_timestamp);
+        assert!(progress.timestamp_snapshot_relative_ms > 0);
+
+        // If no estimated downtime provided, fallback to configured value
+        assert_eq!(
+            progress.downtime_estimated_ms,
+            progress.downtime_configured_ms
+        );
+    }
+
+    #[test]
+    fn update_replaces_memory_info_and_throttle() {
+        let mut progress =
+            MigrationProgress::new(TransportationMode::Local, Duration::from_millis(100));
+
+        let mem = MemoryTransmissionInfo {
+            memory_iteration: 3,
+            memory_transmission_bps: 10_000,
+            memory_bytes_total: 1_000_000,
+            memory_bytes_transmitted: 400_000,
+            memory_bytes_remaining_iteration: 100_000,
+            memory_pages_4k_transmitted: 100,
+            memory_pages_4k_remaining_iteration: 25,
+            memory_pages_constant_count: 10,
+            memory_dirty_rate_pps: 500,
+        };
+
+        progress.update(
+            MigrationStateOngoingPhase::MemoryPrecopy,
+            Some(mem),
+            Some(42),
+            Some(Duration::from_millis(55)),
+        );
+
+        assert_eq!(progress.memory_transmission_info, mem);
+        assert_eq!(progress.downtime_estimated_ms, 55);
+
+        match progress.state {
+            MigrationState::Ongoing {
+                phase,
+                vcpu_throttle_percent,
+            } => {
+                assert_eq!(phase, MigrationStateOngoingPhase::MemoryPrecopy);
+                assert_eq!(vcpu_throttle_percent, 42);
+            }
+            _ => panic!("expected Ongoing"),
+        }
+    }
+
+    #[test]
+    #[should_panic]
+    fn update_panics_if_not_ongoing() {
+        let mut progress =
+            MigrationProgress::new(TransportationMode::Local, Duration::from_millis(10));
+        progress.mark_as_finished();
+
+        progress.update(MigrationStateOngoingPhase::Completing, None, None, None);
+    }
+
+    #[test]
+    #[should_panic]
+    fn throttle_above_100_panics() {
+        let mut progress =
+            MigrationProgress::new(TransportationMode::Local, Duration::from_millis(10));
+
+        progress.update(
+            MigrationStateOngoingPhase::MemoryPrecopy,
+            None,
+            Some(101),
+            None,
+        );
+    }
+
+    #[test]
+    fn mark_as_finished_transitions_state() {
+        let mut progress =
+            MigrationProgress::new(TransportationMode::Local, Duration::from_millis(10));
+
+        thread::sleep(Duration::from_millis(1));
+        progress.mark_as_finished();
+
+        match progress.state {
+            MigrationState::Finished {} => {}
+            _ => panic!("expected Finished"),
+        }
+
+        assert!(progress.timestamp_snapshot_relative_ms > 0);
+    }
+
+    #[test]
+    #[should_panic]
+    fn mark_as_finished_twice_panics() {
+        let mut progress =
+            MigrationProgress::new(TransportationMode::Local, Duration::from_millis(10));
+
+        progress.mark_as_finished();
+        progress.mark_as_finished();
+    }
+
+    #[test]
+    fn mark_as_failed_sets_error_strings() {
+        #[derive(Debug)]
+        struct TestError;
+
+        impl fmt::Display for TestError {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                write!(f, "test error")
+            }
+        }
+
+        impl Error for TestError {}
+
+        let mut progress =
+            MigrationProgress::new(TransportationMode::Local, Duration::from_millis(10));
+
+        progress.mark_as_failed(&TestError);
+
+        match &progress.state {
+            MigrationState::Failed {
+                error_msg,
+                error_msg_debug,
+            } => {
+                assert_eq!(error_msg, "test error");
+                assert!(error_msg_debug.contains("TestError"));
+            }
+            _ => panic!("expected Failed"),
+        }
+    }
+
+    #[test]
+    fn display_formats_are_stable() {
+        let mut progress =
+            MigrationProgress::new(TransportationMode::Local, Duration::from_millis(10));
+
+        progress.update(
+            MigrationStateOngoingPhase::MemoryPrecopy,
+            None,
+            Some(12),
+            None,
+        );
+
+        let s = format!("{}", progress.state);
+        assert!(s.contains("ongoing"));
+        assert!(s.contains("phase=memory (precopy)"));
+        assert!(s.contains("vcpu_throttle=12"));
+
+        progress.mark_as_cancelled();
+        assert_eq!(format!("{}", progress.state), "cancelled");
+    }
+}

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -35,22 +35,11 @@
 //! [special HTTP library]: https://github.com/firecracker-microvm/micro-http
 
 use std::fs::File;
-use std::sync::mpsc::{Receiver, Sender, SyncSender};
-use std::sync::{LazyLock, Mutex};
+use std::sync::mpsc::Sender;
 
 use log::info;
 use micro_http::{Body, Method, Request, Response, StatusCode, Version};
 use vmm_sys_util::eventfd::EventFd;
-
-/// Helper to make the VmSendMigration call blocking as long as a migration is ongoing.
-#[allow(clippy::type_complexity)]
-pub static ONGOING_LIVEMIGRATION: LazyLock<(
-    SyncSender<Result<(), vm_migration::MigratableError>>,
-    Mutex<Receiver<Result<(), vm_migration::MigratableError>>>,
-)> = LazyLock::new(|| {
-    let (sender, receiver) = std::sync::mpsc::sync_channel(0);
-    (sender, Mutex::new(receiver))
-});
 
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
 use crate::api::VmCoredump;
@@ -508,26 +497,15 @@ impl PutHandler for VmSendMigration {
         _files: Vec<File>,
     ) -> std::result::Result<Option<Body>, HttpError> {
         if let Some(body) = body {
-            let res = self
-                .send(
-                    api_notifier,
-                    api_sender,
-                    serde_json::from_slice(body.raw())?,
-                )
-                .map_err(HttpError::ApiError)?;
-
-            info!("live migration started");
-
-            let (_, receiver) = &*ONGOING_LIVEMIGRATION;
-
-            info!("waiting for live migration result");
-            let mig_res = receiver.lock().unwrap().recv().unwrap();
-            info!("received live migration result");
-
-            // We forward the migration error here to the guest
-            mig_res
-                .map(|_| res)
-                .map_err(|e| HttpError::ApiError(ApiError::VmSendMigration(e)))
+            self.send(
+                api_notifier,
+                api_sender,
+                serde_json::from_slice(body.raw())?,
+            )
+            .inspect(|_| {
+                info!("live migration started (in background)");
+            })
+            .map_err(HttpError::ApiError)
         } else {
             Err(HttpError::BadRequest)
         }

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -58,9 +58,10 @@ use crate::api::http::http_endpoint::fds_helper::{attach_fds_to_cfg, attach_fds_
 use crate::api::http::{EndpointHandler, HttpError, error_response};
 use crate::api::{
     AddDisk, ApiAction, ApiError, ApiRequest, NetConfig, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem,
-    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmConfig, VmCounters, VmDelete, VmNmi, VmPause,
-    VmPowerButton, VmReboot, VmReceiveMigration, VmReceiveMigrationData, VmRemoveDevice, VmResize,
-    VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
+    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmConfig, VmCounters, VmDelete,
+    VmMigrationProgress, VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration,
+    VmReceiveMigrationData, VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore,
+    VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::config::RestoreConfig;
 use crate::cpu::Error as CpuError;
@@ -703,6 +704,32 @@ impl EndpointHandler for VmmShutdown {
                     Err(e) => error_response(e, StatusCode::InternalServerError),
                 }
             }
+            _ => error_response(HttpError::BadRequest, StatusCode::BadRequest),
+        }
+    }
+}
+
+impl EndpointHandler for VmMigrationProgress {
+    fn handle_request(
+        &self,
+        req: &Request,
+        api_notifier: EventFd,
+        api_sender: Sender<ApiRequest>,
+    ) -> Response {
+        match req.method() {
+            Method::Get => match crate::api::VmMigrationProgress
+                .send(api_notifier, api_sender, ())
+                .map_err(HttpError::ApiError)
+            {
+                Ok(info) => {
+                    let mut response = Response::new(Version::Http11, StatusCode::OK);
+                    let info_serialized = serde_json::to_string(&info).unwrap();
+
+                    response.set_body(Body::new(info_serialized));
+                    response
+                }
+                Err(e) => error_response(e, StatusCode::InternalServerError),
+            },
             _ => error_response(HttpError::BadRequest, StatusCode::BadRequest),
         }
     }

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -29,9 +29,9 @@ use self::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmPing, VmmShutdow
 use crate::api::VmCoredump;
 use crate::api::{
     AddDisk, ApiError, ApiRequest, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem, VmAddUserDevice,
-    VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmDelete, VmNmi, VmPause, VmPowerButton, VmReboot,
-    VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore, VmResume,
-    VmSendMigration, VmShutdown, VmSnapshot,
+    VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmDelete, VmMigrationProgress, VmNmi, VmPause,
+    VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk,
+    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::landlock::Landlock;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
@@ -274,6 +274,10 @@ pub static HTTP_ROUTES: LazyLock<HttpRoutes> = LazyLock::new(|| {
     r.routes.insert(
         endpoint!("/vm.shutdown"),
         Box::new(VmActionHandler::new(&VmShutdown)),
+    );
+    r.routes.insert(
+        endpoint!("/vm.migration-progress"),
+        Box::new(VmMigrationProgress {}),
     );
     r.routes.insert(
         endpoint!("/vm.snapshot"),

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -43,6 +43,7 @@ use micro_http::Body;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vm_migration::MigratableError;
+use vm_migration::progress::MigrationProgress;
 use vmm_sys_util::eventfd::EventFd;
 
 #[cfg(feature = "dbus_api")]
@@ -203,6 +204,10 @@ pub enum ApiError {
     /// Error triggering NMI
     #[error("Error triggering NMI")]
     VmNmi(#[source] VmError),
+
+    /// Error fetching the migration progress
+    #[error("Error fetching the migration progress")]
+    VmMigrationProgress(#[source] VmError),
 }
 pub type ApiResult<T> = Result<T, ApiError>;
 
@@ -318,6 +323,9 @@ pub enum ApiResponsePayload {
     /// Virtual machine information
     VmInfo(VmInfoResponse),
 
+    /// The progress of a possibly ongoing live migration.
+    VmMigrationProgress(Box<Option<MigrationProgress>>),
+
     /// Vmm ping response
     VmmPing(VmmPingResponse),
 
@@ -403,6 +411,10 @@ pub trait RequestHandler {
     ) -> Result<(), MigratableError>;
 
     fn vm_nmi(&mut self) -> Result<(), VmError>;
+
+    /// Returns the progress of the currently active migration or any previous
+    /// failed or canceled migration.
+    fn vm_migration_progress(&mut self) -> Option<MigrationProgress>;
 }
 
 /// It would be nice if we could pass around an object like this:
@@ -1533,5 +1545,44 @@ impl ApiAction for VmNmi {
         data: Self::RequestBody,
     ) -> ApiResult<Self::ResponseBody> {
         get_response_body(self, api_evt, api_sender, data)
+    }
+}
+
+pub struct VmMigrationProgress;
+
+impl ApiAction for VmMigrationProgress {
+    type RequestBody = ();
+    type ResponseBody = Box<Option<MigrationProgress>>;
+
+    fn request(&self, _: Self::RequestBody, response_sender: Sender<ApiResponse>) -> ApiRequest {
+        Box::new(move |vmm| {
+            info!("API request event: VmMigrationProgress");
+
+            let snapshot = Ok(vmm.vm_migration_progress());
+            let response = snapshot
+                .map(Box::new)
+                .map(ApiResponsePayload::VmMigrationProgress)
+                .map_err(ApiError::VmMigrationProgress);
+
+            response_sender
+                .send(response)
+                .map_err(VmmError::ApiResponseSend)?;
+
+            Ok(false)
+        })
+    }
+
+    fn send(
+        &self,
+        api_evt: EventFd,
+        api_sender: Sender<ApiRequest>,
+        data: Self::RequestBody,
+    ) -> ApiResult<Self::ResponseBody> {
+        let info = get_response(self, api_evt, api_sender, data)?;
+
+        match info {
+            ApiResponsePayload::VmMigrationProgress(info) => Ok(info),
+            _ => Err(ApiError::ResponsePayloadType),
+        }
     }
 }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -304,6 +304,8 @@ pub struct VmSendMigrationData {
     /// Directory containing the TLS root CA certificate (ca-cert.pem)
     #[serde(default)]
     pub tls_dir: Option<PathBuf>,
+    /// Keep the VMM alive.
+    pub keep_alive: bool,
 }
 
 // Default value for downtime the same as qemu.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -69,7 +69,6 @@ use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::unblock_signal;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
 
-use crate::api::http::http_endpoint::ONGOING_LIVEMIGRATION;
 use crate::api::{
     ApiRequest, ApiResponse, RequestHandler, VmInfoResponse, VmReceiveMigrationData,
     VmSendMigrationData, VmmPingResponse,
@@ -833,6 +832,7 @@ impl MigrationWorker {
         MigrationThreadOut {
             vm: self.vm,
             migration_res: res,
+            migration_cfg: self.config,
         }
     }
 }
@@ -883,6 +883,7 @@ impl MaybeVmOwnership {
 struct MigrationThreadOut {
     vm: Vm,
     migration_res: result::Result<(), MigratableError>,
+    migration_cfg: VmSendMigrationData,
 }
 
 pub struct Vmm {
@@ -2587,22 +2588,6 @@ impl Vmm {
             s.iteration,
         );
 
-        // Update migration progress snapshot
-        {
-            let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
-            lock.as_mut()
-                .expect("live migration should be ongoing")
-                .mark_as_finished();
-        }
-
-        // Give management software a chance to fetch the migration state.
-        // The VMM already executes on the other side and keeping Cloud Hypervisor running for a
-        // couple of more seconds is fine.
-        //
-        // We do the sleep in the migration thread to keep the internal API unblocked.
-        info!("Sleeping five seconds before shutting off.");
-        thread::sleep(Duration::from_secs(5));
-
         // Let every Migratable object know about the migration being complete
         vm.complete_migration()
     }
@@ -2741,6 +2726,7 @@ impl Vmm {
         let MigrationThreadOut {
             mut vm,
             migration_res,
+            migration_cfg,
         } = self
             .migration_thread_handle
             .take()
@@ -2754,15 +2740,20 @@ impl Vmm {
                 drop(vm);
 
                 {
-                    info!("Sending Receiver in HTTP thread that migration succeeded");
-                    let (sender, _) = &*ONGOING_LIVEMIGRATION;
-                    // unblock API call; propagate migration result
-                    sender.send(Ok(())).unwrap();
+                    let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+                    lock.as_mut()
+                        .expect("live migration should be ongoing")
+                        .mark_as_finished();
                 }
 
-                // Shutdown the VM after the migration succeeded
-                if let Err(e) = self.exit_evt.write(1) {
-                    error!("Failed shutting down the VM after migration: {e}");
+                if migration_cfg.keep_alive {
+                    // API users can still query live-migration statistics
+                    info!("Keeping VMM alive as requested");
+                } else {
+                    // Shutdown the VM after the migration succeeded
+                    if let Err(e) = self.exit_evt.write(1) {
+                        error!("Failed shutting down the VM after migration: {e}");
+                    }
                 }
             }
             Err(e) => {
@@ -2801,13 +2792,6 @@ impl Vmm {
                     lock.as_mut()
                         .expect("live migration should be ongoing")
                         .mark_as_failed(&e);
-                }
-
-                {
-                    info!("Sending Receiver in HTTP thread that migration failed");
-                    let (sender, _) = &*ONGOING_LIVEMIGRATION;
-                    // unblock API call; propagate migration result
-                    sender.send(Err(e)).unwrap();
                 }
             }
         }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2180,6 +2180,21 @@ impl Vmm {
     ) -> result::Result<MemoryRangeTable, MigratableError> {
         let mut iteration_table;
 
+        let log_migration_progress = |s: &MigrationState, vm: &Vm| {
+            info!(
+                "iter={},dur={}ms,overhead={}ms,throttle={}%,size={}MiB,dirtyrate={}pps,bandwidth={:.2}MiBs,downtime(expected)={}ms",
+                s.iteration,
+                s.iteration_duration.as_millis(),
+                (s.iteration_duration - s.transmit_duration).as_millis(),
+                vm.throttle_percent(),
+                s.bytes_to_transmit.div_ceil(1024).div_ceil(1024),
+                s.dirty_rate_pps,
+                s.bytes_per_sec / 1024.0 / 1024.0,
+                s.calculated_downtime_duration
+                    .map_or(migrate_downtime_limit.as_millis(), |d| d.as_millis()),
+            );
+        };
+
         // We loop until we converge (target downtime is achievable).
         loop {
             // Update the start time of the iteration
@@ -2225,11 +2240,6 @@ impl Vmm {
                 .sum();
             s.pages_to_transmit = s.bytes_to_transmit.div_ceil(PAGE_SIZE as u64);
 
-            // Unlikely happy-path.
-            if s.bytes_to_transmit == 0 {
-                break;
-            }
-
             // Update metrics and exit loop, if conditions are met.
             if s.iteration > 0 {
                 // Refresh dirty rate: How many pages have been dirtied since the last time we
@@ -2257,17 +2267,7 @@ impl Vmm {
                     && downtime <= migrate_downtime_limit
                 {
                     info!("Memory delta transmission stopping - cutoff condition reached!");
-                    info!(
-                        "iteration:{},remaining:{}MiB,downtime(calc):{}ms,mebibyte/s:{:.2},throttle:{}%,dirty_rate:{}pps",
-                        s.iteration,
-                        s.bytes_to_transmit / 1024 / 1024,
-                        s.calculated_downtime_duration
-                            .expect("should have calculated downtime by now")
-                            .as_millis(),
-                        s.bytes_per_sec / 1024.0 / 1024.0,
-                        vm.throttle_percent(),
-                        s.dirty_rate_pps
-                    );
+                    log_migration_progress(s, vm);
                     break;
                 }
             }
@@ -2286,15 +2286,7 @@ impl Vmm {
             }
 
             s.iteration_duration = s.iteration_start_time.elapsed();
-            info!(
-                "iteration:{},cost={}ms,throttle={}%,transmitted={}MiB,dirty_rate={}pps,Mebibyte/s={:.2}",
-                s.iteration,
-                s.iteration_duration.as_millis(),
-                vm.throttle_percent(),
-                s.bytes_to_transmit / 1024 / 1024,
-                s.dirty_rate_pps,
-                s.bytes_per_sec / 1024.0 / 1024.0
-            );
+            log_migration_progress(s, vm);
 
             // Increment iteration counter
             s.iteration += 1;
@@ -2367,8 +2359,14 @@ impl Vmm {
         s.total_transferred_pages += s.pages_to_transmit;
 
         info!(
-            "Memory Migration finished: transmitted {} bytes in total",
-            s.total_transferred_bytes
+            "Memory Migration finished: iter={},throttle={}%,size={}MiB,dirtyrate={}pps,bandwidth={:.2}MiBs,downtime(expected)={}ms",
+            (s.iteration_duration - s.transmit_duration).as_millis(),
+            vm.throttle_percent(),
+            s.bytes_to_transmit.div_ceil(1024).div_ceil(1024),
+            s.dirty_rate_pps,
+            s.bytes_per_sec / 1024.0 / 1024.0,
+            s.calculated_downtime_duration
+                .map_or(migrate_downtime_limit.as_millis(), |d| d.as_millis()),
         );
 
         // Stop logging dirty pages
@@ -2529,8 +2527,8 @@ impl Vmm {
         s.migration_duration = s.migration_start_time.elapsed();
 
         info!(
-            "Migration complete: downtime: {:.3}s, total: {:1}s, iterations: {}",
-            s.downtime_duration.as_secs_f64(),
+            "Migration complete: downtime:{:}ms,total:{:1}s,iterations:{}",
+            s.downtime_duration.as_millis(),
             s.migration_duration.as_secs_f64(),
             s.iteration,
         );

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -697,7 +697,7 @@ impl VmmVersionInfo {
 ///
 /// Is supposed to be updated on the fly.
 #[derive(Debug, Clone)]
-struct MigrationState {
+struct MigrationStateInternal {
     /* ---------------------------------------------- */
     /* Properties that are updated before the first iteration */
     /// The instant where the actual downtime of the VM began.
@@ -743,7 +743,7 @@ struct MigrationState {
     migration_duration: Duration,
 }
 
-impl MigrationState {
+impl MigrationStateInternal {
     pub fn new() -> Self {
         Self {
             // Field will be overwritten later.
@@ -2158,7 +2158,7 @@ impl Vmm {
         Ok(())
     }
 
-    fn can_increase_autoconverge_step(s: &MigrationState) -> bool {
+    fn can_increase_autoconverge_step(s: &MigrationStateInternal) -> bool {
         if s.iteration < AUTO_CONVERGE_ITERATION_DELAY {
             false
         } else {
@@ -2175,13 +2175,13 @@ impl Vmm {
         vm: &mut Vm,
         mem_send: &SendAdditionalConnections,
         socket: &mut SocketStream,
-        s: &mut MigrationState,
+        s: &mut MigrationStateInternal,
         migration_timeout: Duration,
         migrate_downtime_limit: Duration,
     ) -> result::Result<MemoryRangeTable, MigratableError> {
         let mut iteration_table;
 
-        let log_migration_progress = |s: &MigrationState, vm: &Vm| {
+        let log_migration_progress = |s: &MigrationStateInternal, vm: &Vm| {
             info!(
                 "iter={},dur={}ms,overhead={}ms,throttle={}%,size={}MiB,dirtyrate={}pps,bandwidth={:.2}MiBs,downtime(expected)={}ms",
                 s.iteration,
@@ -2299,7 +2299,7 @@ impl Vmm {
     fn do_memory_migration(
         vm: &mut Vm,
         socket: &mut SocketStream,
-        s: &mut MigrationState,
+        s: &mut MigrationStateInternal,
         send_data_migration: &VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
         let mem_send = SendAdditionalConnections::new(send_data_migration, &vm.guest_memory())?;
@@ -2388,7 +2388,7 @@ impl Vmm {
         hypervisor: &dyn hypervisor::Hypervisor,
         send_data_migration: &VmSendMigrationData,
     ) -> result::Result<(), MigratableError> {
-        let mut s = MigrationState::new();
+        let mut s = MigrationStateInternal::new();
 
         // Set up the socket connection
         let mut socket = send_migration_socket(send_data_migration)?;

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -56,6 +56,7 @@ use vm_memory::{
     GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, ReadVolatile,
     VolatileMemoryError, VolatileSlice, WriteVolatile,
 };
+use vm_migration::progress::MigrationProgress;
 use vm_migration::protocol::*;
 use vm_migration::tls::{TlsConnectionWrapper, TlsStream, TlsStreamWrapper};
 use vm_migration::{
@@ -3720,6 +3721,10 @@ impl RequestHandler for Vmm {
         );
 
         Ok(())
+    }
+
+    fn vm_migration_progress(&mut self) -> Option<MigrationProgress> {
+        None
     }
 }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -56,7 +56,10 @@ use vm_memory::{
     GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, ReadVolatile,
     VolatileMemoryError, VolatileSlice, WriteVolatile,
 };
-use vm_migration::progress::MigrationProgress;
+use vm_migration::progress::{
+    MemoryTransmissionInfo, MigrationProgress, MigrationState, MigrationStateOngoingPhase,
+    TransportationMode,
+};
 use vm_migration::protocol::*;
 use vm_migration::tls::{TlsConnectionWrapper, TlsStream, TlsStreamWrapper};
 use vm_migration::{
@@ -281,6 +284,9 @@ impl From<u64> for EpollDispatch {
         }
     }
 }
+
+// TODO make this a member of Vmm?
+static MIGRATION_PROGRESS_SNAPSHOT: Mutex<Option<MigrationProgress>> = Mutex::new(None);
 
 enum SocketStream {
     Unix(UnixStream),
@@ -2180,6 +2186,34 @@ impl Vmm {
         migrate_downtime_limit: Duration,
     ) -> result::Result<MemoryRangeTable, MigratableError> {
         let mut iteration_table;
+        let total_memory_size_bytes = vm
+            .memory_range_table()?
+            .regions()
+            .iter()
+            .map(|range| range.length)
+            .sum::<u64>();
+
+        let update_migration_progress = |s: &mut MigrationStateInternal, vm: &Vm| {
+            let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+            lock.as_mut()
+                .expect("live migration should be ongoing")
+                .update(
+                    MigrationStateOngoingPhase::MemoryPrecopy,
+                    Some(MemoryTransmissionInfo {
+                        memory_iteration: s.iteration,
+                        memory_transmission_bps: s.bytes_per_sec as u64,
+                        memory_bytes_total: total_memory_size_bytes,
+                        memory_bytes_transmitted: s.total_transferred_bytes,
+                        memory_pages_4k_transmitted: s.total_transferred_pages,
+                        memory_pages_4k_remaining_iteration: s.pages_to_transmit,
+                        memory_bytes_remaining_iteration: s.bytes_to_transmit,
+                        memory_dirty_rate_pps: s.dirty_rate_pps,
+                        memory_pages_constant_count: 0, /* TODO */
+                    }),
+                    Some(vm.throttle_percent()),
+                    s.calculated_downtime_duration,
+                );
+        };
 
         let log_migration_progress = |s: &MigrationStateInternal, vm: &Vm| {
             info!(
@@ -2241,6 +2275,9 @@ impl Vmm {
                 .sum();
             s.pages_to_transmit = s.bytes_to_transmit.div_ceil(PAGE_SIZE as u64);
 
+            // Update before we might exit the loop.
+            update_migration_progress(s, vm);
+
             // Update metrics and exit loop, if conditions are met.
             if s.iteration > 0 {
                 // Refresh dirty rate: How many pages have been dirtied since the last time we
@@ -2272,6 +2309,9 @@ impl Vmm {
                     break;
                 }
             }
+
+            // Update with new metrics before transmission.
+            update_migration_progress(s, vm);
 
             // Send the current dirty pages
             s.transmit_start_time = Instant::now();
@@ -2442,6 +2482,11 @@ impl Vmm {
         if send_data_migration.local {
             match &mut socket {
                 SocketStream::Unix(unix_socket) => {
+                    let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+                    lock.as_mut()
+                        .expect("live migration should be ongoing")
+                        .update(MigrationStateOngoingPhase::MemoryFds, None, None, None);
+
                     // Proceed with sending memory file descriptors over UNIX socket
                     vm.send_memory_fds(unix_socket)?;
                 }
@@ -2482,6 +2527,14 @@ impl Vmm {
             vm.pause()?;
         } else {
             Self::do_memory_migration(vm, &mut socket, &mut s, send_data_migration)?;
+        }
+
+        // Update migration progress snapshot
+        {
+            let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+            lock.as_mut()
+                .expect("live migration should be ongoing")
+                .update(MigrationStateOngoingPhase::Completing, None, None, None);
         }
 
         // We release the locks early to enable locking them on the destination host.
@@ -2533,6 +2586,22 @@ impl Vmm {
             s.migration_duration.as_secs_f64(),
             s.iteration,
         );
+
+        // Update migration progress snapshot
+        {
+            let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+            lock.as_mut()
+                .expect("live migration should be ongoing")
+                .mark_as_finished();
+        }
+
+        // Give management software a chance to fetch the migration state.
+        // The VMM already executes on the other side and keeping Cloud Hypervisor running for a
+        // couple of more seconds is fine.
+        //
+        // We do the sleep in the migration thread to keep the internal API unblocked.
+        info!("Sleeping five seconds before shutting off.");
+        thread::sleep(Duration::from_secs(5));
 
         // Let every Migratable object know about the migration being complete
         vm.complete_migration()
@@ -2725,6 +2794,14 @@ impl Vmm {
 
                 // Give VMM back control.
                 self.vm = MaybeVmOwnership::Vmm(vm);
+
+                // Update migration progress snapshot
+                {
+                    let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+                    lock.as_mut()
+                        .expect("live migration should be ongoing")
+                        .mark_as_failed(&e);
+                }
 
                 {
                     info!("Sending Receiver in HTTP thread that migration failed");
@@ -3702,29 +3779,62 @@ impl RequestHandler for Vmm {
         // change the VM (e.g. net device hotplug).
         let vm = self.vm.take_vm_for_migration();
 
-        // Start migration thread
-        let worker = MigrationWorker {
-            vm,
-            check_migration_evt: self.check_migration_evt.try_clone().unwrap(),
-            config: send_data_migration,
-            #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-            hypervisor: self.hypervisor.clone(),
-        };
+        // Update migration progress snapshot early:
+        // We guarantee that migration statistics can be fetched as soon as SendMigration returns.
+        //
+        // If the migration fails, the state will later be updated accordingly.
+        {
+            let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+            if lock
+                .as_ref()
+                .map(|p| &p.state)
+                .is_some_and(|snapshot| matches!(snapshot, MigrationState::Ongoing { .. }))
+            {
+                // If this panic triggers, we made a programming error in our state handling.
+                panic!("migration already ongoing");
+            }
+            let transportation_mode = if send_data_migration.local {
+                TransportationMode::Local
+            } else {
+                TransportationMode::Tcp {
+                    connections: send_data_migration.connections,
+                    tls: send_data_migration.tls_dir.is_some(),
+                }
+            };
+            lock.replace(MigrationProgress::new(
+                transportation_mode,
+                Duration::from_millis(send_data_migration.downtime),
+            ));
+        }
 
-        self.migration_thread_handle = Some(
-            thread::Builder::new()
-                .name("migration".into())
-                .spawn(move || worker.run())
-                // For upstreaming, we should simply continue and return an
-                // error when this fails. For our PoC, this is fine.
-                .unwrap(),
-        );
+        // Start migration thread
+        {
+            let worker = MigrationWorker {
+                vm,
+                check_migration_evt: self.check_migration_evt.try_clone().unwrap(),
+                config: send_data_migration,
+                #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+                hypervisor: self.hypervisor.clone(),
+            };
+
+            self.migration_thread_handle = Some(
+                thread::Builder::new()
+                    .name("migration".into())
+                    .spawn(move || worker.run())
+                    // For upstreaming, we should simply continue and return an
+                    // error when this fails. For our PoC, this is fine.
+                    .unwrap(),
+            );
+        }
 
         Ok(())
     }
 
     fn vm_migration_progress(&mut self) -> Option<MigrationProgress> {
-        None
+        // We explicitly do not check here for `is VM running?` to always
+        // enable querying the state of the last failed migration.
+        let lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+        lock.clone()
     }
 }
 


### PR DESCRIPTION
## TL;DR

This extends the internal API with a `vm_progress` function and adds a `vm.migration-progress` HTTP endpoint including support in `ch-remote` via `ch-remote migration-process` to query the latest migration progress.

# Motivation

Having live and frequently refreshing statistics/metrics about an
ongoing live migration is especially interesting for debugging and
monitoring, such as checking the actual network throughput. With the
proposed changes, for the first time, we will be able to see how live
migrations behave and create benchmarking infrastructure around it.

The ch driver in libvirt will use these information to populate its
`virsh domjobinfo` information.

# Design

We will add a new API endpoint to query information for ongoing live
migrations. The new endpoint will also serve to query information about
any previously failed or canceled migrations. The SendMigration call
will no longer be blocking (wait until the migration is done) but
instead just dispatch the migration.

This streamlines the behavior with QEMU and simplifies management
software.

When one queries the endpoint, a frequently refreshed snapshot of the
migration statistics and progress will be returned. The data will not be
assembled on the fly.

On-behalf-of: SAP philipp.schuster@sap.com
Signed-off-by: Philipp Schuster <philipp.schuster@cyberus-technology.de>


## Steps to Merge
- [x] test it locally using `ch-remote`
- [x] add libvirt-tests testcase and verify everything works
- [x] finish refactoring for "non-blocking send-migration" (2026-02-03)
- [x] deploy it on a node in SAP land and see if it works 
- [x] merge this when we know the libvirt part is also fine (I however think that this is 99% already)
- [x] wait for the latest libvirt/libvirt-tests fixes