### PR TITLE
Add API Call to Cancel Migrations

### DIFF
--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -631,6 +631,8 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
             )?;
             simple_api_command(socket, "PUT", "create", Some(&data)).map_err(Error::HttpApiClient)
         }
+        Some("cancel-migration") => simple_api_command(socket, "PUT", "cancel-migration", None)
+            .map_err(Error::HttpApiClient),
         _ => unreachable!(),
     }
 }
@@ -1139,6 +1141,7 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
             .about("Add vsock device")
             .arg(Arg::new("vsock_config").index(1).help(VsockConfig::SYNTAX)),
         Command::new("boot").about("Boot a created VM"),
+        Command::new("cancel-migration").about("Cancel any ongoing migration"),
         Command::new("coredump")
             .about("Create a coredump from VM")
             .arg(Arg::new("coredump_config").index(1).help("<file_path>")),

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -47,6 +47,9 @@ pub enum MigratableError {
     #[error("Failed to retrieve dirty ranges for migratable component")]
     DirtyLog(#[source] anyhow::Error),
 
+    #[error("Failed to cancel migration")]
+    CancelMigration(#[source] anyhow::Error),
+
     #[error("Failed to start migration for migratable component")]
     StartMigration(#[source] anyhow::Error),
 

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -56,6 +56,9 @@ pub enum MigratableError {
     #[error("Failed to complete migration for migratable component")]
     CompleteMigration(#[source] anyhow::Error),
 
+    #[error("Failed to continue the migration as it was cancelled")]
+    Cancelled,
+
     #[error("Failed to release a disk lock")]
     UnlockError(#[source] anyhow::Error),
 

--- a/vmm/src/api/http/http_endpoint.rs
+++ b/vmm/src/api/http/http_endpoint.rs
@@ -47,8 +47,8 @@ use crate::api::http::http_endpoint::fds_helper::{attach_fds_to_cfg, attach_fds_
 use crate::api::http::{EndpointHandler, HttpError, error_response};
 use crate::api::{
     AddDisk, ApiAction, ApiError, ApiRequest, NetConfig, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem,
-    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmConfig, VmCounters, VmDelete,
-    VmMigrationProgress, VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration,
+    VmAddUserDevice, VmAddVdpa, VmAddVsock, VmBoot, VmCancelMigration, VmConfig, VmCounters,
+    VmDelete, VmMigrationProgress, VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration,
     VmReceiveMigrationData, VmRemoveDevice, VmResize, VmResizeDisk, VmResizeZone, VmRestore,
     VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
@@ -417,6 +417,7 @@ vm_action_put_handler!(VmPause);
 vm_action_put_handler!(VmResume);
 vm_action_put_handler!(VmPowerButton);
 vm_action_put_handler!(VmNmi);
+vm_action_put_handler!(VmCancelMigration);
 
 vm_action_put_handler_body!(VmAddDevice);
 vm_action_put_handler_body!(AddDisk);

--- a/vmm/src/api/http/mod.rs
+++ b/vmm/src/api/http/mod.rs
@@ -29,9 +29,9 @@ use self::http_endpoint::{VmActionHandler, VmCreate, VmInfo, VmmPing, VmmShutdow
 use crate::api::VmCoredump;
 use crate::api::{
     AddDisk, ApiError, ApiRequest, VmAddDevice, VmAddFs, VmAddNet, VmAddPmem, VmAddUserDevice,
-    VmAddVdpa, VmAddVsock, VmBoot, VmCounters, VmDelete, VmMigrationProgress, VmNmi, VmPause,
-    VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize, VmResizeDisk,
-    VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
+    VmAddVdpa, VmAddVsock, VmBoot, VmCancelMigration, VmCounters, VmDelete, VmMigrationProgress,
+    VmNmi, VmPause, VmPowerButton, VmReboot, VmReceiveMigration, VmRemoveDevice, VmResize,
+    VmResizeDisk, VmResizeZone, VmRestore, VmResume, VmSendMigration, VmShutdown, VmSnapshot,
 };
 use crate::landlock::Landlock;
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
@@ -270,6 +270,10 @@ pub static HTTP_ROUTES: LazyLock<HttpRoutes> = LazyLock::new(|| {
     r.routes.insert(
         endpoint!("/vm.send-migration"),
         Box::new(VmActionHandler::new(&VmSendMigration)),
+    );
+    r.routes.insert(
+        endpoint!("/vm.cancel-migration"),
+        Box::new(VmActionHandler::new(&VmCancelMigration)),
     );
     r.routes.insert(
         endpoint!("/vm.shutdown"),

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -197,6 +197,10 @@ pub enum ApiError {
     #[error("Error starting migration sender")]
     VmSendMigration(#[source] MigratableError),
 
+    /// Error cancelling migration
+    #[error("Error cancelling migration")]
+    VmCancelMigration(#[source] MigratableError),
+
     /// Error triggering power button
     #[error("Error triggering power button")]
     VmPowerButton(#[source] VmError),
@@ -407,10 +411,17 @@ pub trait RequestHandler {
         receive_data_migration: VmReceiveMigrationData,
     ) -> Result<(), MigratableError>;
 
+    /// Dispatches the migration.
     fn vm_send_migration(
         &mut self,
         send_data_migration: VmSendMigrationData,
     ) -> Result<(), MigratableError>;
+
+    /// Triggers a migration cancellation.
+    ///
+    /// The cancellation is not guaranteed to succeed, as the migration may have
+    /// succeeded already.
+    fn vm_cancel_migration(&mut self) -> Result<(), MigratableError>;
 
     fn vm_nmi(&mut self) -> Result<(), VmError>;
 
@@ -1105,6 +1116,39 @@ impl ApiAction for VmReceiveMigration {
             let response = vmm
                 .vm_receive_migration(data)
                 .map_err(ApiError::VmReceiveMigration)
+                .map(|_| ApiResponsePayload::Empty);
+
+            response_sender
+                .send(response)
+                .map_err(VmmError::ApiResponseSend)?;
+
+            Ok(false)
+        })
+    }
+
+    fn send(
+        &self,
+        api_evt: EventFd,
+        api_sender: Sender<ApiRequest>,
+        data: Self::RequestBody,
+    ) -> ApiResult<Self::ResponseBody> {
+        get_response_body(self, api_evt, api_sender, data)
+    }
+}
+
+pub struct VmCancelMigration;
+
+impl ApiAction for VmCancelMigration {
+    type RequestBody = ();
+    type ResponseBody = Option<Body>;
+
+    fn request(&self, data: Self::RequestBody, response_sender: Sender<ApiResponse>) -> ApiRequest {
+        Box::new(move |vmm| {
+            info!("API request event: VmCancelMigration {data:?}");
+
+            let response = vmm
+                .vm_cancel_migration()
+                .map_err(ApiError::VmCancelMigration)
                 .map(|_| ApiResponsePayload::Empty);
 
             response_sender

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -802,42 +802,18 @@ struct MigrationWorker {
 }
 
 impl MigrationWorker {
-    /// Performs any final cleanup after failed live migrations.
-    ///
-    /// Helper for [`Self::migrate`].
-    fn migrate_error_cleanup(&mut self) -> result::Result<(), MigratableError> {
-        // Stop logging dirty pages only for non-local migrations
-        if !self.config.local {
-            self.vm.stop_dirty_log()?;
-        }
+    /// Perform the migration and communicate with the [`Vmm`] thread.
+    fn run(mut self) -> MigrationThreadOut {
+        debug!("migration thread is starting");
 
-        Ok(())
-    }
-
-    /// Migrate and cleanup.
-    fn migrate(&mut self) -> result::Result<(), MigratableError> {
-        debug!("start sending migration");
-        Vmm::send_migration(
+        let res = Vmm::send_migration(
             &mut self.vm,
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             self.hypervisor.as_ref(),
             &self.config,
             self.postponed_lifecycle_event.as_ref(),
-        ).inspect_err(|_| {
-            let e = self.migrate_error_cleanup();
-            if let Err(e) = e {
-                error!("Failed to clean up after a failed live migration. VM might keep running but in an odd or possibly slowed-down state: {e}");
-            }
-        })?;
-
-        Ok(())
-    }
-
-    /// Perform the migration and communicate with the [`Vmm`] thread.
-    fn run(mut self) -> MigrationThreadOut {
-        debug!("migration thread is starting");
-
-        let res = self.migrate().inspect_err(|e| error!("migrate error: {e}"));
+        )
+        .inspect_err(|e| error!("migrate error: {e}"));
 
         // Notify VMM thread to get migration result by joining this thread.
         self.check_migration_evt.write(1).unwrap();
@@ -2898,7 +2874,6 @@ impl Vmm {
             Err(e) => {
                 error!("Migration failed: {e}");
                 // we don't fail the VMM here, it just continues running its VM
-
                 // If the failure happened very late in the migration path, the VM might already be
                 // stopped. We resume it to ensure proper operation.
                 //
@@ -2909,11 +2884,6 @@ impl Vmm {
                     match vm.resume() {
                         Ok(_) => {
                             info!("Resumed VM successfully after failed migration");
-
-                            // Ensure full VM performance. The operation is idempotent.
-                            let _ = vm.stop_dirty_log().inspect_err(|e| {
-                                warn!("Failed stopping dirty log after resuming VM: {e} - VM performance might be slower than usual");
-                            });
                         }
                         Err(e) => {
                             error!("Failed resuming VM after failed migration: {e}");
@@ -2921,6 +2891,11 @@ impl Vmm {
                         }
                     }
                 }
+
+                // Ensure full VM performance. The operation is idempotent.
+                let _ = vm.stop_dirty_log().inspect_err(|e| {
+                warn!("Failed stopping dirty log after resuming VM: {e} - VM performance might be slower than usual");
+            });
 
                 // Give VMM back control.
                 self.vm = MaybeVmOwnership::Vmm(vm);

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -792,9 +792,20 @@ impl MigrationStateInternal {
 struct MigrationWorkerHandle {
     // Option to take the inner handle
     handle: Option<JoinHandle<MigrationThreadOut>>,
+    cancel: Arc<AtomicBool>,
 }
 
 impl MigrationWorkerHandle {
+    /// Cancels the migration.
+    ///
+    /// Note that timing issues in the very last phase of the migration allow a
+    /// tiny window in that migration succeeds before they could be canceled.
+    fn trigger_cancellation(&self) {
+        info!("Will cancel ongoing live-migration");
+        self.cancel.store(true, Ordering::Release);
+        // we just dispatch here and do not block for the migration thread
+    }
+
     /// Joins the thread and returns the result.
     fn join(mut self) -> MigrationThreadOut {
         self.handle
@@ -827,6 +838,7 @@ struct MigrationWorker {
     postponed_lifecycle_event: Arc<Mutex<Option<PostMigrationLifecycleEvent>>>,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
+    cancel: Arc<AtomicBool>,
 }
 
 impl MigrationWorker {
@@ -840,6 +852,7 @@ impl MigrationWorker {
             self.hypervisor.as_ref(),
             &self.config,
             self.postponed_lifecycle_event.as_ref(),
+            self.cancel.clone(),
         )
         .inspect_err(|e| error!("migrate error: {e}"));
 
@@ -863,6 +876,7 @@ impl MigrationWorker {
             dyn hypervisor::Hypervisor,
         >,
     ) -> MigrationWorkerHandle {
+        let cancel = Arc::new(AtomicBool::new(false));
         let worker = MigrationWorker {
             vm,
             check_migration_evt,
@@ -870,6 +884,7 @@ impl MigrationWorker {
             postponed_lifecycle_event,
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             hypervisor,
+            cancel: cancel.clone(),
         };
 
         let inner_handle = thread::Builder::new()
@@ -881,6 +896,7 @@ impl MigrationWorker {
 
         MigrationWorkerHandle {
             handle: Some(inner_handle),
+            cancel,
         }
     }
 }
@@ -2597,7 +2613,17 @@ impl Vmm {
         hypervisor: &dyn hypervisor::Hypervisor,
         send_data_migration: &VmSendMigrationData,
         postponed_lifecycle_event: &Mutex<Option<PostMigrationLifecycleEvent>>,
+        cancel: Arc<AtomicBool>,
     ) -> result::Result<(), MigratableError> {
+        let return_if_cancelled_cb = move |socket: &mut SocketStream| {
+            if cancel.load(Ordering::Acquire) {
+                info!("Cancelling migration now");
+                Request::abandon().write_to(socket)?;
+                Err(MigratableError::Cancelled)
+            } else {
+                Ok(())
+            }
+        };
         let mut s = MigrationStateInternal::new();
 
         // Set up the socket connection
@@ -2738,6 +2764,10 @@ impl Vmm {
         )?;
         // Complete the migration
         // At this step, the receiving VMM will acquire disk locks again.
+
+        // Very last and final check:
+        return_if_cancelled_cb(&mut socket)?;
+
         Request::complete().write_to(&mut socket)?;
         Response::read_from(&mut socket)?.ok_or_abandon(
             &mut socket,
@@ -2973,9 +3003,29 @@ impl Vmm {
                     }
                 }
             }
+            Err(MigratableError::Cancelled) => {
+                error!("Migration cancelled");
+                try_resume_vm(vm);
+
+                // Update migration progress snapshot
+                {
+                    let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+                    lock.as_mut()
+                        .expect("live migration should be ongoing")
+                        .mark_as_cancelled();
+                }
+            }
             Err(e) => {
                 error!("Migration failed: {e}");
                 try_resume_vm(vm);
+
+                // Update migration progress snapshot
+                {
+                    let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+                    lock.as_mut()
+                        .expect("live migration should be ongoing")
+                        .mark_as_failed(&e);
+                }
             }
         }
         self.clear_postponed_lifecycle_event();
@@ -4040,7 +4090,14 @@ impl RequestHandler for Vmm {
             }
         }
 
-        todo!()
+        let handle = self
+            .migration_thread_handle
+            .as_ref()
+            .expect("should have handle");
+        // We just dispatch the cancellation.
+        handle.trigger_cancellation();
+
+        Ok(())
     }
 
     fn vm_migration_progress(&mut self) -> Option<MigrationProgress> {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1573,6 +1573,7 @@ impl SendAdditionalConnections {
         &self,
         table: &MemoryRangeTable,
         socket: &mut SocketStream,
+        return_if_cancelled_cb: &impl Fn(&mut SocketStream) -> result::Result<(), MigratableError>,
     ) -> std::result::Result<(), MigratableError> {
         let thread_len = self.threads.len();
 
@@ -1581,7 +1582,11 @@ impl SendAdditionalConnections {
         // because we wait for a response after each chunk instead of sending
         // everything in one go.
         if thread_len == 0 {
-            vm_send_memory(&self.guest_memory, socket, table)?;
+            for chunk in table.partition(Self::CHUNK_SIZE) {
+                return_if_cancelled_cb(socket)
+                    .inspect_err(|_| info!("cancelling migration during memory iteration"))?;
+                vm_send_memory(&self.guest_memory, socket, &chunk)?;
+            }
             return Ok(());
         }
 
@@ -1592,6 +1597,9 @@ impl SendAdditionalConnections {
             // The channel we put work into has a limited size. Thus it may happen that we have to
             // retry putting this chunk into it.
             'retry_chunk: loop {
+                return_if_cancelled_cb(socket)
+                    .inspect_err(|_| info!("cancelling migration during memory iteration"))?;
+
                 // If one of the workers encountered an error, we return it.
                 if self.cancel.load(Ordering::Relaxed) {
                     loop {
@@ -2348,6 +2356,7 @@ impl Vmm {
     ///
     /// This transmits the initial VM memory as well as all VM memory delta transmissions while the
     /// VM keeps running.
+    #[allow(clippy::too_many_arguments)]
     fn memory_copy_iterations(
         vm: &mut Vm,
         mem_send: &SendAdditionalConnections,
@@ -2356,6 +2365,7 @@ impl Vmm {
         migration_timeout: Duration,
         migrate_downtime_limit: Duration,
         postponed_lifecycle_event: &Mutex<Option<PostMigrationLifecycleEvent>>,
+        return_if_cancelled_cb: &impl Fn(&mut SocketStream) -> result::Result<(), MigratableError>,
     ) -> result::Result<MemoryRangeTable, MigratableError> {
         let mut iteration_table;
         let total_memory_size_bytes = vm
@@ -2404,6 +2414,8 @@ impl Vmm {
 
         // We loop until we converge (target downtime is achievable).
         loop {
+            return_if_cancelled_cb(socket)?;
+
             // Update the start time of the iteration
             s.iteration_start_time = Instant::now();
 
@@ -2487,7 +2499,7 @@ impl Vmm {
 
             // Send the current dirty pages
             s.transmit_start_time = Instant::now();
-            mem_send.send_memory(&iteration_table, socket)?;
+            mem_send.send_memory(&iteration_table, socket, return_if_cancelled_cb)?;
             s.transmit_duration = s.transmit_start_time.elapsed();
 
             s.total_transferred_bytes += s.bytes_to_transmit;
@@ -2525,6 +2537,7 @@ impl Vmm {
         s: &mut MigrationStateInternal,
         send_data_migration: &VmSendMigrationData,
         postponed_lifecycle_event: &Mutex<Option<PostMigrationLifecycleEvent>>,
+        return_if_cancelled_cb: &impl Fn(&mut SocketStream) -> result::Result<(), MigratableError>,
     ) -> result::Result<(), MigratableError> {
         let mem_send = SendAdditionalConnections::new(send_data_migration, &vm.guest_memory())?;
 
@@ -2561,6 +2574,7 @@ impl Vmm {
             migration_timeout,
             migrate_downtime_limit,
             postponed_lifecycle_event,
+            return_if_cancelled_cb,
         )?;
 
         info!("Entering downtime phase");
@@ -2576,7 +2590,7 @@ impl Vmm {
         // Send last batch of dirty pages
         let mut final_table = vm.dirty_log()?;
         final_table.extend(iteration_table.clone());
-        mem_send.send_memory(&final_table, socket)?;
+        mem_send.send_memory(&final_table, socket, return_if_cancelled_cb)?;
 
         // Update statistics
         s.bytes_to_transmit = final_table.regions().iter().map(|range| range.length).sum();
@@ -2636,6 +2650,8 @@ impl Vmm {
             MigratableError::MigrateSend(anyhow!("Error starting migration (got bad response)")),
         )?;
 
+        return_if_cancelled_cb(&mut socket)?;
+
         // Send config
         let vm_config = vm.get_config();
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -2674,6 +2690,8 @@ impl Vmm {
             .map_err(MigratableError::MigrateSend)?
         };
 
+        return_if_cancelled_cb(&mut socket)?;
+
         if send_data_migration.local {
             match &mut socket {
                 SocketStream::Unix(unix_socket) => {
@@ -2693,6 +2711,8 @@ impl Vmm {
             }
         }
 
+        return_if_cancelled_cb(&mut socket)?;
+
         let vm_migration_config = VmMigrationConfig {
             vm_config,
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
@@ -2711,6 +2731,8 @@ impl Vmm {
             )),
         )?;
 
+        return_if_cancelled_cb(&mut socket)?;
+
         // Let every Migratable object know about the migration being started.
         vm.start_migration()?;
 
@@ -2724,8 +2746,11 @@ impl Vmm {
                 &mut s,
                 send_data_migration,
                 postponed_lifecycle_event,
+                &return_if_cancelled_cb,
             )?;
         }
+
+        return_if_cancelled_cb(&mut socket)?;
 
         // Update migration progress snapshot
         {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2895,7 +2895,7 @@ impl Vmm {
         // At this point, the thread must be finished.
         // If we fail here, we have lost anyway. Just panic.
         let MigrationThreadOut {
-            mut vm,
+            vm,
             migration_res,
             migration_cfg,
         } = self
@@ -2903,6 +2903,53 @@ impl Vmm {
             .take()
             .expect("should have thread")
             .join();
+
+        let mut try_resume_vm = |mut vm: Vm| {
+            // If the failure happened very late in the migration path, the VM might already be
+            // stopped. We resume it to ensure proper operation.
+            //
+            // Cloud Hypervisor only supports migration of running VMs, therefore it cannot
+            // happen that we resume a previously paused VM.
+            let state = vm.get_state().expect("should acquire lock");
+            if state == VmState::Paused {
+                match vm.resume() {
+                    Ok(_) => {
+                        info!("Resumed VM successfully after failed migration");
+                    }
+                    Err(e) => {
+                        error!("Failed resuming VM after failed migration: {e}");
+                        self.exit_evt.write(1).unwrap();
+                    }
+                }
+            }
+
+            // Ensure full VM performance. The operation is idempotent.
+            let _ = vm.stop_dirty_log().inspect_err(|e| {
+                warn!("Failed stopping dirty log after resuming VM: {e} - VM performance might be slower than usual");
+            });
+
+            // Give VMM back control.
+            self.vm = MaybeVmOwnership::Vmm(vm);
+
+            if let Some(event) = self.current_postponed_lifecycle_event() {
+                match event {
+                    PostMigrationLifecycleEvent::VmReboot => {
+                        self.reset_evt
+                            .write(1)
+                            .context("Failed replaying reset event after failed migration")
+                            .inspect_err(|write_err| error!("{write_err}"))
+                            .ok();
+                    }
+                    PostMigrationLifecycleEvent::VmmShutdown => {
+                        self.exit_evt
+                            .write(1)
+                            .context("Failed replaying shutdown event after failed migration")
+                            .inspect_err(|write_err| error!("{write_err}"))
+                            .ok();
+                    }
+                }
+            }
+        };
 
         match migration_res {
             Ok(()) => {
@@ -2928,57 +2975,7 @@ impl Vmm {
             }
             Err(e) => {
                 error!("Migration failed: {e}");
-                // we don't fail the VMM here, it just continues running its VM
-                // If the failure happened very late in the migration path, the VM might already be
-                // stopped. We resume it to ensure proper operation.
-                //
-                // Cloud Hypervisor only supports migration of running VMs, therefore it cannot
-                // happen that we resume a previously paused VM.
-                let state = vm.get_state().expect("should acquire lock");
-                if state == VmState::Paused {
-                    match vm.resume() {
-                        Ok(_) => {
-                            info!("Resumed VM successfully after failed migration");
-                        }
-                        Err(e) => {
-                            error!("Failed resuming VM after failed migration: {e}");
-                            self.exit_evt.write(1).unwrap();
-                        }
-                    }
-                }
-
-                // Ensure full VM performance. The operation is idempotent.
-                let _ = vm.stop_dirty_log().inspect_err(|e| {
-                warn!("Failed stopping dirty log after resuming VM: {e} - VM performance might be slower than usual");
-            });
-
-                // Give VMM back control.
-                self.vm = MaybeVmOwnership::Vmm(vm);
-                if let Some(event) = self.current_postponed_lifecycle_event() {
-                    match event {
-                        PostMigrationLifecycleEvent::VmReboot => {
-                            self.reset_evt
-                                .write(1)
-                                .context("Failed replaying reset event after failed migration")
-                                .inspect_err(|write_err| error!("{write_err}"))
-                                .ok();
-                        }
-                        PostMigrationLifecycleEvent::VmmShutdown => {
-                            self.exit_evt
-                                .write(1)
-                                .context("Failed replaying shutdown event after failed migration")
-                                .inspect_err(|write_err| error!("{write_err}"))
-                                .ok();
-                        }
-                    }
-                }
-                // Update migration progress snapshot
-                {
-                    let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
-                    lock.as_mut()
-                        .expect("live migration should be ongoing")
-                        .mark_as_failed(&e);
-                }
+                try_resume_vm(vm);
             }
         }
         self.clear_postponed_lifecycle_event();

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -23,7 +23,8 @@ use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{
-    Receiver, RecvError, SendError, Sender, SyncSender, TrySendError, channel, sync_channel,
+    Receiver, RecvError, SendError, Sender, SyncSender, TryRecvError, TrySendError, channel,
+    sync_channel,
 };
 use std::sync::{Arc, Mutex};
 use std::thread::{JoinHandle, sleep};
@@ -1369,6 +1370,8 @@ struct SendAdditionalConnections {
     // using this flag. Only the main thread checks this variable, the other
     // workers will be stopped in the destructor.
     cancel: Arc<AtomicBool>,
+    // Externally triggered cancel.
+    external_cancel: Arc<AtomicBool>,
     // After the main thread sent all memory chunks to the sender threads, it waits until
     // one of the sender threads notifies it. Either because an error occurred, or because
     // they arrived at the Gate.
@@ -1430,6 +1433,7 @@ impl SendAdditionalConnections {
         let buffer_size = Self::BUFFERED_REQUESTS_PER_THREAD * configured_connections as usize;
         let (channel_tx, channel_rx) = sync_channel::<SendMemoryThreadMessage>(buffer_size);
         let cancel = Arc::new(AtomicBool::new(false));
+        let external_cancel = Arc::new(AtomicBool::new(false));
         let (notify_tx, notify_rx) = channel::<SendMemoryThreadNotify>();
 
         let recv = Arc::new(Mutex::new(channel_rx));
@@ -1442,6 +1446,7 @@ impl SendAdditionalConnections {
                 threads,
                 sender: channel_tx,
                 cancel,
+                external_cancel,
                 notify_rx,
             });
         }
@@ -1465,8 +1470,10 @@ impl SendAdditionalConnections {
             let guest_mem = guest_mem.clone();
             let recv = recv.clone();
             let cancel = cancel.clone();
+            let external_cancel = external_cancel.clone();
             let notify_tx = notify_tx.clone();
 
+            // Thread worker loop:
             let thread = thread::spawn(move || {
                 info!("Spawned thread to send VM memory.");
 
@@ -1482,6 +1489,11 @@ impl SendAdditionalConnections {
                     let msg = recv.lock().unwrap().recv().unwrap();
                     match msg {
                         SendMemoryThreadMessage::Memory(table) => {
+                            if external_cancel.load(Ordering::Acquire) {
+                                // We drain all Memory messages and then wait for the Disconnect
+                                continue;
+                            }
+
                             match vm_send_memory(&guest_mem, &mut socket, &table) {
                                 Ok(()) => {
                                     total_sent += table
@@ -1527,12 +1539,17 @@ impl SendAdditionalConnections {
             threads,
             sender: channel_tx,
             cancel,
+            external_cancel,
             notify_rx,
         })
     }
 
     /// Wait until all data that is in-flight has actually been sent and acknowledged.
-    fn wait_for_pending_data(&self) -> std::result::Result<(), MigratableError> {
+    fn wait_for_pending_data(
+        &self,
+        socket: &mut SocketStream,
+        return_if_cancelled_cb: &impl Fn(&mut SocketStream) -> result::Result<(), MigratableError>,
+    ) -> result::Result<(), MigratableError> {
         let gate = Arc::new(Gate::new());
 
         for _ in 0..self.threads.len() {
@@ -1546,19 +1563,36 @@ impl SendAdditionalConnections {
         // threads to notify us that they arrived at the gate using notify_rx.
         let mut seen_threads = 0;
         loop {
-            match self.notify_rx.recv().unwrap() {
-                SendMemoryThreadNotify::Error(e) => {
+            // We instruct all worker threads to cancel all remaining work.
+            return_if_cancelled_cb(socket).inspect_err(|_e| {
+                gate.open();
+                self.external_cancel.store(true, Ordering::Release);
+            })?;
+
+            sleep(Duration::from_millis(2));
+
+            match self.notify_rx.try_recv() {
+                Ok(SendMemoryThreadNotify::Error(e)) => {
                     // If an error occurred in one of the worker threads, we open the gate to make
                     // sure that no thread hangs.
                     gate.open();
                     return Err(e);
                 }
-                SendMemoryThreadNotify::Gate => {
+                Ok(SendMemoryThreadNotify::Gate) => {
                     seen_threads += 1;
                     if seen_threads == self.threads.len() {
                         gate.open();
                         return Ok(());
                     }
+                }
+                Err(TryRecvError::Empty) => {
+                    continue;
+                }
+                Err(TryRecvError::Disconnected) => {
+                    // Unlikely
+                    return Err(MigratableError::MigrateSend(anyhow!(
+                        "All senders died unexpectedly."
+                    )));
                 }
             }
         }
@@ -1597,8 +1631,9 @@ impl SendAdditionalConnections {
             // The channel we put work into has a limited size. Thus it may happen that we have to
             // retry putting this chunk into it.
             'retry_chunk: loop {
-                return_if_cancelled_cb(socket)
-                    .inspect_err(|_| info!("cancelling migration during memory iteration"))?;
+                return_if_cancelled_cb(socket).inspect_err(|_e| {
+                    self.external_cancel.store(true, Ordering::Release);
+                })?;
 
                 // If one of the workers encountered an error, we return it.
                 if self.cancel.load(Ordering::Relaxed) {
@@ -1628,7 +1663,8 @@ impl SendAdditionalConnections {
             }
         }
 
-        self.wait_for_pending_data()?;
+        // When we exit here, drop() will tell all threads to stop next.
+        self.wait_for_pending_data(socket, return_if_cancelled_cb)?;
 
         Ok(())
     }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3987,6 +3987,19 @@ impl RequestHandler for Vmm {
         Ok(())
     }
 
+    fn vm_cancel_migration(&mut self) -> result::Result<(), MigratableError> {
+        match self.vm {
+            MaybeVmOwnership::Migration => (),
+            _ => {
+                return Err(MigratableError::CancelMigration(anyhow!(
+                    "There is no ongoing migration"
+                )));
+            }
+        }
+
+        todo!()
+    }
+
     fn vm_migration_progress(&mut self) -> Option<MigrationProgress> {
         // We explicitly do not check here for `is VM running?` to always
         // enable querying the state of the last failed migration.

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -788,6 +788,34 @@ impl MigrationStateInternal {
     }
 }
 
+/// Handle for the [`MigrationWorker`] thread.
+struct MigrationWorkerHandle {
+    // Option to take the inner handle
+    handle: Option<JoinHandle<MigrationThreadOut>>,
+}
+
+impl MigrationWorkerHandle {
+    /// Joins the thread and returns the result.
+    fn join(mut self) -> MigrationThreadOut {
+        self.handle
+            .take()
+            .expect("should have thread")
+            .join()
+            .expect("should join migration thread gracefully")
+    }
+}
+
+impl Drop for MigrationWorkerHandle {
+    fn drop(&mut self) {
+        if let Some(handle) = self.handle.take() {
+            warn!("Migration thread wasn't cleaned up explicitly via join()");
+            handle
+                .join()
+                .expect("should join migration thread gracefully");
+        }
+    }
+}
+
 /// Abstraction for the thread controlling and performing the live migration.
 ///
 /// The migration thread also takes ownership of the [`Vm`] from the [`Vmm`].
@@ -823,6 +851,36 @@ impl MigrationWorker {
             vm: self.vm,
             migration_res: res,
             migration_cfg: self.config,
+        }
+    }
+
+    fn spawn(
+        vm: Vm,
+        check_migration_evt: EventFd,
+        config: VmSendMigrationData,
+        postponed_lifecycle_event: Arc<Mutex<Option<PostMigrationLifecycleEvent>>>,
+        #[cfg(all(feature = "kvm", target_arch = "x86_64"))] hypervisor: Arc<
+            dyn hypervisor::Hypervisor,
+        >,
+    ) -> MigrationWorkerHandle {
+        let worker = MigrationWorker {
+            vm,
+            check_migration_evt,
+            config,
+            postponed_lifecycle_event,
+            #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+            hypervisor,
+        };
+
+        let inner_handle = thread::Builder::new()
+            .name("migration".into())
+            .spawn(move || worker.run())
+            // For upstreaming, we should simply continue and return an
+            // error when this fails. For our PoC, this is fine.
+            .unwrap();
+
+        MigrationWorkerHandle {
+            handle: Some(inner_handle),
         }
     }
 }
@@ -900,9 +958,7 @@ pub struct Vmm {
     postponed_lifecycle_event: Arc<Mutex<Option<PostMigrationLifecycleEvent>>>,
     received_postponed_lifecycle_event: Option<PostMigrationLifecycleEvent>,
     /// Handle to the [`MigrationWorker`] thread.
-    ///
-    /// The handle will return the [`Vm`] back in any case. Further, the underlying error (if any) is returned.
-    migration_thread_handle: Option<JoinHandle<MigrationThreadOut>>,
+    migration_thread_handle: Option<MigrationWorkerHandle>,
 }
 
 /// Wait for a file descriptor to become readable. In this case, we return
@@ -2846,8 +2902,7 @@ impl Vmm {
             .migration_thread_handle
             .take()
             .expect("should have thread")
-            .join()
-            .expect("should have joined");
+            .join();
 
         match migration_res {
             Ok(()) => {
@@ -3963,26 +4018,17 @@ impl RequestHandler for Vmm {
             ));
         }
 
-        // Start migration thread
-        {
-            let worker = MigrationWorker {
-                vm,
-                check_migration_evt: self.check_migration_evt.try_clone().unwrap(),
-                config: send_data_migration,
-                postponed_lifecycle_event: self.postponed_lifecycle_event.clone(),
-                #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
-                hypervisor: self.hypervisor.clone(),
-            };
-
-            self.migration_thread_handle = Some(
-                thread::Builder::new()
-                    .name("migration".into())
-                    .spawn(move || worker.run())
-                    // For upstreaming, we should simply continue and return an
-                    // error when this fails. For our PoC, this is fine.
-                    .unwrap(),
-            );
-        }
+        let migration_worker = MigrationWorker::spawn(
+            vm,
+            self.check_migration_evt.try_clone().unwrap(),
+            send_data_migration,
+            self.postponed_lifecycle_event.clone(),
+            #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+            self.hypervisor.clone(),
+        );
+        let old = self.migration_thread_handle.replace(migration_worker);
+        // If this fails, we messed up the thread lifecycle management.
+        debug_assert!(old.is_none());
 
         Ok(())
     }


### PR DESCRIPTION
This implements an API call to cancel ongoing live migrations. It is required for proper management of larger cloud deployments.

# Steps to Undraft

- [x] merge and rebase onto #43 