### PR TITLE
virtio-net: Post Migration Announce (RARP advertisements)

### DIFF
--- a/net_util/src/lib.rs
+++ b/net_util/src/lib.rs
@@ -101,7 +101,7 @@ fn create_unix_socket() -> Result<net::UdpSocket> {
     Ok(unsafe { net::UdpSocket::from_raw_fd(sock) })
 }
 
-fn vnet_hdr_len() -> usize {
+pub fn vnet_hdr_len() -> usize {
     std::mem::size_of::<virtio_net_hdr_v1>()
 }
 

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -166,6 +166,12 @@ pub trait VirtioDevice: Send {
     /// Set the access platform trait to let the device perform address
     /// translations if needed.
     fn set_access_platform(&mut self, _access_platform: Arc<dyn AccessPlatform>) {}
+
+    /// Some devices can announce their location after a live migration to
+    /// speed up normal execution.
+    fn post_migration_announcer(&self) -> Option<Box<dyn PostMigrationAnnouncer>> {
+        None
+    }
 }
 
 /// Trait to define address translation for devices managed by virtio-iommu
@@ -337,4 +343,15 @@ impl Pausable for VirtioCommon {
 
         Ok(())
     }
+}
+
+/// A PostMigrationAnnouncer provides a callback that informs other components
+/// in the system. For example, network devices send out RARP packets to update
+/// the MAC to port mappings of switches.
+pub trait PostMigrationAnnouncer: Send {
+    /// Announces that a migration _might_ have occurred.
+    /// Implementers need to assume that the announcement can be
+    /// scheduled to run some time after a migration has occurred and
+    /// that it might even be executed when no migration has happened.
+    fn announce(&mut self);
 }

--- a/virtio-devices/src/lib.rs
+++ b/virtio-devices/src/lib.rs
@@ -42,8 +42,8 @@ pub use self::balloon::Balloon;
 pub use self::block::{Block, BlockState};
 pub use self::console::{Console, ConsoleResizer, Endpoint};
 pub use self::device::{
-    DmaRemapping, VirtioCommon, VirtioDevice, VirtioInterrupt, VirtioInterruptType,
-    VirtioSharedMemoryList,
+    DmaRemapping, PostMigrationAnnouncer, VirtioCommon, VirtioDevice, VirtioInterrupt,
+    VirtioInterruptType, VirtioSharedMemoryList,
 };
 pub use self::epoll_helper::{
     EPOLL_HELPER_EVENT_LAST, EpollHelper, EpollHelperError, EpollHelperHandler,

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -20,8 +20,9 @@ use log::{debug, error, info, trace};
 #[cfg(not(fuzzing))]
 use net_util::virtio_features_to_tap_offload;
 use net_util::{
-    CtrlQueue, MacAddr, NetCounters, NetQueuePair, OpenTapError, RxVirtio, Tap, TapError, TxVirtio,
-    VirtioNetConfig, build_net_config_space, build_net_config_space_with_mq, open_tap,
+    CtrlQueue, MAC_ADDR_LEN, MacAddr, NetCounters, NetQueuePair, OpenTapError, RxVirtio, Tap,
+    TapError, TxVirtio, VirtioNetConfig, build_net_config_space, build_net_config_space_with_mq,
+    open_tap, vnet_hdr_len,
 };
 use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
@@ -40,6 +41,7 @@ use super::{
     EpollHelperHandler, Error as DeviceError, RateLimiterConfig, VirtioCommon, VirtioDevice,
     VirtioDeviceType, VirtioInterruptType,
 };
+use crate::device::PostMigrationAnnouncer;
 use crate::seccomp_filters::Thread;
 use crate::thread_helper::spawn_virtio_thread;
 use crate::{GuestMemoryMmap, VirtioInterrupt};
@@ -424,6 +426,11 @@ pub struct NetState {
     pub queue_size: Vec<u16>,
 }
 
+// Minimum length of an ethernet frame. This size omits the FCS/CRC (frame check
+// sequence), which will be added by the hardware. This size can also be found
+// in the Linux kernel's UAPI headers.
+const ETH_FRAME_LEN: usize = 60;
+
 impl Net {
     /// Create a new virtio network device with the given TAP interface.
     #[allow(clippy::too_many_arguments)]
@@ -655,6 +662,39 @@ impl Net {
     pub fn wait_for_epoll_threads(&mut self) {
         self.common.wait_for_epoll_threads();
     }
+
+    // Builds a reverse ARP packet with this device's MAC address.
+    fn build_rarp_announce(&self) -> [u8; ETH_FRAME_LEN] {
+        const ETH_P_RARP: u16 = 0x8035; // Ethertype RARP
+        const ARP_HTYPE_ETH: u16 = 0x1; // Hardware type Ethernet
+        const ARP_PTYPE_IP: u16 = 0x0800; // Protocol type IPv4
+        const ARP_OP_REQUEST_REV: u16 = 0x0003; // RARP Request opcode
+
+        const IPV4_ADDR_LENGTH: usize = 4; // Size of an IPv4 address
+
+        let mut buf = [0u8; ETH_FRAME_LEN];
+
+        // Ethernet header
+        buf[0..6].copy_from_slice(&[0xff; MAC_ADDR_LEN]); // This is a broadcast
+        buf[6..12].copy_from_slice(&self.config.mac); // Src is this NIC
+        buf[12..14].copy_from_slice(&ETH_P_RARP.to_be_bytes()); // This is a RARP packet
+
+        // ARP Header
+        buf[14..16].copy_from_slice(&ARP_HTYPE_ETH.to_be_bytes());
+        buf[16..18].copy_from_slice(&ARP_PTYPE_IP.to_be_bytes());
+        buf[18] = MAC_ADDR_LEN as u8; // Hardware address length (ethernet)
+        buf[19] = IPV4_ADDR_LENGTH as u8; // Protocol address length (IPv4)
+        // This is a "fake RARP" packet, we don't want to perform a real RARP lookup.
+        // Thus the content of the next fields is largely irrelevant. Setting source
+        // hardware address = target hardware address is fine according to RFC 903.
+        buf[20..22].copy_from_slice(&ARP_OP_REQUEST_REV.to_be_bytes());
+        buf[22..28].copy_from_slice(&self.config.mac); // Source hardware address
+        buf[28..32].copy_from_slice(&[0x00; IPV4_ADDR_LENGTH]); // Source protocol address
+        buf[32..38].copy_from_slice(&self.config.mac); // Target hardware address
+        buf[38..42].copy_from_slice(&[0x00; IPV4_ADDR_LENGTH]); // Target protocol address
+
+        buf
+    }
 }
 
 impl Drop for Net {
@@ -870,6 +910,13 @@ impl VirtioDevice for Net {
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {
         self.common.set_access_platform(access_platform);
     }
+
+    fn post_migration_announcer(&self) -> Option<Box<dyn PostMigrationAnnouncer>> {
+        Some(Box::new(TapRarpAnnouncer::new(
+            self.build_rarp_announce(),
+            self.taps.clone(),
+        )))
+    }
 }
 
 impl Pausable for Net {
@@ -898,3 +945,37 @@ impl Snapshottable for Net {
 }
 impl Transportable for Net {}
 impl Migratable for Net {}
+
+/// Sends RARP packets on a virtio-net device, to update the MAC to port
+/// mappings of switches in the network. This reduces the time until network
+/// packets reliably arrive at the network device.
+pub struct TapRarpAnnouncer {
+    announce: [u8; ETH_FRAME_LEN], // Buffer for the raw RARP packet.
+    taps: Vec<Tap>,                // The TAP devices to the the packets on.
+}
+
+impl TapRarpAnnouncer {
+    pub fn new(announce: [u8; 60], taps: Vec<Tap>) -> Self {
+        Self { announce, taps }
+    }
+}
+
+impl PostMigrationAnnouncer for TapRarpAnnouncer {
+    fn announce(&mut self) {
+        // We have to add a virtio-net header to the announce.
+        let mut buf = vec![0u8; vnet_hdr_len() + self.announce.len()];
+        buf[vnet_hdr_len()..].copy_from_slice(&self.announce);
+
+        for tap in &self.taps {
+            // SAFETY: `buf.as_ptr()` is valid for `buf.len()` bytes and remains
+            // valid until the syscall returns. `tap.as_raw_fd()` is a valid TAP fd.
+            let _ = unsafe {
+                libc::write(
+                    tap.as_raw_fd(),
+                    buf.as_ptr() as *const libc::c_void,
+                    buf.len(),
+                )
+            };
+        }
+    }
+}

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -16,10 +16,11 @@ use std::num::Wrapping;
 use std::os::unix::fs::OpenOptionsExt;
 use std::os::unix::io::{AsRawFd, FromRawFd};
 use std::path::{Path, PathBuf};
-use std::result;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 #[cfg(not(target_arch = "riscv64"))]
 use std::time::Instant;
+use std::{result, thread};
 
 use acpi_tables::sdt::GenericAddress;
 use acpi_tables::{Aml, aml};
@@ -90,8 +91,8 @@ use vfio_ioctls::{VfioContainer, VfioDevice, VfioDeviceFd};
 use virtio_devices::transport::{VirtioPciDevice, VirtioPciDeviceActivator, VirtioTransport};
 use virtio_devices::vhost_user::VhostUserConfig;
 use virtio_devices::{
-    AccessPlatformMapping, ActivateError, Block, Endpoint, IommuMapping, VdpaDmaMapping,
-    VirtioMemMappingSource,
+    AccessPlatformMapping, ActivateError, Block, Endpoint, IommuMapping, PostMigrationAnnouncer,
+    VdpaDmaMapping, VirtioMemMappingSource,
 };
 use vm_allocator::{AddressAllocator, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
@@ -5063,6 +5064,60 @@ impl DeviceManager {
             self.vfio_container = None;
         }
     }
+
+    // Calls the `[PostMigrationAnnouncer]`s of each device that has one, and
+    // schedules periodic announcements.
+    pub fn post_migration_announce(&self) {
+        let mut announcers: Vec<Box<dyn PostMigrationAnnouncer>> = self
+            .virtio_devices
+            .iter()
+            .filter_map(|dev| dev.virtio_device.lock().unwrap().post_migration_announcer())
+            .collect();
+
+        // We do the first announcement synchronously, because we want the announcements
+        // as soon as possible.
+        announcers.iter_mut().for_each(|a| a.announce());
+        // For good measure we repeat the announcements. This increases the chance that
+        // the announcements have the expected effect.
+        const ROUNDS: u32 = 4;
+        const INITIAL_DELAY: Duration = Duration::from_millis(50);
+        const STEP_DELAY: Duration = Duration::from_millis(100);
+        const MAX_DELAY: Duration = Duration::from_millis(450);
+        schedule_post_migration_announcements(
+            announcers,
+            ROUNDS,
+            INITIAL_DELAY,
+            STEP_DELAY,
+            MAX_DELAY,
+        );
+    }
+}
+
+/// Starts a thread that periodically performs the post migration announcements.
+fn schedule_post_migration_announcements(
+    mut announcers: Vec<Box<dyn PostMigrationAnnouncer>>,
+    rounds: u32,
+    initial_delay: Duration,
+    step_delay: Duration,
+    max_delay: Duration,
+) {
+    if announcers.is_empty() || rounds == 0 {
+        return;
+    }
+
+    let _ = thread::Builder::new()
+        .name("post-migration-announcers".to_string())
+        .spawn(move || {
+            for round in 0..rounds {
+                // The first announce is done synchronously, thus we sleep at the
+                // start of the loop.
+
+                let delay = (initial_delay + step_delay.saturating_mul(round)).min(max_delay);
+                thread::sleep(delay);
+
+                announcers.iter_mut().for_each(|a| a.announce());
+            }
+        });
 }
 
 #[cfg(feature = "ivshmem")]
@@ -5406,6 +5461,11 @@ impl Pausable for DeviceManager {
     }
 
     fn resume(&mut self) -> result::Result<(), MigratableError> {
+        // Before resuming the devices, we execute the post migration announcers of those that have one.
+        // NOTE: By contract announcements may be executed even if no migration took place hence we
+        // call this function regardless of the reason for resuming the VM.
+        self.post_migration_announce();
+
         for (_, device_node) in self.device_tree.lock().unwrap().iter() {
             if let Some(migratable) = &device_node.migratable {
                 migratable.lock().unwrap().resume()?;


### PR DESCRIPTION
This PR adds a post migration announce to Cloud Hypervisor. After a successful live migration, Cloud Hypervisor now sends reverse ARP packets on all virtio-net devices. That way switches should learn the new location of the VM faster.