### PR TITLE
GSI Allocator: free GSIs when they are no longer used

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2689,6 +2689,7 @@ version = "0.1.0"
 dependencies = [
  "arch",
  "libc",
+ "thiserror 2.0.17",
  "vm-memory",
 ]
 

--- a/vm-allocator/Cargo.toml
+++ b/vm-allocator/Cargo.toml
@@ -10,6 +10,7 @@ kvm = ["arch/kvm"]
 
 [dependencies]
 libc = { workspace = true }
+thiserror = { workspace = true }
 vm-memory = { workspace = true }
 
 [target.'cfg(any(target_arch = "aarch64", target_arch = "riscv64"))'.dependencies]

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -223,3 +223,104 @@ impl Default for GsiAllocator {
         GsiAllocator::new()
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use super::{InterruptAllocError, InterruptAllocator};
+
+    #[test]
+    // Checks that the allocator can only allocate as many vectors as configured.
+    fn test_allocator_respects_size() {
+        for size in [1, 8, 16, 17, 32, 64, 65, 128] {
+            let mut allocator = InterruptAllocator::new(size, 0);
+            let mut num_vectors = 0u32;
+
+            loop {
+                let vec = allocator.alloc();
+                match vec {
+                    Ok(_) => {
+                        num_vectors += 1;
+                        continue;
+                    }
+                    Err(e) => match e {
+                        InterruptAllocError::ExhaustedError(_) => {
+                            assert_eq!(size, num_vectors);
+                            break;
+                        }
+                        _ => panic!(),
+                    },
+                }
+            }
+            assert_eq!(size, num_vectors);
+        }
+    }
+
+    #[test]
+    // Checks that the allocator starts allocating vectors at the given offset.
+    fn test_allocator_respects_offset() {
+        for offset in [1, 8, 16, 17, 32, 64, 65, 128] {
+            let mut allocator = InterruptAllocator::new(1, offset);
+            let vec = allocator.alloc().unwrap();
+
+            assert_eq!(offset, vec);
+            allocator.free(vec).unwrap();
+        }
+    }
+
+    #[test]
+    // Checks that the calculations in alloc and free are correct.
+    fn test_allocator_alloc_and_free_all_vectors() {
+        for size in [1, 8, 16, 17, 32, 64, 65, 128, 4096] {
+            let mut allocator = InterruptAllocator::new(size, 0);
+            let mut num_vectors = 0u32;
+
+            while allocator.alloc().is_ok() {
+                num_vectors += 1;
+            }
+
+            assert_eq!(size, num_vectors);
+            num_vectors -= 1;
+
+            loop {
+                if let Err(e) = allocator.free(num_vectors) {
+                    println!("Could not free {num_vectors}: {e}");
+                    break;
+                }
+                if let Some(v) = num_vectors.checked_sub(1) {
+                    num_vectors = v;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    #[test]
+    // Checks that freeing a vector that isn't allocated results in an error.
+    fn test_can_only_free_allocated_vectors() {
+        let mut allocator = InterruptAllocator::new(1, 0);
+
+        let vec = allocator.alloc().unwrap();
+        allocator.free(vec).unwrap();
+
+        let e = allocator.free(vec);
+        assert_eq!(e, Err(InterruptAllocError::AlreadyFree(vec)));
+    }
+
+    #[test]
+    // Checks that freeing a vector that is not in range of the allocator results
+    // in an error.
+    fn test_can_only_free_vectors_in_range() {
+        let size = 1u32;
+        let offset = 0u32;
+        let mut allocator = InterruptAllocator::new(size, 0);
+
+        // The allocator has vectors from `0 .. size - 1`, this `size` should be
+        // out of range.
+        let e = allocator.free(size);
+        assert_eq!(
+            e,
+            Err(InterruptAllocError::OutOfRange(size, offset, offset + size))
+        );
+    }
+}

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -190,6 +190,11 @@ impl GsiAllocator {
         self.gsis.alloc()
     }
 
+    /// Frees a GSI
+    pub fn free_gsi(&mut self, vector: u32) -> Result<(), InterruptAllocError> {
+        self.gsis.free(vector)
+    }
+
     #[cfg(target_arch = "x86_64")]
     /// Allocate an IRQ
     pub fn allocate_irq(&mut self) -> Result<u32, InterruptAllocError> {

--- a/vm-allocator/src/gsi.rs
+++ b/vm-allocator/src/gsi.rs
@@ -4,14 +4,9 @@
 
 #[cfg(target_arch = "x86_64")]
 use std::collections::btree_map::BTreeMap;
-use std::result;
+use std::result::Result;
 
-#[derive(Debug)]
-pub enum Error {
-    Overflow,
-}
-
-pub type Result<T> = result::Result<T, Error>;
+use thiserror::Error;
 
 /// GsiApic
 #[cfg(target_arch = "x86_64")]
@@ -29,80 +24,191 @@ impl GsiApic {
     }
 }
 
+// This interrupt allocator is a simple bitmap that stores which interrupt
+// vectors are currently in use. The allocator has an offset, e.g. if you want
+// to have vectors in the range of [512, 1024), you should choose an offset and
+// a size of 512.
+#[derive(Debug)]
+struct InterruptAllocator {
+    // Although this is used as a bitmap, it is a collection of `usize`. Thus the
+    // name `words`.
+    words: Box<[usize]>,
+    size: u32,
+    offset: u32,
+}
+
+/// Errors that may happen while allocating or freeing an interrupt.
+#[derive(Error, Debug, PartialEq)]
+pub enum InterruptAllocError {
+    /// Interrupt allocator is exhausted, i.e. out of interrupt vectors.
+    #[error("Interrupt allocator is exhausted (capacity: {0})")]
+    ExhaustedError(u32 /* capacity/size */),
+
+    /// Tried to free an interrupt that wasn't allocated.
+    #[error("Interrupt was not allocated: {0}")]
+    AlreadyFree(u32 /* vector */),
+
+    /// Tried to free an interrupt that is not in range of the interrupt allocator.
+    #[error("Interrupt vector is out of range: {0} (range: [{1},{2})")]
+    OutOfRange(
+        u32, /* vector */
+        u32, /* lower bound */
+        u32, /* upper bound */
+    ),
+}
+
+// Maximum number of IRQ routes according to the kernel code.
+const KVM_MAX_IRQ_ROUTES: u32 = 4096;
+
+impl InterruptAllocator {
+    fn new(size: u32, offset: u32) -> Self {
+        assert_ne!(size, 0);
+        let num_words = (size + usize::BITS - 1).div_euclid(usize::BITS);
+
+        let mut words = vec![0usize; num_words as usize].into_boxed_slice();
+        words[(num_words - 1) as usize] = Self::last_word(size);
+
+        Self {
+            words,
+            size,
+            offset,
+        }
+    }
+
+    // Returns the mask of the last word. E.g. if our words would be of type u8, and
+    // we want a size of (n * 8 + 4) (e.g. 12), this would return 0b11110000.
+    fn last_word(size: u32) -> usize {
+        let rem = size % usize::BITS;
+        if rem == 0 {
+            0usize
+        } else {
+            !((1usize << rem) - 1)
+        }
+    }
+
+    fn free(&mut self, vector: u32) -> Result<(), InterruptAllocError> {
+        // At first we make sure that the vector is not out of range.
+        if !(self.offset..self.offset + self.size).contains(&vector) {
+            return Err(InterruptAllocError::OutOfRange(
+                vector,
+                self.offset,
+                self.offset + self.size,
+            ));
+        }
+
+        let idx = vector.abs_diff(self.offset);
+        let (w, b) = Self::word_and_bit(idx);
+
+        let mask = 1usize << b;
+
+        // Let's first check whether the bit is set.
+        if self.words[w] & mask == 0usize {
+            return Err(InterruptAllocError::AlreadyFree(vector));
+        }
+        // Clear the bit and we are done!
+        self.words[w] &= !mask;
+        Ok(())
+    }
+
+    fn word_and_bit(
+        vector: u32,
+    ) -> (
+        usize, /* index into `words` */
+        usize, /* index into `words[w]` */
+    ) {
+        let idx = vector as usize;
+        let bits = usize::BITS as usize;
+        (idx / bits, idx % bits)
+    }
+
+    fn alloc(&mut self) -> Result<u32, InterruptAllocError> {
+        let bits = usize::BITS as usize;
+        if let Some(idx) = self.words.iter().position(|&w| w != usize::MAX) {
+            let word: &mut usize = &mut self.words[idx];
+            // Find lowest free bit.
+            let bit = (!*word).trailing_zeros() as usize;
+            // Set the bit.
+            *word |= 1usize << bit;
+            // Calculate index, add offset and return.
+            let vector = idx * bits + bit;
+            return Ok(vector as u32 + self.offset);
+        }
+        Err(InterruptAllocError::ExhaustedError(self.size))
+    }
+
+    fn size(&self) -> u32 {
+        self.size
+    }
+}
+
 /// GsiAllocator
 pub struct GsiAllocator {
     #[cfg(target_arch = "x86_64")]
     apics: BTreeMap<u32, u32>,
-    next_irq: u32,
-    next_gsi: u32,
+    irqs: InterruptAllocator,
+    gsis: InterruptAllocator,
 }
 
 impl GsiAllocator {
     #[cfg(target_arch = "x86_64")]
     /// New GSI allocator
     pub fn new(apics: &[GsiApic]) -> Self {
-        let mut allocator = GsiAllocator {
-            apics: BTreeMap::new(),
-            next_irq: 0xffff_ffff,
-            next_gsi: 0,
-        };
+        let mut allocator_apics = BTreeMap::new();
+        let mut next_irq = 0xffff_ffffu32;
+        let mut next_gsi = 0u32;
 
         for apic in apics {
-            if apic.base < allocator.next_irq {
-                allocator.next_irq = apic.base;
+            if apic.base < next_irq {
+                next_irq = apic.base;
             }
 
-            if apic.base + apic.irqs > allocator.next_gsi {
-                allocator.next_gsi = apic.base + apic.irqs;
+            if apic.base + apic.irqs > next_gsi {
+                next_gsi = apic.base + apic.irqs;
             }
 
-            allocator.apics.insert(apic.base, apic.irqs);
+            allocator_apics.insert(apic.base, apic.irqs);
         }
 
-        allocator
+        Self {
+            apics: allocator_apics,
+            irqs: InterruptAllocator::new(KVM_MAX_IRQ_ROUTES - next_irq, next_irq),
+            gsis: InterruptAllocator::new(KVM_MAX_IRQ_ROUTES - next_gsi, next_gsi),
+        }
     }
 
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     /// New GSI allocator
     pub fn new() -> Self {
         GsiAllocator {
-            next_irq: arch::IRQ_BASE,
-            next_gsi: arch::IRQ_BASE,
+            irqs: InterruptAllocator::new(KVM_MAX_IRQ_ROUTES - arch::IRQ_BASE, arch::IRQ_BASE),
+            gsis: InterruptAllocator::new(KVM_MAX_IRQ_ROUTES - arch::IRQ_BASE, arch::IRQ_BASE),
         }
     }
 
     /// Allocate a GSI
-    pub fn allocate_gsi(&mut self) -> Result<u32> {
-        let gsi = self.next_gsi;
-        self.next_gsi = self.next_gsi.checked_add(1).ok_or(Error::Overflow)?;
-        Ok(gsi)
+    pub fn allocate_gsi(&mut self) -> Result<u32, InterruptAllocError> {
+        self.gsis.alloc()
     }
 
     #[cfg(target_arch = "x86_64")]
     /// Allocate an IRQ
-    pub fn allocate_irq(&mut self) -> Result<u32> {
-        let mut irq: u32 = 0;
+    pub fn allocate_irq(&mut self) -> Result<u32, InterruptAllocError> {
+        let next_irq = self.irqs.alloc()?;
         for (base, irqs) in self.apics.iter() {
             // HACKHACK - This only works with 1 single IOAPIC...
-            if self.next_irq >= *base && self.next_irq < *base + *irqs {
-                irq = self.next_irq;
-                self.next_irq += 1;
+            if next_irq >= *base && next_irq < *base + *irqs {
+                return Ok(next_irq);
             }
         }
 
-        if irq == 0 {
-            return Err(Error::Overflow);
-        }
-
-        Ok(irq)
+        self.irqs.free(next_irq)?;
+        Err(InterruptAllocError::ExhaustedError(self.irqs.size()))
     }
 
     #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
     /// Allocate an IRQ
-    pub fn allocate_irq(&mut self) -> Result<u32> {
-        let irq = self.next_irq;
-        self.next_irq = self.next_irq.checked_add(1).ok_or(Error::Overflow)?;
-        Ok(irq)
+    pub fn allocate_irq(&mut self) -> Result<u32, InterruptAllocError> {
+        self.irqs.alloc()
     }
 }
 

--- a/vm-allocator/src/lib.rs
+++ b/vm-allocator/src/lib.rs
@@ -17,9 +17,9 @@ pub mod page_size;
 mod system;
 
 pub use crate::address::AddressAllocator;
-pub use crate::gsi::GsiAllocator;
 #[cfg(target_arch = "x86_64")]
 pub use crate::gsi::GsiApic;
+pub use crate::gsi::{GsiAllocator, InterruptAllocError};
 pub use crate::system::SystemAllocator;
 mod memory_slot;
 pub use memory_slot::MemorySlotAllocator;

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -91,6 +91,11 @@ impl SystemAllocator {
         self.gsi_allocator.allocate_gsi()
     }
 
+    /// Frees the given GSI.
+    pub fn free_gsi(&mut self, vector: u32) -> Result<(), InterruptAllocError> {
+        self.gsi_allocator.free_gsi(vector)
+    }
+
     /// Reserves a section of `size` bytes of IO address space.
     pub fn allocate_io_addresses(
         &mut self,

--- a/vm-allocator/src/system.rs
+++ b/vm-allocator/src/system.rs
@@ -10,9 +10,9 @@
 use vm_memory::{GuestAddress, GuestUsize};
 
 use crate::address::AddressAllocator;
-use crate::gsi::GsiAllocator;
 #[cfg(target_arch = "x86_64")]
 use crate::gsi::GsiApic;
+use crate::gsi::{GsiAllocator, InterruptAllocError};
 use crate::page_size::get_page_size;
 
 /// Manages allocating system resources such as address space and interrupt numbers.
@@ -31,17 +31,17 @@ use crate::page_size::get_page_size;
 ///           GuestAddress(0x10000000), 0x10000000,
 ///           #[cfg(target_arch = "x86_64")] &[GsiApic::new(5, 19)]).unwrap();
 ///   #[cfg(target_arch = "x86_64")]
-///   assert_eq!(allocator.allocate_irq(), Some(5));
+///   assert_eq!(allocator.allocate_irq(), Ok(5));
 ///   #[cfg(target_arch = "aarch64")]
-///   assert_eq!(allocator.allocate_irq(), Some(32));
+///   assert_eq!(allocator.allocate_irq(), Ok(32));
 ///   #[cfg(target_arch = "riscv64")]
-///   assert_eq!(allocator.allocate_irq(), Some(0));
+///   assert_eq!(allocator.allocate_irq(), Ok(0));
 ///   #[cfg(target_arch = "x86_64")]
-///   assert_eq!(allocator.allocate_irq(), Some(6));
+///   assert_eq!(allocator.allocate_irq(), Ok(6));
 ///   #[cfg(target_arch = "aarch64")]
-///   assert_eq!(allocator.allocate_irq(), Some(33));
+///   assert_eq!(allocator.allocate_irq(), Ok(33));
 ///   #[cfg(target_arch = "riscv64")]
-///   assert_eq!(allocator.allocate_irq(), Some(1));
+///   assert_eq!(allocator.allocate_irq(), Ok(1));
 ///   assert_eq!(allocator.allocate_platform_mmio_addresses(None, 0x1000, Some(0x1000)), Some(GuestAddress(0x1fff_f000)));
 ///
 /// ```
@@ -82,13 +82,13 @@ impl SystemAllocator {
     }
 
     /// Reserves the next available system irq number.
-    pub fn allocate_irq(&mut self) -> Option<u32> {
-        self.gsi_allocator.allocate_irq().ok()
+    pub fn allocate_irq(&mut self) -> Result<u32, InterruptAllocError> {
+        self.gsi_allocator.allocate_irq()
     }
 
     /// Reserves the next available GSI.
-    pub fn allocate_gsi(&mut self) -> Option<u32> {
-        self.gsi_allocator.allocate_gsi().ok()
+    pub fn allocate_gsi(&mut self) -> Result<u32, InterruptAllocError> {
+        self.gsi_allocator.allocate_gsi()
     }
 
     /// Reserves a section of `size` bytes of IO address space.

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -94,7 +94,7 @@ use virtio_devices::{
     AccessPlatformMapping, ActivateError, Block, Endpoint, IommuMapping, PostMigrationAnnouncer,
     VdpaDmaMapping, VirtioMemMappingSource,
 };
-use vm_allocator::{AddressAllocator, SystemAllocator};
+use vm_allocator::{AddressAllocator, InterruptAllocError, SystemAllocator};
 use vm_device::dma_mapping::ExternalDmaMapping;
 use vm_device::interrupt::{
     InterruptIndex, InterruptManager, LegacyIrqGroupConfig, MsiIrqGroupConfig,
@@ -274,7 +274,7 @@ pub enum DeviceManagerError {
 
     /// Cannot allocate IRQ.
     #[error("Cannot allocate IRQ")]
-    AllocateIrq,
+    AllocateIrq(#[from] InterruptAllocError),
 
     /// Cannot configure the IRQ.
     #[error("Cannot configure the IRQ")]

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -31,7 +31,7 @@ impl InterruptRoute {
         let irq_fd = EventFd::new(libc::EFD_NONBLOCK)?;
         let gsi = allocator
             .allocate_gsi()
-            .ok_or_else(|| io::Error::other("Failed allocating new GSI"))?;
+            .map_err(|e| io::Error::other(format!("Failed allocating new GSI: {e}")))?;
 
         Ok(InterruptRoute {
             gsi,

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -24,12 +24,15 @@ struct InterruptRoute {
     gsi: u32,
     irq_fd: EventFd,
     registered: AtomicBool,
+    allocator: Arc<Mutex<SystemAllocator>>,
 }
 
 impl InterruptRoute {
-    pub fn new(allocator: &mut SystemAllocator) -> Result<Self> {
+    pub fn new(allocator: Arc<Mutex<SystemAllocator>>) -> Result<Self> {
         let irq_fd = EventFd::new(libc::EFD_NONBLOCK)?;
         let gsi = allocator
+            .lock()
+            .unwrap()
             .allocate_gsi()
             .map_err(|e| io::Error::other(format!("Failed allocating new GSI: {e}")))?;
 
@@ -37,6 +40,7 @@ impl InterruptRoute {
             gsi,
             irq_fd,
             registered: AtomicBool::new(false),
+            allocator,
         })
     }
 
@@ -74,6 +78,12 @@ impl InterruptRoute {
                 .try_clone()
                 .expect("Failed cloning interrupt's EventFd"),
         )
+    }
+}
+
+impl Drop for InterruptRoute {
+    fn drop(&mut self) {
+        self.allocator.lock().unwrap().free_gsi(self.gsi).unwrap();
     }
 }
 
@@ -292,11 +302,10 @@ impl InterruptManager for MsiInterruptManager {
     type GroupConfig = MsiIrqGroupConfig;
 
     fn create_group(&self, config: Self::GroupConfig) -> Result<Arc<dyn InterruptSourceGroup>> {
-        let mut allocator = self.allocator.lock().unwrap();
         let mut irq_routes: HashMap<InterruptIndex, InterruptRoute> =
             HashMap::with_capacity(config.count as usize);
         for i in config.base..config.base + config.count {
-            irq_routes.insert(i, InterruptRoute::new(&mut allocator)?);
+            irq_routes.insert(i, InterruptRoute::new(self.allocator.clone())?);
         }
 
         Ok(Arc::new(MsiInterruptGroup::new(

--- a/vmm/src/pci_segment.rs
+++ b/vmm/src/pci_segment.rs
@@ -198,7 +198,7 @@ impl PciSegment {
                     .lock()
                     .unwrap()
                     .allocate_irq()
-                    .ok_or(DeviceManagerError::AllocateIrq)? as u8,
+                    .map_err(DeviceManagerError::AllocateIrq)? as u8,
             );
         }
 


### PR DESCRIPTION
This PR changes the `GsiAllocator` to enable it to free GSIs when they are no longer used. To do that, it replaces the `u32` that was used to track used GSIs with a simple bitmap. If you know a good bitmap crate that I should use, please tell me.

While I was here, I also made sure that errors from the allocator a propagated. I also used the bitmap for the IRQs of the `GsiAllocator`, just because it made it easier for me to propagate useful errors. 

I am not completely sure whether I free the GSIs at all necessary places.