### PR TITLE
build: don't strip binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ rust-version = "1.88.0"
 codegen-units = 1
 lto = true
 opt-level = "s"
-strip = true
 
 # Tradeof between performance and fast compilation times for local testing and
 # development with frequent rebuilds.


### PR DESCRIPTION
With debug symbols, we will get better backtraces and can
improve our experience debugging. The only downside is larger
binary size which is negligible in our case. There are no
implications for the performance.

Stripped:   3.9M
Unstripped: 4.7M
