### PR TITLE
vmm: fix panic in http API when connecting GDB

### DIFF
--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -6,6 +6,7 @@
 use std::collections::BTreeMap;
 use std::error::Error;
 use std::fs::File;
+use std::io::ErrorKind;
 use std::os::fd::AsRawFd;
 use std::os::unix::io::{IntoRawFd, RawFd};
 use std::os::unix::net::UnixListener;
@@ -548,7 +549,12 @@ fn start_http_thread(
                 server.start_server().unwrap();
 
                 loop {
-                    let n = outer_epoll.wait(-1, &mut events).unwrap();
+                    let n = match outer_epoll.wait(-1, &mut events) {
+                        Ok(n) => n,
+                        // Can for example happen when connecting a debugger.
+                        Err(e) if e.kind() == ErrorKind::Interrupted => continue,
+                        Err(e) => panic!("failed to wait for events: {e}"),
+                    };
                     for ev in events.iter().take(n) {
                         match ev.data() {
                             HTTP_EPOLL_TOKEN => {


### PR DESCRIPTION
This behavior is by the way well-known and also other code in Cloud Hypervisor uses this check with subsequent continue.
