### PR TITLE
Gracefully handle lost network

### DIFF
--- a/vm-migration/src/keep_alive_stream.rs
+++ b/vm-migration/src/keep_alive_stream.rs
@@ -1,0 +1,282 @@
+// Copyright © 2025 Cyberus Technology GmbH
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+
+use std::io::{self, Read, Write};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, sync_channel};
+use std::thread::JoinHandle;
+use std::time::Duration;
+use std::{result, thread};
+
+use vm_memory::bitmap::BitmapSlice;
+use vm_memory::{ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile};
+
+use crate::protocol::Request;
+
+/// The `KeepAliveStream` is a stream that is intended to be used for the main
+/// connection of live migrations. If the `KeepAliveStream` does not read or
+/// write often enough, it will send keep alive messages on the given stream.
+/// The `KeepAliveStream` should not be used to send or receive memory, because
+/// the `read_volatile()` and `write_volatile()` functions will be very slow.
+///
+/// The `KeepAliveStream` is designed to be compatible with the `SocketStream`
+/// enum, and thus it should be really easy to use it.
+///
+/// The `KeepAliveStream` consists of a thread (the `KeepAliveWorker`) that owns
+/// the given stream, and channels to send messages to said thread, and receive
+/// answers from it.
+// The messages that will be sent to the `KeepAliveWorker`.
+#[derive(Debug)]
+enum KeepAliveStreamMessage {
+    // Read `len` bytes from `stream`.
+    Read(usize /* len */),
+    // Write `buf` to `stream`.
+    Write(Vec<u8> /* buf */),
+    // Flush `stream`.
+    Flush,
+    // Stop listening for messages, i.e. stop the worker.
+    Disconnect,
+}
+
+// The answer we will get from the `KeepAliveWorker`.
+#[derive(Debug)]
+enum KeepAliveStreamAnswer {
+    // Result of reading from `stream`.
+    Read(io::Result<(Vec<u8>, usize)>),
+    // Result of writing to `stream`.
+    Write(io::Result<usize>),
+    // Result of flushing `stream`.
+    Flush(io::Result<()>),
+}
+
+// The [`KeepAliveStream`] should only be used by the sender, not the receiver.
+// Thus it doesn't have to implement `AsFd`.
+struct KeepAliveWorker<S: Read + Write> {
+    stream: S,
+}
+
+impl<S> KeepAliveWorker<S>
+where
+    S: Read + Write,
+{
+    pub fn new(stream: S) -> Self {
+        Self { stream }
+    }
+
+    pub fn read(&mut self, len: usize) -> io::Result<(Vec<u8>, usize)> {
+        let mut buf: Vec<u8> = vec![0u8; len];
+        let n = Read::read(&mut self.stream, &mut buf)?;
+        Ok((buf, n))
+    }
+
+    pub fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        Write::write(&mut self.stream, buf)
+    }
+
+    pub fn flush(&mut self) -> io::Result<()> {
+        Write::flush(&mut self.stream)
+    }
+}
+
+pub struct KeepAliveStream {
+    /// The `KeepAliveWorker`.
+    thread: Option<JoinHandle<()>>,
+
+    /// Used to send messages to the worker.
+    message_tx: SyncSender<KeepAliveStreamMessage>,
+    /// Used to receive answers from the worker.
+    answer_rx: Receiver<KeepAliveStreamAnswer>,
+}
+
+impl KeepAliveStream {
+    pub fn new<T: Read + Write + Send + 'static>(
+        stream: T,
+        timeout: Duration,
+    ) -> result::Result<Self, io::Error> {
+        // We want to block on send and on recv if nobody listens. Thus we set the bound to 0.
+        let (message_tx, message_rx) = sync_channel::<KeepAliveStreamMessage>(0);
+        let (answer_tx, answer_rx) = sync_channel::<KeepAliveStreamAnswer>(0);
+
+        let thread = thread::Builder::new()
+            .name("keep_alive_sender_thread".to_string())
+            .spawn(move || {
+                let mut worker = KeepAliveWorker::new(stream);
+                loop {
+                    // The idea is to always send a keep alive message when this times out.
+                    match message_rx.recv_timeout(timeout) {
+                        Ok(message) => match message {
+                            KeepAliveStreamMessage::Read(payload) => {
+                                if answer_tx
+                                    .send(KeepAliveStreamAnswer::Read(worker.read(payload)))
+                                    .is_err()
+                                {
+                                    // We simply break the loop and thus stop the thread if anything bad happens.
+                                    // The main thread will notice next time it tries to send a message to the thread.
+                                    break;
+                                }
+                            }
+                            KeepAliveStreamMessage::Write(payload) => {
+                                if answer_tx
+                                    .send(KeepAliveStreamAnswer::Write(worker.write(&payload)))
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            KeepAliveStreamMessage::Flush => {
+                                if answer_tx
+                                    .send(KeepAliveStreamAnswer::Flush(worker.flush()))
+                                    .is_err()
+                                {
+                                    break;
+                                }
+                            }
+                            KeepAliveStreamMessage::Disconnect => break,
+                        },
+                        Err(RecvTimeoutError::Timeout) => {
+                            let keep_alive = Request::keep_alive();
+                            let _ = keep_alive.write_to(&mut worker.stream);
+                        }
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                }
+            })?;
+
+        Ok(Self {
+            thread: Some(thread),
+            message_tx,
+            answer_rx,
+        })
+    }
+}
+
+impl Drop for KeepAliveStream {
+    fn drop(&mut self) {
+        let _ = self.message_tx.send(KeepAliveStreamMessage::Disconnect);
+        if let Some(handle) = self.thread.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+impl Read for KeepAliveStream {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.message_tx
+            .send(KeepAliveStreamMessage::Read(buf.len()))
+            .map_err(|e| {
+                io::Error::other(format!("Unable to send message to KeepAliveWorker: {e}"))
+            })?;
+
+        match self.answer_rx.recv() {
+            Ok(KeepAliveStreamAnswer::Read(result)) => match result {
+                Ok((recv_buf, len)) => {
+                    buf.copy_from_slice(&recv_buf);
+                    Ok(len)
+                }
+                Err(e) => Err(e),
+            },
+            Ok(a) => Err(io::Error::other(format!(
+                "Received unexpected answer: {a:?}. This is most likely a bug!"
+            ))),
+            Err(e) => Err(io::Error::other(format!(
+                "Unable to receive answer from KeepAliveWorker: {e}"
+            ))),
+        }
+    }
+}
+
+impl Write for KeepAliveStream {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.message_tx
+            .send(KeepAliveStreamMessage::Write(Vec::from(buf)))
+            .map_err(|e| {
+                io::Error::other(format!("Unable to send message to KeepAliveWorker: {e}"))
+            })?;
+
+        match self.answer_rx.recv() {
+            Ok(KeepAliveStreamAnswer::Write(result)) => result,
+            Ok(a) => Err(io::Error::other(format!(
+                "Received unexpected answer: {a:?}. This is most likely a bug!",
+            ))),
+            Err(e) => Err(io::Error::other(format!(
+                "Unable to receive answer from KeepAliveWorker: {e}"
+            ))),
+        }
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.message_tx
+            .send(KeepAliveStreamMessage::Flush)
+            .map_err(|e| {
+                io::Error::other(format!("Unable to send message to KeepAliveWorker: {e}"))
+            })?;
+        match self.answer_rx.recv() {
+            Ok(KeepAliveStreamAnswer::Flush(result)) => result,
+            Ok(a) => Err(io::Error::other(format!(
+                "Received unexpected answer: {a:?}. This is most likely a bug!",
+            ))),
+            Err(e) => Err(io::Error::other(format!(
+                "Unable to receive answer from KeepAliveWorker: {e}"
+            ))),
+        }
+    }
+}
+
+impl ReadVolatile for KeepAliveStream {
+    fn read_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &mut VolatileSlice<B>,
+    ) -> result::Result<usize, VolatileMemoryError> {
+        self.message_tx
+            .send(KeepAliveStreamMessage::Read(buf.len()))
+            .map_err(|e| {
+                io::Error::other(format!("Unable to send message to KeepAliveWorker: {e}"))
+            })
+            .map_err(VolatileMemoryError::IOError)?;
+
+        match self.answer_rx.recv() {
+            Ok(KeepAliveStreamAnswer::Read(result)) => match result {
+                Ok((recv_buf, len)) => {
+                    buf.copy_from(&recv_buf);
+                    Ok(len)
+                }
+                Err(e) => Err(VolatileMemoryError::IOError(e)),
+            },
+            Ok(a) => Err(VolatileMemoryError::IOError(io::Error::other(format!(
+                "Received unexpected answer: {a:?}. This is most likely a bug!",
+            )))),
+            Err(e) => Err(VolatileMemoryError::IOError(io::Error::other(format!(
+                "Unable to receive answer from KeepAliveWorker: {e}"
+            )))),
+        }
+    }
+}
+
+impl WriteVolatile for KeepAliveStream {
+    fn write_volatile<B: BitmapSlice>(
+        &mut self,
+        buf: &VolatileSlice<B>,
+    ) -> result::Result<usize, VolatileMemoryError> {
+        let mut send_buf = vec![0u8; buf.len()];
+        buf.copy_to(&mut send_buf);
+        self.message_tx
+            .send(KeepAliveStreamMessage::Write(send_buf))
+            .map_err(|e| {
+                io::Error::other(format!("Unable to send message to KeepAliveWorker: {e}"))
+            })
+            .map_err(VolatileMemoryError::IOError)?;
+
+        match self.answer_rx.recv() {
+            Ok(KeepAliveStreamAnswer::Write(result)) => {
+                result.map_err(VolatileMemoryError::IOError)
+            }
+            Ok(a) => Err(VolatileMemoryError::IOError(io::Error::other(format!(
+                "Received unexpected answer: {a:?}. This is most likely a bug!",
+            )))),
+            Err(e) => Err(VolatileMemoryError::IOError(io::Error::other(format!(
+                "Unable to receive answer from KeepAliveWorker: {e}"
+            )))),
+        }
+    }
+}

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -9,11 +9,11 @@ use thiserror::Error;
 
 use crate::protocol::MemoryRangeTable;
 
+mod bitpos_iterator;
+pub mod keep_alive_stream;
 pub mod progress;
 pub mod protocol;
 pub mod tls;
-
-mod bitpos_iterator;
 
 #[derive(Error, Debug)]
 pub enum MigratableError {

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -118,6 +118,7 @@ pub enum Command {
     Complete,
     Abandon,
     MemoryFd,
+    KeepAlive,
 }
 
 #[repr(C)]
@@ -166,6 +167,10 @@ impl Request {
 
     pub fn abandon() -> Self {
         Self::new(Command::Abandon, 0)
+    }
+
+    pub fn keep_alive() -> Self {
+        Self::new(Command::KeepAlive, 0)
     }
 
     pub fn command(&self) -> Command {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -56,6 +56,7 @@ use vm_memory::{
     GuestAddress, GuestAddressSpace, GuestMemory, GuestMemoryAtomic, ReadVolatile,
     VolatileMemoryError, VolatileSlice, WriteVolatile,
 };
+use vm_migration::keep_alive_stream::KeepAliveStream;
 use vm_migration::progress::{
     MemoryTransmissionInfo, MigrationProgress, MigrationState, MigrationStateOngoingPhase,
     TransportationMode,
@@ -291,6 +292,7 @@ enum SocketStream {
     Unix(UnixStream),
     Tcp(TcpStream),
     Tls(Box<TlsStreamWrapper>),
+    KeepAlive(KeepAliveStream),
 }
 
 impl Read for SocketStream {
@@ -299,6 +301,7 @@ impl Read for SocketStream {
             SocketStream::Unix(stream) => stream.read(buf),
             SocketStream::Tcp(stream) => stream.read(buf),
             SocketStream::Tls(stream) => stream.read(buf),
+            SocketStream::KeepAlive(stream) => stream.read(buf),
         }
     }
 }
@@ -309,6 +312,7 @@ impl Write for SocketStream {
             SocketStream::Unix(stream) => stream.write(buf),
             SocketStream::Tcp(stream) => stream.write(buf),
             SocketStream::Tls(stream) => stream.write(buf),
+            SocketStream::KeepAlive(stream) => stream.write(buf),
         }
     }
 
@@ -317,6 +321,7 @@ impl Write for SocketStream {
             SocketStream::Unix(stream) => stream.flush(),
             SocketStream::Tcp(stream) => stream.flush(),
             SocketStream::Tls(stream) => stream.flush(),
+            SocketStream::KeepAlive(stream) => stream.flush(),
         }
     }
 }
@@ -327,6 +332,9 @@ impl AsFd for SocketStream {
             SocketStream::Unix(s) => s.as_fd(),
             SocketStream::Tcp(s) => s.as_fd(),
             SocketStream::Tls(s) => s.as_fd(),
+            SocketStream::KeepAlive(_) => unimplemented!(
+                "AsFd should not be used by a sender, and the KeepAliveStream should only be used by senders."
+            ),
         }
     }
 }
@@ -340,6 +348,7 @@ impl ReadVolatile for SocketStream {
             SocketStream::Unix(s) => s.read_volatile(buf),
             SocketStream::Tcp(s) => s.read_volatile(buf),
             SocketStream::Tls(s) => s.read_volatile(buf),
+            SocketStream::KeepAlive(s) => s.read_volatile(buf),
         }
     }
 
@@ -351,6 +360,7 @@ impl ReadVolatile for SocketStream {
             SocketStream::Unix(s) => s.read_exact_volatile(buf),
             SocketStream::Tcp(s) => s.read_exact_volatile(buf),
             SocketStream::Tls(s) => s.read_exact_volatile(buf),
+            SocketStream::KeepAlive(s) => s.read_exact_volatile(buf),
         }
     }
 }
@@ -364,6 +374,7 @@ impl WriteVolatile for SocketStream {
             SocketStream::Unix(s) => s.write_volatile(buf),
             SocketStream::Tcp(s) => s.write_volatile(buf),
             SocketStream::Tls(s) => s.write_volatile(buf),
+            SocketStream::KeepAlive(s) => s.write_volatile(buf),
         }
     }
 
@@ -375,6 +386,7 @@ impl WriteVolatile for SocketStream {
             SocketStream::Unix(s) => s.write_all_volatile(buf),
             SocketStream::Tcp(s) => s.write_all_volatile(buf),
             SocketStream::Tls(s) => s.write_all_volatile(buf),
+            SocketStream::KeepAlive(s) => s.write_all_volatile(buf),
         }
     }
 }
@@ -971,8 +983,12 @@ impl AsFd for ReceiveListener {
 }
 
 impl ReceiveListener {
-    /// Block until a connection is accepted.
+    /// The time the receiver side may read on a socket until it throws an error.
+    /// This timeout has to be larger than `TIMEOUT_DURATION` in `send_migration_timeout`,
+    /// otherwise spurious timeouts may happen.
     const TIMEOUT_DURATION: Duration = Duration::from_secs(10);
+
+    /// Block until a connection is accepted.
     fn accept(&mut self) -> std::result::Result<SocketStream, std::io::Error> {
         match self {
             ReceiveListener::Tcp(listener) => listener.accept().map(|(socket, _)| {
@@ -1359,7 +1375,7 @@ impl SendAdditionalConnections {
         // memory chunks to the workers, but does not send memory anymore. Thus in this
         // case we create one thread for each connection.
         for n in 0..(configured_connections) {
-            let socket = (match send_migration_socket(send_data_migration) {
+            let socket = (match send_migration_socket(send_data_migration, false) {
                 Err(e) if n == 0 => {
                     // If we encounter a problem on the first additional
                     // connection, we just assume the other side doesn't support
@@ -1558,34 +1574,60 @@ impl Drop for SendAdditionalConnections {
 /// Establishes a connection to a migration destination socket (TCP or UNIX).
 fn send_migration_socket(
     send_data_migration: &VmSendMigrationData,
+    main_connection: bool,
 ) -> std::result::Result<SocketStream, MigratableError> {
-    const SEND_TIMEOUT: Duration = Duration::from_secs(5);
-    if let Some(address) = send_data_migration.destination_url.strip_prefix("tcp:") {
-        info!("Connecting to TCP socket at {address}");
+    // The time the sender side may block on a socket, until it throws an error.
+    // Also the interval at which the {`KeepAliveStream`] sends keep alive messages.
+    // This timeout has to be smaller than [`ReceiveListener::TIMEOUT_DURATION`],
+    // otherwise spurious timeouts may happen.
+    const TIMEOUT_DURATION: Duration = Duration::from_secs(5);
 
-        let socket = TcpStream::connect(address).map_err(|e| {
-            MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {e}"))
-        })?;
-        socket.set_read_timeout(Some(SEND_TIMEOUT)).map_err(|e| {
-            MigratableError::MigrateSend(anyhow!("Error setting read timeout on TCP socket: {e}"))
-        })?;
-        socket.set_write_timeout(Some(SEND_TIMEOUT)).map_err(|e| {
-            MigratableError::MigrateSend(anyhow!("Error setting write timeout on TCP socket: {e}"))
-        })?;
-        if let Some(tls_dir) = send_data_migration.tls_dir.as_ref() {
-            info!("Live Migration will be encrypted using TLS.");
-            // The address may still contain a port. I think we should build something more robust to also handle IPv6.
-            let tls_stream = tls::client_stream(
-                socket,
-                tls_dir,
-                address.split_once(':').map_or(address, |(host, _)| host),
-            )?;
-            Ok(SocketStream::Tls(Box::new(TlsStreamWrapper::new(
-                TlsStream::Client(tls_stream),
-            ))))
-        } else {
-            Ok(SocketStream::Tcp(socket))
+    if let Some(address) = send_data_migration.destination_url.strip_prefix("tcp:") {
+        let socket = {
+            info!("Connecting to TCP socket at {address}");
+
+            let socket = TcpStream::connect(address).map_err(|e| {
+                MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {e}"))
+            })?;
+            socket
+                .set_read_timeout(Some(TIMEOUT_DURATION))
+                .map_err(|e| {
+                    MigratableError::MigrateSend(anyhow!(
+                        "Error setting read timeout on TCP socket: {e}"
+                    ))
+                })?;
+            socket
+                .set_write_timeout(Some(TIMEOUT_DURATION))
+                .map_err(|e| {
+                    MigratableError::MigrateSend(anyhow!(
+                        "Error setting write timeout on TCP socket: {e}"
+                    ))
+                })?;
+            if let Some(tls_dir) = send_data_migration.tls_dir.as_ref() {
+                info!("Live Migration will be encrypted using TLS.");
+                // The address may still contain a port. I think we should build something more robust to also handle IPv6.
+                let tls_stream = tls::client_stream(
+                    socket,
+                    tls_dir,
+                    address.split_once(':').map_or(address, |(host, _)| host),
+                )?;
+                SocketStream::Tls(Box::new(TlsStreamWrapper::new(TlsStream::Client(
+                    tls_stream,
+                ))))
+            } else {
+                SocketStream::Tcp(socket)
+            }
+        };
+        // If we use multiple TCP connections, we have to send periodic keep alive messages. Thus, we create a KeepAliveStream.
+        if send_data_migration.connections.get() > 1 && main_connection {
+            return Ok(SocketStream::KeepAlive(
+                KeepAliveStream::new(socket, TIMEOUT_DURATION).map_err(|e| {
+                    MigratableError::MigrateSend(anyhow!("Error creating keep alive sender: {e}"))
+                })?,
+            ));
         }
+        // Otherwise we return the socket.
+        Ok(socket)
     } else if let Some(path) = &send_data_migration.destination_url.strip_prefix("unix:") {
         info!("Connecting to UNIX socket at {path:?}");
 
@@ -2443,7 +2485,7 @@ impl Vmm {
         let mut s = MigrationStateInternal::new();
 
         // Set up the socket connection
-        let mut socket = send_migration_socket(send_data_migration)?;
+        let mut socket = send_migration_socket(send_data_migration, true)?;
 
         // Start the migration
         Request::start().write_to(&mut socket)?;
@@ -2502,12 +2544,7 @@ impl Vmm {
                     // Proceed with sending memory file descriptors over UNIX socket
                     vm.send_memory_fds(unix_socket)?;
                 }
-                SocketStream::Tcp(_tcp_socket) => {
-                    return Err(MigratableError::MigrateSend(anyhow!(
-                        "--local option is not supported with TCP sockets",
-                    )));
-                }
-                SocketStream::Tls(_tls_socket) => {
+                _ => {
                     return Err(MigratableError::MigrateSend(anyhow!(
                         "--local option is not supported with TCP sockets",
                     )));
@@ -3689,6 +3726,10 @@ impl RequestHandler for Vmm {
         while !state.finished() {
             let req = Request::read_from(&mut socket)?;
             trace!("Command {:?} received", req.command());
+
+            if req.command() == Command::KeepAlive {
+                continue;
+            }
 
             let (response, new_state) = match self.vm_receive_migration_step(
                 &listener,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -69,6 +69,7 @@ use vm_migration::{
 use vmm_sys_util::eventfd::EventFd;
 use vmm_sys_util::signal::unblock_signal;
 use vmm_sys_util::sock_ctrl_msg::ScmSocket;
+use vmm_sys_util::timerfd::TimerFd;
 
 use crate::api::{
     ApiRequest, ApiResponse, RequestHandler, VmInfoResponse, VmReceiveMigrationData,
@@ -929,9 +930,9 @@ pub struct Vmm {
 /// true. In case, the eventfd was signaled, return false.
 fn wait_for_readable(
     fd: &impl AsFd,
-    eventfd: &EventFd,
+    eventfd: &impl AsRawFd,
 ) -> std::result::Result<bool, std::io::Error> {
-    let fd_event = eventfd.as_raw_fd().as_raw_fd();
+    let fd_event = eventfd.as_raw_fd();
     let fd_io = fd.as_fd().as_raw_fd();
     let mut poll_fds = [
         libc::pollfd {
@@ -960,7 +961,6 @@ fn wait_for_readable(
     if poll_fds[1].revents & libc::POLLIN != 0 {
         return Ok(true);
     }
-
     panic!("Poll returned, but neither file descriptor is readable?");
 }
 
@@ -991,11 +991,13 @@ impl ReceiveListener {
     /// Block until a connection is accepted.
     fn accept(&mut self) -> std::result::Result<SocketStream, std::io::Error> {
         match self {
-            ReceiveListener::Tcp(listener) => listener.accept().map(|(socket, _)| {
-                socket.set_read_timeout(Some(Self::TIMEOUT_DURATION))?;
-                socket.set_write_timeout(Some(Self::TIMEOUT_DURATION))?;
-                Ok(SocketStream::Tcp(socket))
-            })?,
+            ReceiveListener::Tcp(listener) => {
+                Self::accept_with_timeout(listener, Self::TIMEOUT_DURATION).map(|(socket, _)| {
+                    socket.set_read_timeout(Some(Self::TIMEOUT_DURATION))?;
+                    socket.set_write_timeout(Some(Self::TIMEOUT_DURATION))?;
+                    Ok(SocketStream::Tcp(socket))
+                })?
+            }
             ReceiveListener::Unix(listener, opt_path) => {
                 let socket = listener
                     .accept()
@@ -1012,14 +1014,16 @@ impl ReceiveListener {
 
                 Ok(socket)
             }
-            ReceiveListener::Tls(listener, conn) => listener.accept().map(|(socket, _)| {
-                socket.set_read_timeout(Some(Self::TIMEOUT_DURATION))?;
-                socket.set_write_timeout(Some(Self::TIMEOUT_DURATION))?;
-                conn.wrap(socket)
-                    .map(Box::new)
-                    .map(SocketStream::Tls)
-                    .map_err(std::io::Error::other)
-            })?,
+            ReceiveListener::Tls(listener, conn) => {
+                Self::accept_with_timeout(listener, Self::TIMEOUT_DURATION).map(|(socket, _)| {
+                    socket.set_read_timeout(Some(Self::TIMEOUT_DURATION))?;
+                    socket.set_write_timeout(Some(Self::TIMEOUT_DURATION))?;
+                    conn.wrap(socket)
+                        .map(Box::new)
+                        .map(SocketStream::Tls)
+                        .map_err(std::io::Error::other)
+                })?
+            }
         }
     }
 
@@ -1031,6 +1035,26 @@ impl ReceiveListener {
         wait_for_readable(&self, eventfd)?
             .then(|| self.accept())
             .transpose()
+    }
+
+    /// Same as listener.accept(), but returns an error if the given timeout expires.
+    fn accept_with_timeout(
+        listener: &TcpListener,
+        timeout: Duration,
+    ) -> result::Result<(TcpStream, std::net::SocketAddr), std::io::Error> {
+        let mut timer_fd = TimerFd::new()?;
+        timer_fd
+            .reset(timeout, None)
+            .map_err(|e| io::Error::from_raw_os_error(e.errno()))?;
+
+        wait_for_readable(&listener, &timer_fd)?
+            .then(|| listener.accept())
+            .ok_or_else(|| {
+                io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "Timed out waiting for sender to connect.",
+                )
+            })?
     }
 
     fn try_clone(&self) -> std::result::Result<Self, std::io::Error> {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3716,6 +3716,9 @@ impl RequestHandler for Vmm {
         if let ReceiveMigrationState::Aborted = state {
             self.vm = MaybeVmOwnership::None;
             self.vm_config = None;
+            return Err(MigratableError::CompleteMigration(anyhow!(
+                "Migration was aborted"
+            )));
         }
 
         Ok(())

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -972,11 +972,14 @@ impl AsFd for ReceiveListener {
 
 impl ReceiveListener {
     /// Block until a connection is accepted.
+    const TIMEOUT_DURATION: Duration = Duration::from_secs(10);
     fn accept(&mut self) -> std::result::Result<SocketStream, std::io::Error> {
         match self {
-            ReceiveListener::Tcp(listener) => listener
-                .accept()
-                .map(|(socket, _)| SocketStream::Tcp(socket)),
+            ReceiveListener::Tcp(listener) => listener.accept().map(|(socket, _)| {
+                socket.set_read_timeout(Some(Self::TIMEOUT_DURATION))?;
+                socket.set_write_timeout(Some(Self::TIMEOUT_DURATION))?;
+                Ok(SocketStream::Tcp(socket))
+            })?,
             ReceiveListener::Unix(listener, opt_path) => {
                 let socket = listener
                     .accept()
@@ -994,6 +997,8 @@ impl ReceiveListener {
                 Ok(socket)
             }
             ReceiveListener::Tls(listener, conn) => listener.accept().map(|(socket, _)| {
+                socket.set_read_timeout(Some(Self::TIMEOUT_DURATION))?;
+                socket.set_write_timeout(Some(Self::TIMEOUT_DURATION))?;
                 conn.wrap(socket)
                     .map(Box::new)
                     .map(SocketStream::Tls)
@@ -1554,13 +1559,19 @@ impl Drop for SendAdditionalConnections {
 fn send_migration_socket(
     send_data_migration: &VmSendMigrationData,
 ) -> std::result::Result<SocketStream, MigratableError> {
+    const SEND_TIMEOUT: Duration = Duration::from_secs(5);
     if let Some(address) = send_data_migration.destination_url.strip_prefix("tcp:") {
         info!("Connecting to TCP socket at {address}");
 
         let socket = TcpStream::connect(address).map_err(|e| {
             MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {e}"))
         })?;
-
+        socket.set_read_timeout(Some(SEND_TIMEOUT)).map_err(|e| {
+            MigratableError::MigrateSend(anyhow!("Error setting read timeout on TCP socket: {e}"))
+        })?;
+        socket.set_write_timeout(Some(SEND_TIMEOUT)).map_err(|e| {
+            MigratableError::MigrateSend(anyhow!("Error setting write timeout on TCP socket: {e}"))
+        })?;
         if let Some(tls_dir) = send_data_migration.tls_dir.as_ref() {
             info!("Live Migration will be encrypted using TLS.");
             // The address may still contain a port. I think we should build something more robust to also handle IPv6.


### PR DESCRIPTION
This PR includes multiple changes to handle errors during live migrations:

1. fix hanging VMM on both sides when the network is lost during live migrations. This is now handled by adding read and write timeouts to the sockets used to send/receive migration data.
2. fix the problem 1. introduced: during a live migration with multiple TCP connections, the main connection is not used while the VM memory is send. This leads to expired timeouts on the receiver side, and thus a failed live migration. I fixed that by sending periodic keep-alive messages from the sending side to the receiver side.
3. fix hanging VMM on the receiver side if the sender side fails very early: if the sender of a live migration fails before the connection to the receiver side has been established, the receiver waits forever on `socket.connect()`. This has been fixed by again adding a timeout.

Please review this PR commit by commit. This PR needs changes in libvirt to really fix the whole problem, but merging this PR also shouldn't break anything.

Test is in https://github.com/cyberus-technology/libvirt-tests/pull/167