### PR TITLE
Fix prefaulting pages

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3851,7 +3851,7 @@ impl RequestHandler for Vmm {
 
         let mut state = ReceiveMigrationState::Established;
 
-        while !state.finished() {
+        let res: result::Result<ReceiveMigrationState, MigratableError> = loop {
             let req = Request::read_from(&mut socket)?;
             trace!("Command {:?} received", req.command());
 
@@ -3859,35 +3859,46 @@ impl RequestHandler for Vmm {
                 continue;
             }
 
-            let (response, new_state) = match self.vm_receive_migration_step(
+            let (response, new_state, mut maybe_error) = match self.vm_receive_migration_step(
                 &listener,
                 &mut socket,
                 state,
                 &req,
                 &receive_data_migration,
             ) {
-                Ok(next_state) => (Response::ok(), next_state),
+                Ok(next_state) => (Response::ok(), next_state, None),
                 Err(err) => {
                     warn!(
                         "Migration aborted as migration command {:?} failed: {}",
                         req.command(),
                         err
                     );
-                    (Response::error(), ReceiveMigrationState::Aborted)
+                    (Response::error(), ReceiveMigrationState::Aborted, Some(err))
                 }
             };
 
             state = new_state;
             assert_eq!(response.length(), 0);
             response.write_to(&mut socket)?;
-        }
 
-        if let ReceiveMigrationState::Aborted = state {
+            if maybe_error.is_some() {
+                break Err(maybe_error.take().unwrap());
+            } else if state.finished() {
+                break Ok(state);
+            }
+        };
+
+        if matches!(res, Err(_) | Ok(ReceiveMigrationState::Aborted)) {
             self.vm = MaybeVmOwnership::None;
             self.vm_config = None;
-            return Err(MigratableError::CompleteMigration(anyhow!(
-                "Migration was aborted"
-            )));
+            match res {
+                Ok(_) => {
+                    return Err(MigratableError::CompleteMigration(anyhow!(
+                        "Migration was aborted by sender"
+                    )));
+                }
+                Err(e) => return Err(MigratableError::CompleteMigration(e.into())),
+            }
         }
 
         Ok(())

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -348,6 +348,10 @@ pub enum Error {
     /// Memory size is misaligned with default page size or its hugepage size
     #[error("Memory size is misaligned with default page size or its hugepage size")]
     MisalignedMemorySize,
+
+    /// Failed to prefault memory
+    #[error("Failed to prefault memory")]
+    PrefaultMemory(#[source] io::Error),
 }
 
 const ENABLE_FLAG: usize = 0;
@@ -1464,27 +1468,47 @@ impl MemoryManager {
             let barrier = Arc::new(Barrier::new(num_threads));
             thread::scope(|s| {
                 let r = &region;
+                let mut handles = Vec::new();
                 for i in 0..num_threads {
                     let barrier = Arc::clone(&barrier);
-                    s.spawn(move || {
-                        // Wait until all threads have been spawned to avoid contention
-                        // over mmap_sem between thread stack allocation and page faulting.
-                        barrier.wait();
-                        let pages = pages_per_thread + if i < remainder { 1 } else { 0 };
-                        let offset =
-                            page_size * ((i * pages_per_thread) + std::cmp::min(i, remainder));
-                        // SAFETY: FFI call with correct arguments
-                        let ret = unsafe {
-                            let addr = r.as_ptr().add(offset);
-                            libc::madvise(addr as _, pages * page_size, libc::MADV_POPULATE_WRITE)
-                        };
-                        if ret != 0 {
-                            let e = io::Error::last_os_error();
-                            warn!("Failed to prefault pages: {e}");
-                        }
-                    });
+                    let h: thread::ScopedJoinHandle<'_, Result<(), io::Error>> =
+                        s.spawn(move || {
+                            // Wait until all threads have been spawned to avoid contention
+                            // over mmap_sem between thread stack allocation and page faulting.
+                            barrier.wait();
+                            let pages = pages_per_thread + if i < remainder { 1 } else { 0 };
+                            let offset =
+                                page_size * ((i * pages_per_thread) + std::cmp::min(i, remainder));
+                            // SAFETY: FFI call with correct arguments
+                            let ret = unsafe {
+                                let addr = r.as_ptr().add(offset);
+                                libc::madvise(
+                                    addr as _,
+                                    pages * page_size,
+                                    libc::MADV_POPULATE_WRITE,
+                                )
+                            };
+                            if ret != 0 {
+                                let e = io::Error::last_os_error();
+                                warn!("Failed to prefault pages: {e}");
+                                return Err(e);
+                            }
+                            Ok(())
+                        });
+                    handles.push(h);
                 }
-            });
+
+                for handle in handles {
+                    handle
+                        .join()
+                        .map_err(|_| {
+                            Error::PrefaultMemory(io::Error::other("Prefault thread died"))
+                        })?
+                        .map_err(Error::PrefaultMemory)?;
+                }
+
+                Ok(())
+            })?;
         }
 
         if region.file_offset().is_none() && thp {


### PR DESCRIPTION
Before this change, prefaulting pages was done on a best-effort basis, meaning that errors were ignored. This could lead to runtime errors. This change fixes this behavior, and errors during prefaulting will be reported.

This change also fixes the error reporting on the receiving side of a live migration. Before, errors were not reported to the API, the response was just `Migration was aborted`, and the real reason had to be found in the log. With this change the reason will be reported to the API.

## Before:

API Response:

```
["Error from API","Error starting migration receiver","Failed to complete migration for migratable component","Migration was aborted"]
```

Log:

```
...
<anonymous> WARN:vmm/src/memory_manager.rs:1493 -- Failed to prefault pages: Bad address (os error 14)
<vmm> WARN:vmm/src/lib.rs:3766 -- Migration aborted as migration command Config failed: Failed to receive migratable component snapshot
...
```

## After:

API Response:

```
["Error from API","Error starting migration receiver","Failed to complete migration for migratable component","Failed to receive migratable component snapshot","Error creating MemoryManager from snapshot","Failed to prefault memory","Bad address (os error 14)"]
```

This is also a good showcase for #98, because without the API response would have been

```
["Error from API","Error starting migration receiver","Failed to complete migration for migratable component","Migration was aborted: Failed to receive migratable component snapshot"]
```

Steps to undraft:

- [x] merge #98