### PR TITLE
arch: Fix misleading CPUID compatibility check error log

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -562,7 +562,9 @@ impl CpuidFeatureEntry {
                 .as_slice()
                 .iter()
                 .find(|(param, _)| {
-                    (param.leaf == entry.function) && (param.sub_leaf.contains(&entry.index))
+                    (param.leaf == entry.function)
+                        && (param.sub_leaf.contains(&entry.index)
+                            && (param.register == entry.feature_reg))
                 })
             {
                 for def in defs.as_slice() {


### PR DESCRIPTION
A small fix that prevents confusing logs. It does not have any function beyond that.