### PR TITLE
Allow to modify host numa settings

### DIFF
--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -951,6 +951,7 @@ fn receive_migration_data(url: String, tls_dir: Option<PathBuf>) -> String {
         // almost always invalid.
         net_fds: vec![],
         tls_dir,
+        zones: vec![],
     };
 
     serde_json::to_string(&receive_migration_data).unwrap()

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -53,8 +53,8 @@ use crate::config::{RestoreConfig, RestoredNetConfig};
 use crate::device_tree::DeviceTree;
 use crate::vm::{Error as VmError, VmState};
 use crate::vm_config::{
-    DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, UserDeviceConfig, VdpaConfig,
-    VmConfig, VsockConfig,
+    DeviceConfig, DiskConfig, FsConfig, MemoryZoneConfig, NetConfig, PmemConfig, UserDeviceConfig,
+    VdpaConfig, VmConfig, VsockConfig,
 };
 
 /// API errors are sent back from the VMM API server through the ApiResponse.
@@ -270,6 +270,8 @@ pub struct VmReceiveMigrationData {
     /// Directory containing the TLS server certificate (server-cert.pem) and TLS server key (server-key.pem).
     #[serde(default)]
     pub tls_dir: Option<PathBuf>,
+    /// Optional memory zone reconfiguration data
+    pub zones: Vec<MemoryZoneConfig>,
 }
 
 #[derive(Clone, Deserialize, Serialize, Debug)]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -84,8 +84,8 @@ use crate::seccomp_filters::{Thread, get_seccomp_filter};
 use crate::sync_utils::Gate;
 use crate::vm::{Error as VmError, Vm, VmState};
 use crate::vm_config::{
-    DeviceConfig, DiskConfig, FsConfig, NetConfig, PmemConfig, UserDeviceConfig, VdpaConfig,
-    VmConfig, VsockConfig,
+    DeviceConfig, DiskConfig, FsConfig, MemoryZoneConfig, NetConfig, PmemConfig, UserDeviceConfig,
+    VdpaConfig, VmConfig, VsockConfig,
 };
 
 mod acpi;
@@ -1865,6 +1865,7 @@ impl Vmm {
                 socket,
                 memory_files,
                 receive_data_migration.tcp_serial_url.clone(),
+                receive_data_migration.zones.clone(),
             )?;
             // Apply external FDs to virtio-net devices.
             if !receive_data_migration.net_fds.is_empty() {
@@ -1965,6 +1966,7 @@ impl Vmm {
         socket: &mut T,
         existing_memory_files: HashMap<u32, File>,
         tcp_serial_url: Option<String>,
+        zones: Vec<MemoryZoneConfig>,
     ) -> std::result::Result<Arc<Mutex<MemoryManager>>, MigratableError>
     where
         T: Read,
@@ -1993,6 +1995,42 @@ impl Vmm {
         if let Some(tcp_serial_url) = tcp_serial_url {
             let mut vm_config = self.vm_config.as_mut().unwrap().lock().unwrap();
             vm_config.serial.url = Some(tcp_serial_url);
+        }
+
+        // Adopt host nodes.
+        if !zones.is_empty() {
+            let mut vm_config = self.vm_config.as_mut().unwrap().lock().unwrap();
+            if let Some(config_zones) = &mut vm_config.memory.zones {
+                for zone in zones {
+                    // We currently only support to move MemoryZones to different host nodes. We therefore ensure that
+                    // there exists a memory zone in the new config that matches the same size and ID for each memory
+                    // zone of the old config.
+                    if let Some(matched_zone) = config_zones.iter_mut().find(|z| z.id == zone.id) {
+                        if matched_zone.size != zone.size {
+                            return Err(MigratableError::MigrateReceive(anyhow!(
+                                "Size update of memory zone with ID {} not allowed. Tried to resize from {:018x?} to {:018x?}",
+                                zone.id,
+                                zone.size,
+                                matched_zone.size
+                            )));
+                        }
+                        // Override the host numa node
+                        matched_zone.host_numa_node = zone.host_numa_node;
+                    } else {
+                        // We did not find a match for a memory zone that was defined in the old config, so we cannot
+                        // update it.
+                        return Err(MigratableError::MigrateReceive(anyhow!(
+                            "Failed to associate new memory zone information with ID {} to an existing zone",
+                            zone.id
+                        )));
+                    }
+                }
+            } else {
+                // MemoryZoneConfigs were provided but the initial config didn't contain any
+                return Err(MigratableError::MigrateReceive(anyhow!(
+                    "Updating memory zone data is forbidden as VM was instantiated without any zones"
+                )));
+            }
         }
 
         self.console_info = Some(pre_create_console_devices(self).map_err(|e| {
@@ -3561,8 +3599,11 @@ impl RequestHandler for Vmm {
         receive_data_migration: VmReceiveMigrationData,
     ) -> result::Result<(), MigratableError> {
         info!(
-            "Receiving migration: receiver_url = {}, net_fds={:?}",
-            receive_data_migration.receiver_url, &receive_data_migration.net_fds
+            "Receiving migration: receiver_url = {}, net_fds={:?}, tcp_url={:?}, zones={:?}",
+            receive_data_migration.receiver_url,
+            &receive_data_migration.net_fds,
+            &receive_data_migration.tcp_serial_url,
+            &receive_data_migration.zones,
         );
 
         let mut listener = receive_migration_listener(&receive_data_migration)?;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -1058,7 +1058,6 @@ impl MemoryManager {
                 .filter(|r| r.2 == RegionType::Ram)
                 .map(|r| (r.0, r.1))
                 .collect();
-
             let arch_mem_regions: Vec<ArchMemRegion> = arch_mem_regions
                 .iter()
                 .map(|(a, b, c)| ArchMemRegion {
@@ -1438,6 +1437,10 @@ impl MemoryManager {
             // MPOL_BIND is the selected mode as it specifies a strict policy
             // that restricts memory allocation to the nodes specified in the
             // nodemask.
+            info!(
+                "Creating raw memory region: host-addr={:018x}, len={len}, mode={mode}, host-node={node}",
+                addr as u64
+            );
             Self::mbind(addr, len, mode, &nodemask, maxnode, flags)
                 .map_err(Error::ApplyNumaPolicy)?;
         }


### PR DESCRIPTION
It is possible to migrate a VM to a host that might have a different numa configuration. In such a case, we need to adjust the mapping of guest memory to host nodes. This patch therefore adds a new field to `VmReceiveMigrationData` in order to allow to provide the VMM with information about changing `MemoryZoneConfig`s.

Currently we only support the reassignment of the `host_numa_node`. Any other form of reconfiguration is left out for a followup.

This is a fix for https://github.com/cobaltcore-dev/cobaltcore/issues/401