### PR TITLE
ch-remote: fix tls-dir handling

### DIFF
--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -518,7 +518,7 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                 matches
                     .subcommand_matches("send-migration")
                     .unwrap()
-                    .get_one::<PathBuf>("tls_dir")
+                    .get_one::<PathBuf>("tls-dir")
                     .cloned(),
             );
             simple_api_command(socket, "PUT", "send-migration", Some(&send_migration_data))
@@ -533,9 +533,9 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .unwrap()
                     .to_owned(),
                 matches
-                    .subcommand_matches("receive_migration")
+                    .subcommand_matches("receive-migration")
                     .unwrap()
-                    .get_one::<PathBuf>("tls_dir")
+                    .get_one::<PathBuf>("tls-dir")
                     .cloned(),
             );
             simple_api_command(

--- a/src/bin/ch-remote.rs
+++ b/src/bin/ch-remote.rs
@@ -1085,6 +1085,12 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
                     .index(1)
                     // Live migration with net_fds not supported in ch-remote.
                     .help("<receiver_url>"),
+            )
+            .arg(
+                Arg::new("tls-dir")
+                    .long("tls-dir")
+                    .help("directory with TLS certificates")
+                    .num_args(1),
             ),
         Command::new("remove-device")
             .about("Remove VFIO and PCI device")
@@ -1183,6 +1189,12 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
                     .long("local")
                     .num_args(0)
                     .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("tls-dir")
+                    .long("tls-dir")
+                    .help("directory with TLS certificates")
+                    .num_args(1),
             ),
         Command::new("shutdown").about("Shutdown the VM"),
         Command::new("shutdown-vmm").about("Shutdown the VMM"),


### PR DESCRIPTION
Follow-up of d5e345b20882878440f082e43d33296283fd8847.

