### PR TITLE
build: flake: init

### DIFF
--- a/.github/workflows/build_nix.yaml
+++ b/.github/workflows/build_nix.yaml
@@ -1,0 +1,38 @@
+name: Cloud Hypervisor Build (Nix)
+on: [push, pull_request, merge_group]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: cachix/install-nix-action@v31
+      # We restore Nix evaluation and Nix tarball cache, speeding up the CI.
+      # This does not cover any Nix artifacts from the Nix store.
+      - name: Restore Nix cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/nix
+          key: nix-cache-${{ github.job }}
+      # Nix binary cache
+      - uses: DeterminateSystems/magic-nix-cache-action@main
+      # Dedicated step to separate all the
+      # "copying path '/nix/store/...' from 'https://cache.nixos.org'."
+      # messages from the actual build output.
+      - name: Prepare Nix Store
+        run: nix develop --command bash -c "nix --version"
+      - name: Check Nix format
+        run: nix fmt -- --ci
+      - name: Check Nix Flake
+        run: nix flake check -L
+      - name: Build Cloud Hypervisor
+        run: |
+          nix build -L .#default
+          nix build -L .#cloud-hypervisor

--- a/.reuse/dep5
+++ b/.reuse/dep5
@@ -7,6 +7,6 @@ Files: docs/*.md *.md
 Copyright: 2024
 License: CC-BY-4.0
 
-Files: scripts/* test_data/* *.toml .git* fuzz/Cargo.lock fuzz/.gitignore resources/linux-config-* vmm/src/api/openapi/cloud-hypervisor.yaml CODEOWNERS Cargo.lock
+Files: scripts/* test_data/* *.toml .git* fuzz/Cargo.lock fuzz/.gitignore resources/linux-config-* vmm/src/api/openapi/cloud-hypervisor.yaml CODEOWNERS Cargo.lock flake.nix flake.lock chv.nix
 Copyright: 2024
 License: Apache-2.0

--- a/chv.nix
+++ b/chv.nix
@@ -1,0 +1,65 @@
+# Builds Cloud Hypervisor with using crane.
+#
+# Uses a pragmatic release profile with debug-ability and faster
+# compilation times in mind without sacrificing too much performance.
+
+{
+  # helper from nixpkgs
+  lib,
+  openssl,
+  pkg-config,
+  # other helper
+  craneLib,
+  # other
+  meta, # meta of pkgs.cloud-hypervisor
+  src, # clean source
+}:
+let
+  commonArgs = {
+    inherit meta src;
+    # Since Nov 2025 (v50), Cloud Hypervisor has a virtual manifest and the
+    # main package was moved into a sub directory.
+    cargoToml = "${src}/cloud-hypervisor/Cargo.toml";
+
+    # Pragmatic release profile with debug-ability and faster
+    # compilation times in mind.
+    env = {
+      CARGO_PROFILE_RELEASE_DEBUG_ASSERTIONS = "true";
+      CARGO_PROFILE_RELEASE_OPT_LEVEL = 2;
+      CARGO_PROFILE_RELEASE_OVERFLOW_CHECKS = "true";
+      CARGO_PROFILE_RELEASE_LTO = "thin";
+
+      # Fix build. Reference:
+      # - https://github.com/sfackler/rust-openssl/issues/1430
+      # - https://docs.rs/openssl/latest/openssl/
+      OPENSSL_NO_VENDOR = true;
+    };
+
+    nativeBuildInputs = [
+      pkg-config
+    ];
+    buildInputs = [
+      openssl
+    ];
+  };
+
+  # Downloaded and compiled dependencies.
+  cargoArtifacts = craneLib.buildDepsOnly (
+    commonArgs
+    // {
+      doCheck = false;
+    }
+  );
+
+  cargoPackageKvm = craneLib.buildPackage (
+    commonArgs
+    // {
+      inherit cargoArtifacts;
+      # Don't execute tests here. Too expensive for local development with
+      # frequent rebuilds + little benefit.
+      doCheck = false;
+      cargoExtraArgs = "--features kvm";
+    }
+  );
+in
+cargoPackageKvm

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "crane": {
+      "locked": {
+        "lastModified": 1769287525,
+        "narHash": "sha256-gABuYA6BzoRMLuPaeO5p7SLrpd4qExgkwEmYaYQY4bM=",
+        "owner": "ipetkov",
+        "repo": "crane",
+        "rev": "0314e365877a85c9e5758f9ea77a9972afbb4c21",
+        "type": "github"
+      },
+      "original": {
+        "owner": "ipetkov",
+        "ref": "master",
+        "repo": "crane",
+        "type": "github"
+      }
+    },
+    "dried-nix-flakes": {
+      "locked": {
+        "lastModified": 1756139350,
+        "narHash": "sha256-pObQv94NclXVXjJV8sTiKwFes4fGEWpkNzDsXw5DqnY=",
+        "owner": "cyberus-technology",
+        "repo": "dried-nix-flakes",
+        "rev": "1b2ba62710c6c1d9eba0e8e3adc029cc2e9291a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cyberus-technology",
+        "repo": "dried-nix-flakes",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769318308,
+        "narHash": "sha256-Mjx6p96Pkefks3+aA+72lu1xVehb6mv2yTUUqmSet6Q=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "1cd347bf3355fce6c64ab37d3967b4a2cb4b878c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "crane": "crane",
+        "dried-nix-flakes": "dried-nix-flakes",
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769568593,
+        "narHash": "sha256-vf3cZf8imUlPzFtICa1uyReDzoPV0XhHOIRM3tqI5VY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "6fe5039018d05cee5d01dda7df1c0846fb7943a4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+{
+  description = "Cyberus Hypervisor for SAP / Apeiro";
+
+  inputs = {
+    dried-nix-flakes.url = "github:cyberus-technology/dried-nix-flakes";
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.11";
+    # Convenient Nix tooling to build Rust projects.
+    crane.url = "github:ipetkov/crane/master";
+    # Get proper Rust toolchain, independent of pkgs.rustc.
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    inputs:
+    let
+      dnf = (inputs.dried-nix-flakes.for inputs).override {
+        systems = [ "x86_64-linux" ];
+      };
+      inherit (dnf)
+        exportOutputs
+        ;
+    in
+    exportOutputs (
+      {
+        self,
+        # Keep list sorted:
+        crane,
+        nixpkgs,
+        rust-overlay,
+        ...
+      }:
+      let
+        pkgs = nixpkgs.legacyPackages;
+        lib = pkgs.lib;
+        rust-bin = (rust-overlay.lib.mkRustBin { }) pkgs;
+      in
+      {
+
+        formatter = pkgs.nixfmt-tree;
+        devShells.default = pkgs.mkShellNoCC {
+          inputsFrom = builtins.attrValues self.packages;
+          packages = with pkgs; [
+            gitlint
+          ];
+        };
+        packages =
+          let
+            jsonFilter = path: _type: builtins.match ".*json$" path != null;
+            sourceFilter = path: type: (jsonFilter path type) || (craneLib.filterCargoSources path type);
+            src = lib.cleanSourceWith {
+              src = self;
+              filter = sourceFilter;
+              name = "source";
+            };
+
+            rustToolchain = rust-bin.stable.latest.default;
+            craneLib = crane.mkLib pkgs;
+            craneLib' = craneLib.overrideToolchain rustToolchain;
+
+            cloud-hypervisor = pkgs.callPackage ./chv.nix {
+              inherit (pkgs.cloud-hypervisor) meta;
+              inherit src;
+              craneLib = craneLib';
+            };
+          in
+          {
+            default = cloud-hypervisor;
+            inherit cloud-hypervisor;
+          };
+      }
+    );
+}


### PR DESCRIPTION
Adds a flake configuration that enables building Cloud Hypervisor
directly from this repository using Nix.

This makes it possible to deploy and test Cloud Hypervisor on NixOS
systems in real environments.