### PR TITLE
vmm: Supply a default for `VmReceiveMigrationData` members

### DIFF
--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -266,11 +266,13 @@ pub struct VmReceiveMigrationData {
     /// migration. Example: "192.168.1.1:2222".
     pub tcp_serial_url: Option<String>,
     /// Map with new network FDs on the new host.
+    #[serde(default)]
     pub net_fds: Vec<RestoredNetConfig>,
     /// Directory containing the TLS server certificate (server-cert.pem) and TLS server key (server-key.pem).
     #[serde(default)]
     pub tls_dir: Option<PathBuf>,
     /// Optional memory zone reconfiguration data
+    #[serde(default)]
     pub zones: Vec<MemoryZoneConfig>,
 }
 


### PR DESCRIPTION
If no defaults are supplied for `VmReceiveMigrationData` deserialization, deserialization can fail.


On-behalf-of: SAP pascal.scholz@sap.com