### PR TITLE
Fix seccomp violations after replacing KVM_GET_XSAVE with KVM_GET_XSAVE2

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -550,6 +550,8 @@ fn vmm_thread_rules(
         (libc::SYS_accept4, vec![]),
         #[cfg(target_arch = "x86_64")]
         (libc::SYS_access, vec![]),
+        #[cfg(target_arch = "x86_64")]
+        (libc::SYS_arch_prctl, vec![]),
         (libc::SYS_bind, vec![]),
         (libc::SYS_brk, vec![]),
         (libc::SYS_clock_gettime, vec![]),

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -376,7 +376,7 @@ fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError>
     const KVM_GET_SREGS: u64 = 0x8138_ae83;
     const KVM_GET_TSC_KHZ: u64 = 0xaea3;
     const KVM_GET_XCRS: u64 = 0x8188_aea6;
-    const KVM_GET_XSAVE: u64 = 0x9000_aea4;
+    const KVM_GET_XSAVE2: u64 = 0x9000_aecf;
     const KVM_KVMCLOCK_CTRL: u64 = 0xaead;
     const KVM_SET_CLOCK: u64 = 0x4030_ae7b;
     const KVM_SET_CPUID2: u64 = 0x4008_ae90;
@@ -404,7 +404,7 @@ fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError>
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_SREGS)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_TSC_KHZ)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_XCRS,)?],
-        and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_XSAVE,)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_XSAVE2,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_KVMCLOCK_CTRL)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_CLOCK)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_CPUID2)?],


### PR DESCRIPTION
In https://github.com/cyberus-technology/cloud-hypervisor/pull/46 we replaced all calls to `KVM_GET_XSAVE` with `KVM_GET_XSAVE2`, but we forgot to update the seccomp filters accordingly. This omission is addressed by this PR.

Note that I have also cherry picked https://github.com/cloud-hypervisor/cloud-hypervisor/commit/41382879d35dbfb199170af790f87f76c0af00fc from upstream as I needed it to test with amx.

## How this PR was tested

This time I performed live migrations between two machines both running CHV with seccomp set to `true`. I confirmed that this worked both when AMX is enabled and when it is not. I also confirmed that this does not work without the changes introduced here.

