### PR TITLE
 vmm: keep virtio activation alive in migration

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -26,7 +26,7 @@ use std::sync::mpsc::{
     Receiver, RecvError, SendError, Sender, SyncSender, TryRecvError, TrySendError, channel,
     sync_channel,
 };
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::thread::{JoinHandle, sleep};
 #[cfg(not(target_arch = "riscv64"))]
 use std::time::{Duration, Instant};
@@ -81,6 +81,7 @@ use crate::config::{RestoreConfig, add_to_config};
 use crate::coredump::GuestDebuggable;
 #[cfg(feature = "kvm")]
 use crate::cpu::IS_IN_SHUTDOWN;
+use crate::device_manager::DeviceManager;
 use crate::landlock::Landlock;
 use crate::memory_manager::MemoryManager;
 use crate::migration::{get_vm_snapshot, recv_vm_config, recv_vm_state};
@@ -922,13 +923,40 @@ pub struct VmmThreadHandle {
     pub http_api_handle: Option<HttpApiHandle>,
 }
 
+struct MigrationVmState {
+    // The migration worker owns the VM during migration, so this should stop
+    // working once that VM has been dropped.
+    device_manager: Weak<Mutex<DeviceManager>>,
+}
+
+impl MigrationVmState {
+    fn new(vm: &Vm) -> Self {
+        Self {
+            device_manager: Arc::downgrade(vm.device_manager()),
+        }
+    }
+
+    fn activate_virtio_devices(&self) -> result::Result<(), VmError> {
+        self.device_manager
+            .upgrade()
+            .expect("device manager should remain alive during migration")
+            .lock()
+            .unwrap()
+            .activate_virtio_devices()
+            .map_err(VmError::ActivateVirtioDevices)
+    }
+}
+
 /// Describes the current ownership of a running VM.
 #[allow(clippy::large_enum_variant)]
-pub enum MaybeVmOwnership {
+enum MaybeVmOwnership {
     /// The VMM holds the ownership of the VM.
     Vmm(Vm),
     /// The VM is temporarily blocked by the current ongoing migration.
-    Migration,
+    ///
+    /// We still keep the device manager reachable so the epoll thread can
+    /// drain pending virtio activations while the migration worker owns the VM.
+    Migration(MigrationVmState),
     /// No VM is running.
     None,
 }
@@ -939,13 +967,12 @@ impl MaybeVmOwnership {
     /// # Panics
     /// This method panics if `self` is not [`Self::Vmm`].
     fn take_vm_for_migration(&mut self) -> Vm {
-        if !matches!(self, Self::Vmm(_)) {
-            panic!("should only be called when a migration can start");
-        }
-
-        match mem::replace(self, Self::Migration) {
-            MaybeVmOwnership::Vmm(vm) => vm,
-            _ => unreachable!(),
+        match mem::replace(self, Self::None) {
+            Self::Vmm(vm) => {
+                *self = Self::Migration(MigrationVmState::new(&vm));
+                vm
+            }
+            _ => panic!("should only be called when a migration can start"),
         }
     }
 
@@ -2942,7 +2969,7 @@ impl Vmm {
         vm_config: Arc<Mutex<VmConfig>>,
         prefault: bool,
     ) -> std::result::Result<(), VmError> {
-        if matches!(self.vm, MaybeVmOwnership::Migration) {
+        if matches!(self.vm, MaybeVmOwnership::Migration(_)) {
             return Err(VmError::VmMigrating);
         }
 
@@ -3175,7 +3202,7 @@ impl Vmm {
                         // Consume the event.
                         self.reset_evt.read().map_err(Error::EventFdRead)?;
                         // Workaround for guest-induced shutdown during a live-migration.
-                        if matches!(self.vm, MaybeVmOwnership::Migration) {
+                        if matches!(self.vm, MaybeVmOwnership::Migration(_)) {
                             self.postpone_lifecycle_event_during_migration(
                                 PostMigrationLifecycleEvent::VmReboot,
                             );
@@ -3187,7 +3214,7 @@ impl Vmm {
                         info!("VM guest exit event");
                         self.guest_exit_evt.read().map_err(Error::EventFdRead)?;
                         // Workaround for guest-induced shutdown during a live-migration.
-                        if matches!(self.vm, MaybeVmOwnership::Migration) {
+                        if matches!(self.vm, MaybeVmOwnership::Migration(_)) {
                             self.postpone_lifecycle_event_during_migration(
                                 PostMigrationLifecycleEvent::VmShutdown,
                             );
@@ -3201,11 +3228,18 @@ impl Vmm {
                         }
                     }
                     EpollDispatch::ActivateVirtioDevices => {
-                        if let MaybeVmOwnership::Vmm(ref vm) = self.vm {
-                            let count = self.activate_evt.read().map_err(Error::EventFdRead)?;
-                            info!("Trying to activate pending virtio devices: count = {count}");
-                            vm.activate_virtio_devices()
-                                .map_err(Error::ActivateVirtioDevices)?;
+                        let count = self.activate_evt.read().map_err(Error::EventFdRead)?;
+                        info!("Trying to activate pending virtio devices: count = {count}");
+                        match &self.vm {
+                            MaybeVmOwnership::Vmm(vm) => vm
+                                .activate_virtio_devices()
+                                .map_err(Error::ActivateVirtioDevices)?,
+                            MaybeVmOwnership::Migration(state) => {
+                                state
+                                    .activate_virtio_devices()
+                                    .map_err(Error::ActivateVirtioDevices)?;
+                            }
+                            MaybeVmOwnership::None => {}
                         }
                     }
                     EpollDispatch::Api => {
@@ -3300,7 +3334,7 @@ impl RequestHandler for Vmm {
         info!("Booting VM");
         event!("vm", "booting");
 
-        if matches!(self.vm, MaybeVmOwnership::Migration) {
+        if matches!(self.vm, MaybeVmOwnership::Migration(_)) {
             return Err(VmError::VmMigrating);
         }
 
@@ -3376,7 +3410,7 @@ impl RequestHandler for Vmm {
     fn vm_pause(&mut self) -> result::Result<(), VmError> {
         match self.vm {
             MaybeVmOwnership::Vmm(ref mut vm) => vm.pause().map_err(VmError::Pause),
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating)?,
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating)?,
             MaybeVmOwnership::None => Err(VmError::VmNotRunning)?,
         }
     }
@@ -3384,7 +3418,7 @@ impl RequestHandler for Vmm {
     fn vm_resume(&mut self) -> result::Result<(), VmError> {
         match self.vm {
             MaybeVmOwnership::Vmm(ref mut vm) => vm.resume().map_err(VmError::Resume),
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating)?,
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating)?,
             MaybeVmOwnership::None => Err(VmError::VmNotRunning)?,
         }
     }
@@ -3401,7 +3435,7 @@ impl RequestHandler for Vmm {
                             .map_err(VmError::SnapshotSend)
                     })
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating)?,
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating)?,
             MaybeVmOwnership::None => Err(VmError::VmNotRunning)?,
         }
     }
@@ -3409,7 +3443,7 @@ impl RequestHandler for Vmm {
     fn vm_restore(&mut self, restore_cfg: RestoreConfig) -> result::Result<(), VmError> {
         match &self.vm {
             MaybeVmOwnership::Vmm(_vm) => return Err(VmError::VmAlreadyCreated),
-            MaybeVmOwnership::Migration => return Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => return Err(VmError::VmMigrating),
             MaybeVmOwnership::None => (),
         }
 
@@ -3464,7 +3498,7 @@ impl RequestHandler for Vmm {
             MaybeVmOwnership::Vmm(ref mut vm) => {
                 vm.coredump(destination_url).map_err(VmError::Coredump)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => Err(VmError::VmNotRunning),
         }
     }
@@ -3472,7 +3506,7 @@ impl RequestHandler for Vmm {
     fn vm_shutdown(&mut self) -> result::Result<(), VmError> {
         let vm = match self.vm {
             MaybeVmOwnership::Vmm(ref mut vm) => vm,
-            MaybeVmOwnership::Migration => return Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => return Err(VmError::VmMigrating),
             MaybeVmOwnership::None => return Err(VmError::VmNotRunning),
         };
         // Drain console_info so that the FDs are not reused
@@ -3493,7 +3527,7 @@ impl RequestHandler for Vmm {
         // First we stop the current VM
         let vm = match self.vm {
             MaybeVmOwnership::Vmm(ref mut vm) => vm,
-            MaybeVmOwnership::Migration => return Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => return Err(VmError::VmMigrating),
             MaybeVmOwnership::None => return Err(VmError::VmNotRunning),
         };
         let config = vm.get_config();
@@ -3566,7 +3600,7 @@ impl RequestHandler for Vmm {
         let state = match &self.vm {
             MaybeVmOwnership::Vmm(vm) => vm.get_state(),
             // TODO in theory one could live-migrate a non-running VM ..
-            MaybeVmOwnership::Migration => VmState::Running,
+            MaybeVmOwnership::Migration(_) => VmState::Running,
             MaybeVmOwnership::None => VmState::Created,
         };
 
@@ -3575,14 +3609,14 @@ impl RequestHandler for Vmm {
             MaybeVmOwnership::Vmm(vm) => {
                 memory_actual_size -= vm.balloon_size();
             }
-            MaybeVmOwnership::Migration => {}
+            MaybeVmOwnership::Migration(_) => {}
             MaybeVmOwnership::None => {}
         }
 
         let device_tree = match &self.vm {
             MaybeVmOwnership::Vmm(vm) => Some(vm.device_tree().lock().unwrap().clone()),
             // TODO we need to fix this
-            MaybeVmOwnership::Migration => None,
+            MaybeVmOwnership::Migration(_) => None,
             MaybeVmOwnership::None => None,
         };
 
@@ -3624,7 +3658,7 @@ impl RequestHandler for Vmm {
             MaybeVmOwnership::None => {
                 self.vm_config = None;
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating)?,
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating)?,
         }
 
         Ok(())
@@ -3654,7 +3688,7 @@ impl RequestHandler for Vmm {
                     .inspect_err(|e| error!("Error when resizing VM: {e:?}"))?;
                 Ok(())
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
                 if let Some(desired_vcpus) = desired_vcpus {
@@ -3687,7 +3721,7 @@ impl RequestHandler for Vmm {
                     Ok(())
                 }
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => Err(VmError::ResizeDisk),
         }
     }
@@ -3701,7 +3735,7 @@ impl RequestHandler for Vmm {
                     .inspect_err(|e| error!("Error when resizing zone: {e:?}"))?;
                 Ok(())
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 // Update VmConfig by setting the new desired ram.
                 let memory_config = &mut self.vm_config.as_ref().unwrap().lock().unwrap().memory;
@@ -3743,7 +3777,7 @@ impl RequestHandler for Vmm {
                     .map(Some)
                     .map_err(VmError::SerializeJson)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 // Update VmConfig by adding the new device.
                 let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
@@ -3775,7 +3809,7 @@ impl RequestHandler for Vmm {
                     .map(Some)
                     .map_err(VmError::SerializeJson)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 // Update VmConfig by adding the new device.
                 let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
@@ -3792,7 +3826,7 @@ impl RequestHandler for Vmm {
                     .inspect_err(|e| error!("Error when removing device from the VM: {e:?}"))?;
                 Ok(())
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 if let Some(ref config) = self.vm_config {
                     let mut config = config.lock().unwrap();
@@ -3827,7 +3861,7 @@ impl RequestHandler for Vmm {
                     .map(Some)
                     .map_err(VmError::SerializeJson)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 // Update VmConfig by adding the new device.
                 let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
@@ -3856,7 +3890,7 @@ impl RequestHandler for Vmm {
                     .map(Some)
                     .map_err(VmError::SerializeJson)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 // Update VmConfig by adding the new device.
                 let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
@@ -3885,7 +3919,7 @@ impl RequestHandler for Vmm {
                     .map(Some)
                     .map_err(VmError::SerializeJson)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 // Update VmConfig by adding the new device.
                 let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
@@ -3914,7 +3948,7 @@ impl RequestHandler for Vmm {
                     .map(Some)
                     .map_err(VmError::SerializeJson)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 // Update VmConfig by adding the new device.
                 let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
@@ -3943,7 +3977,7 @@ impl RequestHandler for Vmm {
                     .map(Some)
                     .map_err(VmError::SerializeJson)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 // Update VmConfig by adding the new device.
                 let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
@@ -3977,7 +4011,7 @@ impl RequestHandler for Vmm {
                     .map(Some)
                     .map_err(VmError::SerializeJson)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => {
                 // Update VmConfig by adding the new device.
                 let mut config = self.vm_config.as_ref().unwrap().lock().unwrap();
@@ -3997,7 +4031,7 @@ impl RequestHandler for Vmm {
                     .map(Some)
                     .map_err(VmError::SerializeJson)
             }
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => Err(VmError::VmNotRunning),
         }
     }
@@ -4005,7 +4039,7 @@ impl RequestHandler for Vmm {
     fn vm_power_button(&mut self) -> result::Result<(), VmError> {
         match self.vm {
             MaybeVmOwnership::Vmm(ref mut vm) => vm.power_button(),
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => Err(VmError::VmNotRunning),
         }
     }
@@ -4013,7 +4047,7 @@ impl RequestHandler for Vmm {
     fn vm_nmi(&mut self) -> result::Result<(), VmError> {
         match self.vm {
             MaybeVmOwnership::Vmm(ref mut vm) => vm.nmi(),
-            MaybeVmOwnership::Migration => Err(VmError::VmMigrating),
+            MaybeVmOwnership::Migration(_) => Err(VmError::VmMigrating),
             MaybeVmOwnership::None => Err(VmError::VmNotRunning),
         }
     }
@@ -4103,7 +4137,7 @@ impl RequestHandler for Vmm {
     ) -> result::Result<(), MigratableError> {
         match self.vm {
             MaybeVmOwnership::Vmm(_) => (),
-            MaybeVmOwnership::Migration => {
+            MaybeVmOwnership::Migration(_) => {
                 return Err(MigratableError::MigrateSend(anyhow!(
                     "There is already an ongoing migration"
                 )));
@@ -4192,7 +4226,7 @@ impl RequestHandler for Vmm {
 
     fn vm_cancel_migration(&mut self) -> result::Result<(), MigratableError> {
         match self.vm {
-            MaybeVmOwnership::Migration => (),
+            MaybeVmOwnership::Migration(_) => (),
             _ => {
                 return Err(MigratableError::CancelMigration(anyhow!(
                     "There is no ongoing migration"

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -2897,6 +2897,10 @@ impl Vm {
         Ok(())
     }
 
+    pub fn device_manager(&self) -> &Arc<Mutex<DeviceManager>> {
+        &self.device_manager
+    }
+
     pub fn activate_virtio_devices(&self) -> Result<()> {
         self.device_manager
             .lock()


### PR DESCRIPTION
This fixes https://github.com/cobaltcore-dev/cobaltcore/issues/411

Live migration can deadlock if the guest triggers a virtio device
activation while the migration worker owns the VM.

The failure shows up during boot and firmware, where the guest can
reset and reinitialize virtio devices while precopy is running. In the
failing case, the source log shows a pending virtio activation that
never completes:
```
  8.115833s _virtio-pci-net_0: Needs activation; returning barrier
  8.115854s vmm/src/vm.rs:464 -- Waiting for barrier
  24.875452s Entering downtime phase
  24.875481s stopping vcpu throttling thread
  ...
  vCPU thread did not respond in 10ms to signal - retrying
  vCPU thread did not respond in 20ms to signal - retrying
  ...
  thread 'throttle-vcpu' (1029) panicked
  ...
  Pause(Error signalling vCPUs: Timeout when waiting for signal
        to be acknowledged)
```
The vCPU blocks on the activation barrier and never reaches the normal
pause checkpoint. Later, migration enters downtime and stops the vCPU
throttle thread. In the failing case, that thread is still inside a
CpuManager::pause() call, which waits for every vCPU to acknowledge
the signal. The blocked vCPU never does, so the pause times out.

The VMM already receives ActivateVirtioDevices events during
migration, but it only drains pending activations when self.vm is in
MaybeVmOwnership::Vmm. Once vm_send_migration() moves the Vm into the
migration worker, self.vm becomes MaybeVmOwnership::Migration and the
event handler no longer has a path to call activate_virtio_devices().

Fix this by storing the DeviceManager inside
MaybeVmOwnership::Migration. This keeps just enough state on the VMM
thread to drain pending virtio activations while the migration worker
owns the Vm. The barrier logic stays unchanged. The VMM now releases
the same activation barrier during migration that it already released
before migration started.

This keeps the guest from getting stuck in the activation wait and
lets the later pause succeed.

See reproducer in [libvirt-tests](https://github.com/cyberus-technology/libvirt-tests/pull/179)

## Steps to un-draft
- [x] verify if there is anything left for https://github.com/cobaltcore-dev/cobaltcore/issues/411
- [x] Wait for [Pipeline](https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/pipelines/197946) to go green
- [x] drop xxx commit