### PR TITLE
ci: fix gardenlinux clippy (new rust/clippy version)

### DIFF
--- a/api_client/src/lib.rs
+++ b/api_client/src/lib.rs
@@ -188,8 +188,8 @@ pub fn simple_api_full_command_with_fds<T: Read + Write + ScmSocket>(
         request_fds,
     )?;
 
-    if response.is_some() {
-        println!("{}", response.unwrap());
+    if let Some(response) = response {
+        println!("{response}");
     }
 
     Ok(())

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2194,6 +2194,7 @@ impl Vmm {
     /// This function performs necessary after-migration cleanup only in the
     /// good case. Callers are responsible for properly handling failed
     /// migrations.
+    #[allow(unused_assignments)] // because of `s.total_time =`
     fn send_migration(
         vm: &mut Vm,
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))] hypervisor: Arc<


### PR DESCRIPTION
We have a new rust version since yesterday and the new clippy catches more things.

