### PR TITLE
Fix live migration when AMX is enabled

### DIFF
--- a/hypervisor/Cargo.toml
+++ b/hypervisor/Cargo.toml
@@ -21,7 +21,10 @@ cfg-if = { workspace = true }
 concat-idents = "1.1.5"
 igvm = { workspace = true, optional = true }
 igvm_defs = { workspace = true, optional = true }
-kvm-bindings = { workspace = true, optional = true, features = ["serde"] }
+kvm-bindings = { workspace = true, optional = true, features = [
+  "fam-wrappers",
+  "serde",
+] }
 kvm-ioctls = { workspace = true, optional = true }
 libc = { workspace = true }
 log = { workspace = true }

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -111,6 +111,16 @@ pub trait Hypervisor: Send + Sync {
     /// Return a hypervisor-agnostic Vm trait object
     ///
     fn create_vm(&self) -> Result<Arc<dyn Vm>>;
+
+    /// Query the hypervisor for the availability of an extension.
+    ///
+    ///
+    /// Generally 0 means no and 1 means yes, but some extensions may report
+    /// additional information in the integer return value.
+    ///
+    #[cfg(feature = "kvm")]
+    fn check_extension_int(&self, capability: kvm_ioctls::Cap) -> i32;
+
     ///
     /// Create a Vm of a specific type using the underlying hypervisor
     /// Return a hypervisor-agnostic Vm trait object

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1281,6 +1281,10 @@ impl hypervisor::Hypervisor for KvmHypervisor {
         self.create_vm_with_type(vm_type)
     }
 
+    fn check_extension_int(&self, capability: kvm_ioctls::Cap) -> i32 {
+        self.kvm.check_extension_int(capability)
+    }
+
     fn check_required_extensions(&self) -> hypervisor::Result<()> {
         check_required_kvm_extensions(&self.kvm)
             .map_err(|e| hypervisor::HypervisorError::CheckExtensions(e.into()))

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -3004,13 +3004,11 @@ impl KvmVcpu {
     /// X86 specific call that returns the vcpu's current "xsave struct".
     ///
     fn get_xsave(&self) -> cpu::Result<XsaveState> {
-        Ok(self
-            .fd
-            .lock()
-            .unwrap()
-            .get_xsave()
-            .map_err(|e| cpu::HypervisorCpuError::GetXsaveState(e.into()))?
-            .into())
+        XsaveState::with_initializer(|state|
+            // SAFETY: Any configured dynamically enabled state components are always enabled via
+            // static methods on `XsaveState` hence we know that `state` has the expected size.
+            unsafe { self.fd.lock().unwrap().get_xsave2(state) })
+        .map_err(|e| cpu::HypervisorCpuError::GetXsaveState(anyhow::Error::from_boxed(e)))
     }
 
     #[cfg(target_arch = "x86_64")]
@@ -3018,16 +3016,11 @@ impl KvmVcpu {
     /// X86 specific call that sets the vcpu's current "xsave struct".
     ///
     fn set_xsave(&self, xsave: &XsaveState) -> cpu::Result<()> {
-        let xsave: kvm_bindings::kvm_xsave = (*xsave).clone().into();
-        // SAFETY: Here we trust the kernel not to read past the end of the kvm_xsave struct
-        // when calling the kvm-ioctl library function.
-        unsafe {
-            self.fd
-                .lock()
-                .unwrap()
-                .set_xsave(&xsave)
-                .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
-        }
+        // SAFETY: Any configured dynamically enabled state components are always enabled via
+        // static methods on `XsaveState` hence we know that the wrapped instance has the
+        // expected size.
+        unsafe { self.fd.lock().unwrap().set_xsave2(&xsave.0) }
+            .map_err(|e| cpu::HypervisorCpuError::SetXsaveState(e.into()))
     }
 
     #[cfg(target_arch = "x86_64")]

--- a/hypervisor/src/kvm/x86_64/mod.rs
+++ b/hypervisor/src/kvm/x86_64/mod.rs
@@ -291,18 +291,3 @@ impl From<MsrEntry> for kvm_msr_entry {
         }
     }
 }
-
-impl From<kvm_xsave> for XsaveState {
-    fn from(s: kvm_xsave) -> Self {
-        Self { region: s.region }
-    }
-}
-
-impl From<XsaveState> for kvm_xsave {
-    fn from(s: XsaveState) -> Self {
-        Self {
-            region: s.region,
-            extra: Default::default(),
-        }
-    }
-}

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -427,6 +427,12 @@ impl hypervisor::Hypervisor for MshvHypervisor {
         let vm_type = 0;
         self.create_vm_with_type(vm_type)
     }
+
+    #[cfg(feature = "kvm")]
+    fn check_extension_int(&self, _capability: kvm_ioctls::Cap) -> i32 {
+        unimplemented!()
+    }
+
     #[cfg(target_arch = "x86_64")]
     ///
     /// Get the supported CpuID

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -738,34 +738,8 @@ impl CpuManager {
 
         #[cfg(target_arch = "x86_64")]
         if config.features.amx {
-            const ARCH_GET_XCOMP_GUEST_PERM: usize = 0x1024;
-            const ARCH_REQ_XCOMP_GUEST_PERM: usize = 0x1025;
-            const XFEATURE_XTILEDATA: usize = 18;
-            const XFEATURE_XTILEDATA_MASK: usize = 1 << XFEATURE_XTILEDATA;
-
-            // SAFETY: the syscall is only modifying kernel internal
-            // data structures that the kernel is itself expected to safeguard.
-            let amx_tile = unsafe {
-                libc::syscall(
-                    libc::SYS_arch_prctl,
-                    ARCH_REQ_XCOMP_GUEST_PERM,
-                    XFEATURE_XTILEDATA,
-                )
-            };
-
-            if amx_tile != 0 {
-                return Err(Error::AmxEnable(anyhow!("Guest AMX usage not supported")));
-            } else {
-                let mask: usize = 0;
-                // SAFETY: the mask being modified (not marked mutable as it is
-                // modified in unsafe only which is permitted) isn't in use elsewhere.
-                let result = unsafe {
-                    libc::syscall(libc::SYS_arch_prctl, ARCH_GET_XCOMP_GUEST_PERM, &mask)
-                };
-                if result != 0 || (mask & XFEATURE_XTILEDATA_MASK) != XFEATURE_XTILEDATA_MASK {
-                    return Err(Error::AmxEnable(anyhow!("Guest AMX usage not supported")));
-                }
-            }
+            hypervisor::arch::x86::XsaveState::enable_amx_state_components(hypervisor.as_ref())
+                .map_err(|e| crate::cpu::Error::AmxEnable(e.into()))?;
         }
 
         let proximity_domain_per_cpu: BTreeMap<u32, u32> = {


### PR DESCRIPTION
Closes https://github.com/cloud-hypervisor/cloud-hypervisor/issues/5800

## Variable length Xsave state

When XSAVE state components are dynamically enabled, the de-facto length of `kvm_xsave` changes and this needs to be accounted for. I do this by updating the pre-existing `XSaveState` struct to wrap the FAM-struct `Xsave` from the `kvm_bindings` crate directly and I track the FAM length in a Oncelocked static variable.

## How this relates to the upcoming CPU profiles feature

This fix is necessary to properly test the upcoming CPU Profiles feature, but the `XSaveState::enable_amx_state_components` method introduced here will also be called during CPU profile generation and also prior to checking CPU compatibility when receiving a live migration command.

## Risks

There are a few things we should keep in mind with regards to this fix:

1. It assumes that the FAM (flexible array member) struct approach from the `kvm_bindings` crate is sound. I am not entirely convinced that this will be the case in the eyes of the Rust abstract machine, but I think we can investigate that more in the future.
2. It uses static variables. This is fine as long as there are no plans to introduce unit tests, some with and some without AMX (or other dynamically enabled state components), running in the same process. If I recall correctly `cargo nextest` runs each test in a separate process hence as long as that is used for running the unit/integration tests this should not be a problem.
3. Heap allocations: The `XsaveState` will now heap allocate whenever AMX is enabled. Each initialization will require roughly 1KB of memory on the heap. We have however determined that this will never be called in any hot paths.




## How this PR has been tested

This was tested by running an AMX workload (loading and mutiplying some matrices, then printing the result in a loop)
inside a guest on a Sapphire rapids server and then migrating it to a Granite rapids server. The migration was successful and the program kept running.