### PR TITLE
Handle paused vCPUs in legacy reset/shutdown wait loops

### DIFF
--- a/devices/src/acpi.rs
+++ b/devices/src/acpi.rs
@@ -24,6 +24,7 @@ pub struct AcpiShutdownDevice {
     exit_evt: EventFd,
     reset_evt: EventFd,
     vcpus_kill_signalled: Arc<AtomicBool>,
+    vcpus_pause_signalled: Arc<AtomicBool>,
 }
 
 impl AcpiShutdownDevice {
@@ -32,11 +33,13 @@ impl AcpiShutdownDevice {
         exit_evt: EventFd,
         reset_evt: EventFd,
         vcpus_kill_signalled: Arc<AtomicBool>,
+        vcpus_pause_signalled: Arc<AtomicBool>,
     ) -> AcpiShutdownDevice {
         AcpiShutdownDevice {
             exit_evt,
             reset_evt,
             vcpus_kill_signalled,
+            vcpus_pause_signalled,
         }
     }
 }
@@ -56,7 +59,9 @@ impl BusDevice for AcpiShutdownDevice {
             }
             // Spin until we are sure the reset_evt has been handled and that when
             // we return from the KVM_RUN we will exit rather than re-enter the guest.
-            while !self.vcpus_kill_signalled.load(Ordering::SeqCst) {
+            while !self.vcpus_kill_signalled.load(Ordering::SeqCst)
+                && !self.vcpus_pause_signalled.load(Ordering::SeqCst)
+            {
                 // This is more effective than thread::yield_now() at
                 // avoiding a priority inversion with the VMM thread
                 thread::sleep(std::time::Duration::from_millis(1));
@@ -73,7 +78,9 @@ impl BusDevice for AcpiShutdownDevice {
             }
             // Spin until we are sure the reset_evt has been handled and that when
             // we return from the KVM_RUN we will exit rather than re-enter the guest.
-            while !self.vcpus_kill_signalled.load(Ordering::SeqCst) {
+            while !self.vcpus_kill_signalled.load(Ordering::SeqCst)
+                && !self.vcpus_pause_signalled.load(Ordering::SeqCst)
+            {
                 // This is more effective than thread::yield_now() at
                 // avoiding a priority inversion with the VMM thread
                 thread::sleep(std::time::Duration::from_millis(1));

--- a/devices/src/legacy/cmos.rs
+++ b/devices/src/legacy/cmos.rs
@@ -27,8 +27,8 @@ pub struct Cmos {
     index: u8,
     data: [u8; DATA_LEN],
     reset_evt: EventFd,
-    vcpus_kill_signalled: Option<Arc<AtomicBool>>,
-    vcpus_pause_signalled: Option<Arc<AtomicBool>>,
+    vcpus_kill_signalled: Arc<AtomicBool>,
+    vcpus_pause_signalled: Arc<AtomicBool>,
 }
 
 impl Cmos {
@@ -39,8 +39,8 @@ impl Cmos {
         mem_below_4g: u64,
         mem_above_4g: u64,
         reset_evt: EventFd,
-        vcpus_kill_signalled: Option<Arc<AtomicBool>>,
-        vcpus_pause_signalled: Option<Arc<AtomicBool>>,
+        vcpus_kill_signalled: Arc<AtomicBool>,
+        vcpus_pause_signalled: Arc<AtomicBool>,
     ) -> Cmos {
         let mut data = [0u8; DATA_LEN];
 
@@ -81,19 +81,14 @@ impl BusDevice for Cmos {
                 if self.index == 0x8f && data[0] == 0 {
                     info!("CMOS reset");
                     self.reset_evt.write(1).unwrap();
-                    if let Some(vcpus_kill_signalled) = self.vcpus_kill_signalled.take() {
-                        let pause_signalled = self.vcpus_pause_signalled.clone();
-                        // Spin until we are sure the reset_evt has been handled and that when
-                        // we return from the KVM_RUN we will exit rather than re-enter the guest.
-                        while !vcpus_kill_signalled.load(Ordering::SeqCst)
-                            && !pause_signalled
-                                .as_ref()
-                                .is_some_and(|p| p.load(Ordering::SeqCst))
-                        {
-                            // This is more effective than thread::yield_now() at
-                            // avoiding a priority inversion with the VMM thread
-                            thread::sleep(std::time::Duration::from_millis(1));
-                        }
+                    // Spin until we are sure the reset_evt has been handled and that when
+                    // we return from the KVM_RUN we will exit rather than re-enter the guest.
+                    while !self.vcpus_kill_signalled.load(Ordering::SeqCst)
+                        && !self.vcpus_pause_signalled.load(Ordering::SeqCst)
+                    {
+                        // This is more effective than thread::yield_now() at
+                        // avoiding a priority inversion with the VMM thread
+                        thread::sleep(std::time::Duration::from_millis(1));
                     }
                 } else {
                     self.data[(self.index & INDEX_MASK) as usize] = data[0];

--- a/devices/src/legacy/cmos.rs
+++ b/devices/src/legacy/cmos.rs
@@ -28,6 +28,7 @@ pub struct Cmos {
     data: [u8; DATA_LEN],
     reset_evt: EventFd,
     vcpus_kill_signalled: Option<Arc<AtomicBool>>,
+    vcpus_pause_signalled: Option<Arc<AtomicBool>>,
 }
 
 impl Cmos {
@@ -39,6 +40,7 @@ impl Cmos {
         mem_above_4g: u64,
         reset_evt: EventFd,
         vcpus_kill_signalled: Option<Arc<AtomicBool>>,
+        vcpus_pause_signalled: Option<Arc<AtomicBool>>,
     ) -> Cmos {
         let mut data = [0u8; DATA_LEN];
 
@@ -61,6 +63,7 @@ impl Cmos {
             data,
             reset_evt,
             vcpus_kill_signalled,
+            vcpus_pause_signalled,
         }
     }
 }
@@ -79,9 +82,14 @@ impl BusDevice for Cmos {
                     info!("CMOS reset");
                     self.reset_evt.write(1).unwrap();
                     if let Some(vcpus_kill_signalled) = self.vcpus_kill_signalled.take() {
+                        let pause_signalled = self.vcpus_pause_signalled.clone();
                         // Spin until we are sure the reset_evt has been handled and that when
                         // we return from the KVM_RUN we will exit rather than re-enter the guest.
-                        while !vcpus_kill_signalled.load(Ordering::SeqCst) {
+                        while !vcpus_kill_signalled.load(Ordering::SeqCst)
+                            && !pause_signalled
+                                .as_ref()
+                                .is_some_and(|p| p.load(Ordering::SeqCst))
+                        {
                             // This is more effective than thread::yield_now() at
                             // avoiding a priority inversion with the VMM thread
                             thread::sleep(std::time::Duration::from_millis(1));

--- a/devices/src/legacy/i8042.rs
+++ b/devices/src/legacy/i8042.rs
@@ -16,14 +16,20 @@ use vmm_sys_util::eventfd::EventFd;
 pub struct I8042Device {
     reset_evt: EventFd,
     vcpus_kill_signalled: Arc<AtomicBool>,
+    vcpus_pause_signalled: Arc<AtomicBool>,
 }
 
 impl I8042Device {
     /// Constructs a i8042 device that will signal the given event when the guest requests it.
-    pub fn new(reset_evt: EventFd, vcpus_kill_signalled: Arc<AtomicBool>) -> I8042Device {
+    pub fn new(
+        reset_evt: EventFd,
+        vcpus_kill_signalled: Arc<AtomicBool>,
+        vcpus_pause_signalled: Arc<AtomicBool>,
+    ) -> I8042Device {
         I8042Device {
             reset_evt,
             vcpus_kill_signalled,
+            vcpus_pause_signalled,
         }
     }
 }
@@ -50,7 +56,9 @@ impl BusDevice for I8042Device {
             }
             // Spin until we are sure the reset_evt has been handled and that when
             // we return from the KVM_RUN we will exit rather than re-enter the guest.
-            while !self.vcpus_kill_signalled.load(Ordering::SeqCst) {
+            while !self.vcpus_kill_signalled.load(Ordering::SeqCst)
+                && !self.vcpus_pause_signalled.load(Ordering::SeqCst)
+            {
                 // This is more effective than thread::yield_now() at
                 // avoiding a priority inversion with the VMM thread
                 thread::sleep(std::time::Duration::from_millis(1));

--- a/fuzz/fuzz_targets/cmos.rs
+++ b/fuzz/fuzz_targets/cmos.rs
@@ -26,6 +26,7 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
         u64::from_le_bytes(above_4g),
         EventFd::new(EFD_NONBLOCK).unwrap(),
         None,
+        None,
     );
 
     let mut i = 16;

--- a/fuzz/fuzz_targets/cmos.rs
+++ b/fuzz/fuzz_targets/cmos.rs
@@ -3,6 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![no_main]
+use std::sync::atomic::AtomicBool;
+use std::sync::Arc;
+
 use devices::legacy::Cmos;
 use libc::EFD_NONBLOCK;
 use libfuzzer_sys::{fuzz_target, Corpus};
@@ -25,8 +28,8 @@ fuzz_target!(|bytes: &[u8]| -> Corpus {
         u64::from_le_bytes(below_4g),
         u64::from_le_bytes(above_4g),
         EventFd::new(EFD_NONBLOCK).unwrap(),
-        None,
-        None,
+        Arc::new(AtomicBool::new(false)),
+        Arc::new(AtomicBool::new(false)),
     );
 
     let mut i = 16;

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -2119,6 +2119,10 @@ impl CpuManager {
         &self.vcpus_kill_signalled
     }
 
+    pub(crate) fn vcpus_pause_signalled(&self) -> &Arc<AtomicBool> {
+        &self.vcpus_pause_signalled
+    }
+
     #[cfg(feature = "igvm")]
     pub(crate) fn get_cpuid_leaf(
         &self,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1825,10 +1825,17 @@ impl DeviceManager {
             .unwrap()
             .vcpus_kill_signalled()
             .clone();
+        let vcpus_pause_signalled = self
+            .cpu_manager
+            .lock()
+            .unwrap()
+            .vcpus_pause_signalled()
+            .clone();
         let shutdown_device = Arc::new(Mutex::new(devices::AcpiShutdownDevice::new(
             exit_evt,
             reset_evt,
             vcpus_kill_signalled,
+            vcpus_pause_signalled,
         )));
 
         self.bus_devices
@@ -1933,10 +1940,17 @@ impl DeviceManager {
             .unwrap()
             .vcpus_kill_signalled()
             .clone();
+        let vcpus_pause_signalled = self
+            .cpu_manager
+            .lock()
+            .unwrap()
+            .vcpus_pause_signalled()
+            .clone();
         // Add a shutdown device (i8042)
         let i8042 = Arc::new(Mutex::new(devices::legacy::I8042Device::new(
             reset_evt.try_clone().unwrap(),
             vcpus_kill_signalled.clone(),
+            vcpus_pause_signalled.clone(),
         )));
 
         self.bus_devices
@@ -1965,6 +1979,7 @@ impl DeviceManager {
                 mem_above_4g,
                 reset_evt,
                 Some(vcpus_kill_signalled),
+                Some(vcpus_pause_signalled.clone()),
             )));
 
             self.bus_devices

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1978,8 +1978,8 @@ impl DeviceManager {
                 mem_below_4g,
                 mem_above_4g,
                 reset_evt,
-                Some(vcpus_kill_signalled),
-                Some(vcpus_pause_signalled.clone()),
+                vcpus_kill_signalled,
+                vcpus_pause_signalled.clone(),
             )));
 
             self.bus_devices


### PR DESCRIPTION
This fixes a migration related hang in the legacy reset and shutdown paths.

Some wait loops only stopped when vcpus_kill_signalled was set. During migration, including PR #87, vCPUs may be pause signalled instead, so those loops could keep spinning and block migration completion during guest reset or shutdown handling.

This updates the affected legacy device paths (i8042, CMOS, and ACPI) so they also stop waiting when vcpus_pause_signalled is set, and wires that flag through the device construction paths.

It also cleans up the CMOS reset wait handling by using the pause and kill flags directly instead of optional wrappers, which makes the logic easier to follow and consistent with the other devices.

This may also help with cobaltcore issue https://github.com/cobaltcore-dev/cobaltcore/issues/411 (Signal Timeout during live-migration) by avoiding cases where migration triggered guest reset or shutdown handling gets stuck while vCPUs are paused rather than killed.

