### PR TITLE
vmm: api: remove error message on VMM shutdown

### DIFF
--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -421,8 +421,9 @@ impl HttpWorkerThreads {
                                     // Notify the HTTP server thread.
                                     response_event.write(1).ok();
                                 }
-                                Err(e) => {
-                                    error!("HTTP worker thread {id}: error receiving request {e}");
+                                Err(_) => {
+                                    // We assume that the other side of the channel
+                                    // closed because the VMM received a shutdown request.
                                     break;
                                 }
                             }


### PR DESCRIPTION
Removes the unnecessary error message on VMM shutdown.