### PR TITLE
clippy: latest fixes (new Rust version 1.93)

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -643,6 +643,7 @@ pub fn generate_common_cpuid(
     hypervisor: &dyn hypervisor::Hypervisor,
     config: &CpuidConfig,
 ) -> super::Result<Vec<CpuIdEntry>> {
+    #[allow(unused_unsafe)]
     // SAFETY: cpuid called with valid leaves
     if unsafe { x86_64::__cpuid(1) }.ecx & (1 << HYPERVISOR_ECX_BIT) == 1 << HYPERVISOR_ECX_BIT {
         // SAFETY: cpuid called with valid leaves
@@ -716,6 +717,7 @@ pub fn generate_common_cpuid(
     for i in 0x8000_0002..=0x8000_0004 {
         host_cpuid.retain(|c| c.function != i);
         // SAFETY: call cpuid with valid leaves
+        #[allow(unused_unsafe)]
         let leaf = unsafe { std::arch::x86_64::__cpuid(i) };
         host_cpuid.push(CpuIdEntry {
             function: i,
@@ -1006,6 +1008,7 @@ pub fn configure_vcpu(
     // The TSC frequency CPUID leaf should not be included when running with HyperV emulation
     if !kvm_hyperv && let Some(tsc_khz) = vcpu.tsc_khz().map_err(Error::GetTscFrequency)? {
         // Need to check that the TSC doesn't vary with dynamic frequency
+        #[allow(unused_unsafe)]
         // SAFETY: cpuid called with valid leaves
         if unsafe { std::arch::x86_64::__cpuid(0x8000_0007) }.edx & (1u32 << INVARIANT_TSC_EDX_BIT)
             > 0
@@ -1454,6 +1457,7 @@ pub fn initramfs_load_addr(
 
 pub fn get_host_cpu_phys_bits(hypervisor: &dyn hypervisor::Hypervisor) -> u8 {
     // SAFETY: call cpuid with valid leaves
+    #[allow(unused_unsafe)]
     unsafe {
         let leaf = x86_64::__cpuid(0x8000_0000);
 

--- a/hypervisor/src/hypervisor.rs
+++ b/hypervisor/src/hypervisor.rs
@@ -155,7 +155,8 @@ pub trait Hypervisor: Send + Sync {
     /// Determine CPU vendor
     ///
     fn get_cpu_vendor(&self) -> CpuVendor {
-        // SAFETY: call cpuid with valid leaves
+        #[allow(unused_unsafe)]
+        // SAFETY: not actually unsafe, but considered unsafe by current stable
         unsafe {
             let leaf = x86_64::__cpuid(0x0);
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1444,19 +1444,19 @@ fn send_migration_socket(
             MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {e}"))
         })?;
 
-        if send_data_migration.tls_dir.is_none() {
-            Ok(SocketStream::Tcp(socket))
-        } else {
+        if let Some(tls_dir) = send_data_migration.tls_dir.as_ref() {
             info!("Live Migration will be encrypted using TLS.");
             // The address may still contain a port. I think we should build something more robust to also handle IPv6.
             let tls_stream = tls::client_stream(
                 socket,
-                send_data_migration.tls_dir.as_ref().unwrap(),
+                tls_dir,
                 address.split_once(':').map_or(address, |(host, _)| host),
             )?;
             Ok(SocketStream::Tls(Box::new(TlsStreamWrapper::new(
                 TlsStream::Client(tls_stream),
             ))))
+        } else {
+            Ok(SocketStream::Tcp(socket))
         }
     } else if let Some(path) = &send_data_migration.destination_url.strip_prefix("unix:") {
         info!("Connecting to UNIX socket at {path:?}");
@@ -1483,13 +1483,13 @@ fn receive_migration_listener(
             MigratableError::MigrateReceive(anyhow!("Error binding to TCP socket: {e}"))
         })?;
 
-        if receiver_data_migration.tls_dir.is_none() {
-            Ok(ReceiveListener::Tcp(listener))
-        } else {
+        if let Some(tls_dir) = receiver_data_migration.tls_dir.as_ref() {
             Ok(ReceiveListener::Tls(
                 listener,
-                TlsConnectionWrapper::new(receiver_data_migration.tls_dir.as_ref().unwrap())?,
+                TlsConnectionWrapper::new(tls_dir)?,
             ))
+        } else {
+            Ok(ReceiveListener::Tcp(listener))
         }
     } else if let Some(path) = receiver_data_migration.receiver_url.strip_prefix("unix:") {
         UnixListener::bind(path)


### PR DESCRIPTION
This contains a cherry-pick from upstream and a two additional fixes.

Without this, clippy 1.93 fails (which surprises me, as it seems the function is still unsafe in rust 1.93 std)