### PR TITLE
vmm: Refactor locking in `AddressManager::move_bar`

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -723,15 +723,10 @@ impl DeviceRelocation for AddressManager {
     ) -> std::result::Result<(), std::io::Error> {
         match region_type {
             PciBarRegionType::IoRegion => {
+                let mut allocator = self.allocator.lock().unwrap();
                 // Update system allocator
-                self.allocator
-                    .lock()
-                    .unwrap()
-                    .free_io_addresses(GuestAddress(old_base), len as GuestUsize);
-
-                self.allocator
-                    .lock()
-                    .unwrap()
+                allocator.free_io_addresses(GuestAddress(old_base), len as GuestUsize);
+                allocator
                     .allocate_io_addresses(Some(GuestAddress(new_base)), len as GuestUsize, None)
                     .ok_or_else(|| io::Error::other("failed allocating new IO range"))?;
 
@@ -747,20 +742,14 @@ impl DeviceRelocation for AddressManager {
                     &self.pci_mmio64_allocators
                 };
 
-                // Find the specific allocator that this BAR was allocated from and use it for new one
+                // Find the specific allocator that this BAR was allocated from and use it for a new one
                 for allocator in allocators {
-                    let allocator_base = allocator.lock().unwrap().base();
-                    let allocator_end = allocator.lock().unwrap().end();
+                    let mut allocator_guard = allocator.lock().unwrap();
 
-                    if old_base >= allocator_base.0 && old_base <= allocator_end.0 {
-                        allocator
-                            .lock()
-                            .unwrap()
-                            .free(GuestAddress(old_base), len as GuestUsize);
+                    if old_base >= allocator_guard.base().0 && old_base <= allocator_guard.end().0 {
+                        allocator_guard.free(GuestAddress(old_base), len as GuestUsize);
 
-                        allocator
-                            .lock()
-                            .unwrap()
+                        allocator_guard
                             .allocate(Some(GuestAddress(new_base)), len as GuestUsize, Some(len))
                             .ok_or_else(|| io::Error::other("failed allocating new MMIO range"))?;
 


### PR DESCRIPTION
The current implementation performs multiple operations on allocators in a row, with the single goal of updating the allocator. For each of these operations, the `Mutex` guarding the respective allocator is locked anew, which introduces room for race conditions. For example, after thread 1 copies `allocator_base` and `allocator_end`, both could be changed by thread 2, making thread 1 work with stale data.

Instead of locking the mutex multiple times, we should lock it once to perform the whole move.

This is a fix for https://github.com/cobaltcore-dev/cobaltcore/issues/409