### PR TITLE
vmm: add context to MigrateSend and MigrateReceive Errors

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1099,11 +1099,8 @@ where
                     socket,
                     (range.length - offset) as usize,
                 )
-                .map_err(|e| {
-                    MigratableError::MigrateReceive(anyhow!(
-                        "Error receiving memory from socket: {e}"
-                    ))
-                })?;
+                .context("Error receiving memory from socket")
+                .map_err(MigratableError::MigrateReceive)?;
             offset += bytes_read as u64;
 
             if offset == range.length {
@@ -1143,9 +1140,10 @@ impl ReceiveAdditionalConnections {
         guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
     ) -> std::result::Result<(), MigratableError> {
         loop {
-            if !wait_for_readable(socket, abort_event_fd).map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Failed to poll descriptors: {e}"))
-            })? {
+            if !wait_for_readable(socket, abort_event_fd)
+                .context("Failed to poll descriptors")
+                .map_err(MigratableError::MigrateReceive)?
+            {
                 info!("Got signal to tear down connection.");
                 return Ok(());
             }
@@ -1671,9 +1669,9 @@ fn receive_migration_listener(
     receiver_data_migration: &VmReceiveMigrationData,
 ) -> std::result::Result<ReceiveListener, MigratableError> {
     if let Some(address) = receiver_data_migration.receiver_url.strip_prefix("tcp:") {
-        let listener = TcpListener::bind(address).map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error binding to TCP socket: {e}"))
-        })?;
+        let listener = TcpListener::bind(address)
+            .context("Error binding to TCP socket")
+            .map_err(MigratableError::MigrateReceive)?;
 
         if let Some(tls_dir) = receiver_data_migration.tls_dir.as_ref() {
             Ok(ReceiveListener::Tls(
@@ -1685,9 +1683,8 @@ fn receive_migration_listener(
         }
     } else if let Some(path) = receiver_data_migration.receiver_url.strip_prefix("unix:") {
         UnixListener::bind(path)
-            .map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error binding to UNIX socket: {e}"))
-            })
+            .context("Error binding to UNIX socket")
+            .map_err(MigratableError::MigrateReceive)
             .map(|listener| ReceiveListener::Unix(listener, Some(path.into())))
     } else {
         Err(MigratableError::MigrateSend(anyhow!(
@@ -1896,9 +1893,10 @@ impl Vmm {
     ) -> std::result::Result<(u32, File), MigratableError> {
         if let SocketStream::Unix(unix_socket) = socket {
             let mut buf = [0u8; 4];
-            let (_, file) = unix_socket.recv_with_fd(&mut buf).map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error receiving slot from socket: {e}"))
-            })?;
+            let (_, file) = unix_socket
+                .recv_with_fd(&mut buf)
+                .context("Error receiving slot from socket")
+                .map_err(MigratableError::MigrateReceive)?;
 
             file.ok_or_else(|| MigratableError::MigrateReceive(anyhow!("Failed to receive socket")))
                 .map(|file| (u32::from_le_bytes(buf), file))
@@ -1968,11 +1966,8 @@ impl Vmm {
                 listener
                     .try_clone()
                     .and_then(|l| ReceiveAdditionalConnections::new(l, guest_memory))
-                    .map_err(|e| {
-                        MigratableError::MigrateReceive(anyhow!(
-                            "Failed to create receive additional connections: {e}"
-                        ))
-                    })?,
+                    .context("Failed to create additional receive connections")
+                    .map_err(MigratableError::MigrateReceive)?,
             ))
         };
 
@@ -2058,10 +2053,9 @@ impl Vmm {
             .read_exact(&mut data)
             .map_err(MigratableError::MigrateSocket)?;
 
-        let vm_migration_config: VmMigrationConfig =
-            serde_json::from_slice(&data).map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error deserialising config: {e}"))
-            })?;
+        let vm_migration_config: VmMigrationConfig = serde_json::from_slice(&data)
+            .context("Error deserialising config")
+            .map_err(MigratableError::MigrateReceive)?;
 
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
         self.vm_check_cpuid_compatibility(
@@ -2113,9 +2107,11 @@ impl Vmm {
             }
         }
 
-        self.console_info = Some(pre_create_console_devices(self).map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error creating console devices: {e:?}"))
-        })?);
+        self.console_info = Some(
+            pre_create_console_devices(self)
+                .context("Error creating console devices")
+                .map_err(MigratableError::MigrateReceive)?,
+        );
 
         if self
             .vm_config
@@ -2126,9 +2122,9 @@ impl Vmm {
             .landlock_enable
         {
             let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
-            apply_landlock(&mut config).map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error applying landlock: {e:?}"))
-            })?;
+            apply_landlock(&mut config)
+                .context("Error applying landlock")
+                .map_err(MigratableError::MigrateReceive)?;
         }
 
         let vm = Vm::create_hypervisor_vm(
@@ -2161,11 +2157,8 @@ impl Vmm {
             Some(&vm_migration_config.memory_manager_data),
             existing_memory_files,
         )
-        .map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!(
-                "Error creating MemoryManager from snapshot: {e:?}"
-            ))
-        })?;
+        .context("Error creating MemoryManager from snapshot")
+        .map_err(MigratableError::MigrateReceive)?;
 
         Ok(memory_manager)
     }
@@ -2185,23 +2178,31 @@ impl Vmm {
         socket
             .read_exact(&mut data)
             .map_err(MigratableError::MigrateSocket)?;
-        let snapshot: Snapshot = serde_json::from_slice(&data).map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error deserialising snapshot: {e}"))
-        })?;
+        let snapshot: Snapshot = serde_json::from_slice(&data)
+            .context("Error deserialising snapshot")
+            .map_err(MigratableError::MigrateReceive)?;
 
-        let exit_evt = self.exit_evt.try_clone().map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error cloning exit EventFd: {e}"))
-        })?;
-        let reset_evt = self.reset_evt.try_clone().map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error cloning reset EventFd: {e}"))
-        })?;
+        let exit_evt = self
+            .exit_evt
+            .try_clone()
+            .context("Error cloning exit EventFd")
+            .map_err(MigratableError::MigrateReceive)?;
+        let reset_evt = self
+            .reset_evt
+            .try_clone()
+            .context("Error cloning reset EventFd")
+            .map_err(MigratableError::MigrateReceive)?;
         #[cfg(feature = "guest_debug")]
-        let debug_evt = self.vm_debug_evt.try_clone().map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error cloning debug EventFd: {e}"))
-        })?;
-        let activate_evt = self.activate_evt.try_clone().map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!("Error cloning activate EventFd: {e}"))
-        })?;
+        let debug_evt = self
+            .vm_debug_evt
+            .try_clone()
+            .context("Error clonung debug EventFd")
+            .map_err(MigratableError::MigrateReceive)?;
+        let activate_evt = self
+            .activate_evt
+            .try_clone()
+            .context("Error cloning activate EventFd")
+            .map_err(MigratableError::MigrateReceive)?;
 
         #[cfg(not(target_arch = "riscv64"))]
         let timestamp = Instant::now();
@@ -2702,15 +2703,12 @@ impl Vmm {
                     profile: vm_config.cpus.profile,
                 },
             )
-            .map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error generating common cpuid: {e:?}"))
-            })?
+            .context("Error generating common cpuid")
+            .map_err(MigratableError::MigrateReceive)?
         };
-        arch::CpuidFeatureEntry::check_cpuid_compatibility(src_vm_cpuid, dest_cpuid).map_err(|e| {
-            MigratableError::MigrateReceive(anyhow!(
-                "Error checking cpu feature compatibility': {e:?}"
-            ))
-        })
+        arch::CpuidFeatureEntry::check_cpuid_compatibility(src_vm_cpuid, dest_cpuid)
+            .context("Error checking cpu feature compatibility")
+            .map_err(MigratableError::MigrateReceive)
     }
 
     fn vm_restore(
@@ -3738,10 +3736,13 @@ impl RequestHandler for Vmm {
 
         let mut listener = receive_migration_listener(&receive_data_migration)?;
         // Accept the connection and get the socket
-        let mut socket = listener.accept().map_err(|e| {
-            warn!("Failed to accept migration connection: {e}");
-            MigratableError::MigrateReceive(anyhow!("Failed to accept migration connection: {e}"))
-        })?;
+        let mut socket = listener
+            .accept()
+            .context("Failed to accept migration connection")
+            .map_err(|e| {
+                warn!("{e}");
+                MigratableError::MigrateReceive(e)
+            })?;
 
         let mut state = ReceiveMigrationState::Established;
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -31,7 +31,7 @@ use std::thread::{JoinHandle, sleep};
 use std::time::{Duration, Instant};
 use std::{io, mem, result, thread};
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 #[cfg(feature = "dbus_api")]
 use api::dbus::{DBusApiOptions, DBusApiShutdownChannels};
 use api::http::HttpApiHandle;
@@ -1342,7 +1342,9 @@ fn vm_send_memory(
     send_memory_regions(guest_memory, table, socket)?;
     Response::read_from(socket)?.ok_or_abandon(
         socket,
-        MigratableError::MigrateSend(anyhow!("Error during dirty memory migration")),
+        MigratableError::MigrateSend(anyhow!(
+            "Error during dirty memory migration (got bad response)"
+        )),
     )?;
 
     Ok(())
@@ -1610,23 +1612,17 @@ fn send_migration_socket(
         let socket = {
             info!("Connecting to TCP socket at {address}");
 
-            let socket = TcpStream::connect(address).map_err(|e| {
-                MigratableError::MigrateSend(anyhow!("Error connecting to TCP socket: {e}"))
-            })?;
+            let socket = TcpStream::connect(address)
+                .context("Error connecting to TCP socket")
+                .map_err(MigratableError::MigrateSend)?;
             socket
                 .set_read_timeout(Some(TIMEOUT_DURATION))
-                .map_err(|e| {
-                    MigratableError::MigrateSend(anyhow!(
-                        "Error setting read timeout on TCP socket: {e}"
-                    ))
-                })?;
+                .context("Error setting read timeout on TCP socket")
+                .map_err(MigratableError::MigrateSend)?;
             socket
                 .set_write_timeout(Some(TIMEOUT_DURATION))
-                .map_err(|e| {
-                    MigratableError::MigrateSend(anyhow!(
-                        "Error setting write timeout on TCP socket: {e}"
-                    ))
-                })?;
+                .context("Error setting write timeout on TCP socket")
+                .map_err(MigratableError::MigrateSend)?;
             if let Some(tls_dir) = send_data_migration.tls_dir.as_ref() {
                 info!("Live Migration will be encrypted using TLS.");
                 // The address may still contain a port. I think we should build something more robust to also handle IPv6.
@@ -1642,22 +1638,24 @@ fn send_migration_socket(
                 SocketStream::Tcp(socket)
             }
         };
+
         // If we use multiple TCP connections, we have to send periodic keep alive messages. Thus, we create a KeepAliveStream.
         if send_data_migration.connections.get() > 1 && main_connection {
             return Ok(SocketStream::KeepAlive(
-                KeepAliveStream::new(socket, TIMEOUT_DURATION).map_err(|e| {
-                    MigratableError::MigrateSend(anyhow!("Error creating keep alive sender: {e}"))
-                })?,
+                KeepAliveStream::new(socket, TIMEOUT_DURATION)
+                    .context("Error creating keep alive sender")
+                    .map_err(MigratableError::MigrateSend)?,
             ));
         }
+
         // Otherwise we return the socket.
         Ok(socket)
     } else if let Some(path) = &send_data_migration.destination_url.strip_prefix("unix:") {
         info!("Connecting to UNIX socket at {path:?}");
 
-        let socket = UnixStream::connect(path).map_err(|e| {
-            MigratableError::MigrateSend(anyhow!("Error connecting to UNIX socket: {e}"))
-        })?;
+        let socket = UnixStream::connect(path)
+            .context("Error connecting to UNIX socket")
+            .map_err(MigratableError::MigrateSend)?;
 
         Ok(SocketStream::Unix(socket))
     } else {
@@ -1720,11 +1718,8 @@ fn send_memory_regions(
                     fd,
                     (range.length - offset) as usize,
                 )
-                .map_err(|e| {
-                    MigratableError::MigrateSend(anyhow!(
-                        "Error transferring memory to socket: {e}"
-                    ))
-                })?;
+                .context("Error transferring memory to socket")
+                .map_err(MigratableError::MigrateSend)?;
             offset += bytes_written as u64;
 
             if offset == range.length {
@@ -2515,7 +2510,7 @@ impl Vmm {
         Request::start().write_to(&mut socket)?;
         Response::read_from(&mut socket)?.ok_or_abandon(
             &mut socket,
-            MigratableError::MigrateSend(anyhow!("Error starting migration")),
+            MigratableError::MigrateSend(anyhow!("Error starting migration (got bad response)")),
         )?;
 
         // Send config
@@ -2552,9 +2547,8 @@ impl Vmm {
                     profile,
                 },
             )
-            .map_err(|e| {
-                MigratableError::MigrateSend(anyhow!("Error generating common cpuid': {e:?}"))
-            })?
+            .context("Error generating common cpuid")
+            .map_err(MigratableError::MigrateSend)?
         };
 
         if send_data_migration.local {
@@ -2589,7 +2583,9 @@ impl Vmm {
             .map_err(MigratableError::MigrateSocket)?;
         Response::read_from(&mut socket)?.ok_or_abandon(
             &mut socket,
-            MigratableError::MigrateSend(anyhow!("Error during config migration")),
+            MigratableError::MigrateSend(anyhow!(
+                "Error during config migration (got bad response)"
+            )),
         )?;
 
         // Let every Migratable object know about the migration being started.
@@ -2632,14 +2628,16 @@ impl Vmm {
             .map_err(MigratableError::MigrateSocket)?;
         Response::read_from(&mut socket)?.ok_or_abandon(
             &mut socket,
-            MigratableError::MigrateSend(anyhow!("Error during state migration")),
+            MigratableError::MigrateSend(anyhow!(
+                "Error during state migration (got bad response)"
+            )),
         )?;
         // Complete the migration
         // At this step, the receiving VMM will acquire disk locks again.
         Request::complete().write_to(&mut socket)?;
         Response::read_from(&mut socket)?.ok_or_abandon(
             &mut socket,
-            MigratableError::MigrateSend(anyhow!("Error completing migration")),
+            MigratableError::MigrateSend(anyhow!("Error completing migration (got bad response)")),
         )?;
 
         // Record downtime

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, Barrier, Mutex};
 use std::{ffi, result, thread};
 
 use acpi_tables::{Aml, aml};
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 use arch::RegionType;
 #[cfg(target_arch = "x86_64")]
 use devices::ioapic;
@@ -2542,7 +2542,8 @@ impl Transportable for MemoryManager {
             .write(true)
             .create_new(true)
             .open(memory_file_path)
-            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+            .context("Error creating snapshot file for memory")
+            .map_err(MigratableError::MigrateSend)?;
 
         let guest_memory = self.guest_memory.memory();
 
@@ -2560,7 +2561,8 @@ impl Transportable for MemoryManager {
                         &mut memory_file,
                         (range.length - offset) as usize,
                     )
-                    .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+                    .context("Error writing guest memory to snapshot file")
+                    .map_err(MigratableError::MigrateSend)?;
                 offset += bytes_written as u64;
 
                 if offset == range.length {
@@ -2578,9 +2580,10 @@ impl Migratable for MemoryManager {
     // Just before we do a bulk copy we want to start/clear the dirty log so that
     // pages touched during our bulk copy are tracked.
     fn start_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
-        self.vm.start_dirty_log().map_err(|e| {
-            MigratableError::MigrateSend(anyhow!("Error starting VM dirty log {e}"))
-        })?;
+        self.vm
+            .start_dirty_log()
+            .context("Error starting VM dirty log")
+            .map_err(MigratableError::MigrateSend)?;
 
         for r in self.guest_memory.memory().iter() {
             (**r).bitmap().reset();
@@ -2590,9 +2593,10 @@ impl Migratable for MemoryManager {
     }
 
     fn stop_dirty_log(&mut self) -> std::result::Result<(), MigratableError> {
-        self.vm.stop_dirty_log().map_err(|e| {
-            MigratableError::MigrateSend(anyhow!("Error stopping VM dirty log {e}"))
-        })?;
+        self.vm
+            .stop_dirty_log()
+            .context("Error stopping VM dirty log")
+            .map_err(MigratableError::MigrateSend)?;
 
         Ok(())
     }
@@ -2602,9 +2606,11 @@ impl Migratable for MemoryManager {
     fn dirty_log(&mut self) -> std::result::Result<MemoryRangeTable, MigratableError> {
         let mut table = MemoryRangeTable::default();
         for r in &self.guest_ram_mappings {
-            let vm_dirty_bitmap = self.vm.get_dirty_log(r.slot, r.gpa, r.size).map_err(|e| {
-                MigratableError::MigrateSend(anyhow!("Error getting VM dirty log {e}"))
-            })?;
+            let vm_dirty_bitmap = self
+                .vm
+                .get_dirty_log(r.slot, r.gpa, r.size)
+                .context("Error getting VM dirty log")
+                .map_err(MigratableError::MigrateSend)?;
             let vmm_dirty_bitmap = match self.guest_memory.memory().find_region(GuestAddress(r.gpa))
             {
                 Some(region) => {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -24,7 +24,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::time::Instant;
 use std::{cmp, result, str, thread};
 
-use anyhow::anyhow;
+use anyhow::{Context, anyhow};
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use arch::PciSpaceInfo;
 #[cfg(target_arch = "x86_64")]
@@ -2545,18 +2545,18 @@ impl Vm {
         {
             Request::memory_fd(std::mem::size_of_val(&slot) as u64)
                 .write_to(socket)
-                .map_err(|e| {
-                    MigratableError::MigrateSend(anyhow!("Error sending memory fd request: {e}"))
-                })?;
+                .context("Error sending memory fd request")
+                .map_err(MigratableError::MigrateSend)?;
             socket
                 .send_with_fd(&slot.to_le_bytes()[..], fd)
-                .map_err(|e| {
-                    MigratableError::MigrateSend(anyhow!("Error sending memory fd: {e}"))
-                })?;
+                .context("Error sending memory fd")
+                .map_err(MigratableError::MigrateSend)?;
 
             Response::read_from(socket)?.ok_or_abandon(
                 socket,
-                MigratableError::MigrateSend(anyhow!("Error during memory fd migration")),
+                MigratableError::MigrateSend(anyhow!(
+                    "Error during memory fd migration (got bad response)"
+                )),
             )?;
         }
 
@@ -2919,15 +2919,18 @@ impl Transportable for Vm {
             .write(true)
             .create_new(true)
             .open(snapshot_config_path)
-            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+            .context("Error creating config snapshot file")
+            .map_err(MigratableError::MigrateSend)?;
 
         // Serialize and write the snapshot config
         let vm_config = serde_json::to_string(self.config.lock().unwrap().deref())
-            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+            .context("Error serializing VM config")
+            .map_err(MigratableError::MigrateSend)?;
 
         snapshot_config_file
             .write(vm_config.as_bytes())
-            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+            .context("Error writing serialized VM config")
+            .map_err(MigratableError::MigrateSend)?;
 
         let mut snapshot_state_path = url_to_path(destination_url)?;
         snapshot_state_path.push(SNAPSHOT_STATE_FILE);
@@ -2938,15 +2941,18 @@ impl Transportable for Vm {
             .write(true)
             .create_new(true)
             .open(snapshot_state_path)
-            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+            .context("Error creating state snapshot file")
+            .map_err(MigratableError::MigrateSend)?;
 
         // Serialize and write the snapshot state
-        let vm_state =
-            serde_json::to_vec(snapshot).map_err(|e| MigratableError::MigrateSend(e.into()))?;
+        let vm_state = serde_json::to_vec(snapshot)
+            .context("Error serializing state snapshot")
+            .map_err(MigratableError::MigrateSend)?;
 
         snapshot_state_file
             .write(&vm_state)
-            .map_err(|e| MigratableError::MigrateSend(e.into()))?;
+            .context("Error writing serialized state snapshot")
+            .map_err(MigratableError::MigrateSend)?;
 
         // Tell the memory manager to also send/write its own snapshot.
         if let Some(memory_manager_snapshot) = snapshot.snapshots.get(MEMORY_MANAGER_SNAPSHOT_ID) {


### PR DESCRIPTION
This commit adds more context to MigrateSend-Errors, since they were often not helpful. I did that by 

1. stop converting errors to strings
2. using `anyhow::Context` to add context to errors, and
3. just adding more text to some error messages.

I am currently trying to reproduce some errors to see whether the changes have the intended effect.

While I was here I also did the same thing for `MigrateReceive`