### PR TITLE
Fix timeout during prefault

### DIFF
--- a/vm-migration/src/keep_alive_stream.rs
+++ b/vm-migration/src/keep_alive_stream.rs
@@ -13,7 +13,7 @@ use std::{result, thread};
 use vm_memory::bitmap::BitmapSlice;
 use vm_memory::{ReadVolatile, VolatileMemoryError, VolatileSlice, WriteVolatile};
 
-use crate::protocol::Request;
+use crate::protocol::{Request, Response};
 
 /// The `KeepAliveStream` is a stream that is intended to be used for the main
 /// connection of live migrations. If the `KeepAliveStream` does not read or
@@ -51,14 +51,16 @@ enum KeepAliveStreamAnswer {
 
 struct KeepAliveWorker<S: Read + Write + AsFd> {
     stream: S,
+    /// Is this running on the sender or receiver side?
+    is_sender: bool,
 }
 
 impl<S> KeepAliveWorker<S>
 where
     S: Read + Write + AsFd,
 {
-    pub fn new(stream: S) -> Self {
-        Self { stream }
+    pub fn new(stream: S, is_sender: bool) -> Self {
+        Self { stream, is_sender }
     }
 
     pub fn read(&mut self, mut buf: Vec<u8>, len: usize) -> io::Result<(Vec<u8>, usize)> {
@@ -101,6 +103,7 @@ impl KeepAliveStream {
     pub fn new<T: Read + Write + Send + AsFd + 'static>(
         stream: T,
         timeout: Duration,
+        is_sender: bool,
     ) -> result::Result<Self, io::Error> {
         let fd = stream.as_fd().try_clone_to_owned()?;
 
@@ -109,9 +112,9 @@ impl KeepAliveStream {
         let (answer_tx, answer_rx) = sync_channel::<KeepAliveStreamAnswer>(0);
 
         let thread = thread::Builder::new()
-            .name("keep_alive_sender_thread".to_string())
+            .name("migration_keep_alive_thread".to_string())
             .spawn(move || {
-                let mut worker = KeepAliveWorker::new(stream);
+                let mut worker = KeepAliveWorker::new(stream, is_sender);
                 loop {
                     // The idea is to always send a keep alive message when this times out.
                     match message_rx.recv_timeout(timeout) {
@@ -145,8 +148,13 @@ impl KeepAliveStream {
                             KeepAliveStreamMessage::Disconnect => break,
                         },
                         Err(RecvTimeoutError::Timeout) => {
-                            let keep_alive = Request::keep_alive();
-                            let _ = keep_alive.write_to(&mut worker.stream);
+                            if worker.is_sender {
+                                let keep_alive = Request::keep_alive();
+                                let _ = keep_alive.write_to(&mut worker.stream);
+                            } else {
+                                let keep_alive = Response::keep_alive();
+                                let _ = keep_alive.write_to(&mut worker.stream);
+                            }
                         }
                         Err(RecvTimeoutError::Disconnected) => break,
                     }

--- a/vm-migration/src/keep_alive_stream.rs
+++ b/vm-migration/src/keep_alive_stream.rs
@@ -4,6 +4,7 @@
 //
 
 use std::io::{self, Read, Write};
+use std::os::fd::{AsFd, BorrowedFd, OwnedFd};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, SyncSender, sync_channel};
 use std::thread::JoinHandle;
 use std::time::Duration;
@@ -17,8 +18,6 @@ use crate::protocol::Request;
 /// The `KeepAliveStream` is a stream that is intended to be used for the main
 /// connection of live migrations. If the `KeepAliveStream` does not read or
 /// write often enough, it will send keep alive messages on the given stream.
-/// The `KeepAliveStream` should not be used to send or receive memory, because
-/// the `read_volatile()` and `write_volatile()` functions will be very slow.
 ///
 /// The `KeepAliveStream` is designed to be compatible with the `SocketStream`
 /// enum, and thus it should be really easy to use it.
@@ -50,15 +49,13 @@ enum KeepAliveStreamAnswer {
     Flush(io::Result<()>),
 }
 
-// The [`KeepAliveStream`] should only be used by the sender, not the receiver.
-// Thus it doesn't have to implement `AsFd`.
-struct KeepAliveWorker<S: Read + Write> {
+struct KeepAliveWorker<S: Read + Write + AsFd> {
     stream: S,
 }
 
 impl<S> KeepAliveWorker<S>
 where
-    S: Read + Write,
+    S: Read + Write + AsFd,
 {
     pub fn new(stream: S) -> Self {
         Self { stream }
@@ -87,6 +84,8 @@ where
 pub struct KeepAliveStream {
     /// The `KeepAliveWorker`.
     thread: Option<JoinHandle<()>>,
+    /// Duplicated file descriptor for `AsFd`.
+    fd: OwnedFd,
 
     /// Used to send messages to the worker.
     message_tx: SyncSender<KeepAliveStreamMessage>,
@@ -99,10 +98,12 @@ pub struct KeepAliveStream {
 }
 
 impl KeepAliveStream {
-    pub fn new<T: Read + Write + Send + 'static>(
+    pub fn new<T: Read + Write + Send + AsFd + 'static>(
         stream: T,
         timeout: Duration,
     ) -> result::Result<Self, io::Error> {
+        let fd = stream.as_fd().try_clone_to_owned()?;
+
         // We want to block on send and on recv if nobody listens. Thus we set the bound to 0.
         let (message_tx, message_rx) = sync_channel::<KeepAliveStreamMessage>(0);
         let (answer_tx, answer_rx) = sync_channel::<KeepAliveStreamAnswer>(0);
@@ -154,6 +155,7 @@ impl KeepAliveStream {
 
         Ok(Self {
             thread: Some(thread),
+            fd,
             message_tx,
             answer_rx,
             read_buf: Vec::new(),
@@ -168,6 +170,12 @@ impl Drop for KeepAliveStream {
         if let Some(handle) = self.thread.take() {
             let _ = handle.join();
         }
+    }
+}
+
+impl AsFd for KeepAliveStream {
+    fn as_fd(&self) -> BorrowedFd<'_> {
+        self.fd.as_fd()
     }
 }
 

--- a/vm-migration/src/keep_alive_stream.rs
+++ b/vm-migration/src/keep_alive_stream.rs
@@ -29,10 +29,10 @@ use crate::protocol::Request;
 // The messages that will be sent to the `KeepAliveWorker`.
 #[derive(Debug)]
 enum KeepAliveStreamMessage {
-    // Read `len` bytes from `stream`.
-    Read(usize /* len */),
-    // Write `buf` to `stream`.
-    Write(Vec<u8> /* buf */),
+    // Read `len` bytes into `buf` from `stream`.
+    Read { len: usize, buf: Vec<u8> },
+    // Write `buf[..len]` to `stream`.
+    Write { len: usize, buf: Vec<u8> },
     // Flush `stream`.
     Flush,
     // Stop listening for messages, i.e. stop the worker.
@@ -45,7 +45,7 @@ enum KeepAliveStreamAnswer {
     // Result of reading from `stream`.
     Read(io::Result<(Vec<u8>, usize)>),
     // Result of writing to `stream`.
-    Write(io::Result<usize>),
+    Write(io::Result<(Vec<u8>, usize)>),
     // Result of flushing `stream`.
     Flush(io::Result<()>),
 }
@@ -64,14 +64,19 @@ where
         Self { stream }
     }
 
-    pub fn read(&mut self, len: usize) -> io::Result<(Vec<u8>, usize)> {
-        let mut buf: Vec<u8> = vec![0u8; len];
-        let n = Read::read(&mut self.stream, &mut buf)?;
+    pub fn read(&mut self, mut buf: Vec<u8>, len: usize) -> io::Result<(Vec<u8>, usize)> {
+        if buf.len() < len {
+            buf.resize(len, 0);
+        }
+
+        let n = Read::read(&mut self.stream, &mut buf[..len])?;
         Ok((buf, n))
     }
 
-    pub fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        Write::write(&mut self.stream, buf)
+    pub fn write(&mut self, buf: Vec<u8>, len: usize) -> io::Result<(Vec<u8>, usize)> {
+        debug_assert!(len <= buf.len());
+        let n = Write::write(&mut self.stream, &buf[..len])?;
+        Ok((buf, n))
     }
 
     pub fn flush(&mut self) -> io::Result<()> {
@@ -87,6 +92,10 @@ pub struct KeepAliveStream {
     message_tx: SyncSender<KeepAliveStreamMessage>,
     /// Used to receive answers from the worker.
     answer_rx: Receiver<KeepAliveStreamAnswer>,
+    /// Scratch buffer that gets moved to/from the worker for reads.
+    read_buf: Vec<u8>,
+    /// Scratch buffer that gets moved to/from the worker for writes.
+    write_buf: Vec<u8>,
 }
 
 impl KeepAliveStream {
@@ -106,9 +115,9 @@ impl KeepAliveStream {
                     // The idea is to always send a keep alive message when this times out.
                     match message_rx.recv_timeout(timeout) {
                         Ok(message) => match message {
-                            KeepAliveStreamMessage::Read(payload) => {
+                            KeepAliveStreamMessage::Read { len, buf } => {
                                 if answer_tx
-                                    .send(KeepAliveStreamAnswer::Read(worker.read(payload)))
+                                    .send(KeepAliveStreamAnswer::Read(worker.read(buf, len)))
                                     .is_err()
                                 {
                                     // We simply break the loop and thus stop the thread if anything bad happens.
@@ -116,9 +125,9 @@ impl KeepAliveStream {
                                     break;
                                 }
                             }
-                            KeepAliveStreamMessage::Write(payload) => {
+                            KeepAliveStreamMessage::Write { len, buf } => {
                                 if answer_tx
-                                    .send(KeepAliveStreamAnswer::Write(worker.write(&payload)))
+                                    .send(KeepAliveStreamAnswer::Write(worker.write(buf, len)))
                                     .is_err()
                                 {
                                     break;
@@ -147,6 +156,8 @@ impl KeepAliveStream {
             thread: Some(thread),
             message_tx,
             answer_rx,
+            read_buf: Vec::new(),
+            write_buf: Vec::new(),
         })
     }
 }
@@ -161,17 +172,22 @@ impl Drop for KeepAliveStream {
 }
 
 impl Read for KeepAliveStream {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    fn read(&mut self, out_buf: &mut [u8]) -> io::Result<usize> {
+        let len = out_buf.len();
+        // Move the buffer to avoid lifetime or ownership issues.
+        let read_buf = std::mem::take(&mut self.read_buf);
+
         self.message_tx
-            .send(KeepAliveStreamMessage::Read(buf.len()))
+            .send(KeepAliveStreamMessage::Read { len, buf: read_buf })
             .map_err(|e| {
                 io::Error::other(format!("Unable to send message to KeepAliveWorker: {e}"))
             })?;
 
         match self.answer_rx.recv() {
             Ok(KeepAliveStreamAnswer::Read(result)) => match result {
-                Ok((recv_buf, len)) => {
-                    buf.copy_from_slice(&recv_buf);
+                Ok((buf, len)) => {
+                    self.read_buf = buf;
+                    out_buf[..len].copy_from_slice(&self.read_buf[..len]);
                     Ok(len)
                 }
                 Err(e) => Err(e),
@@ -187,15 +203,33 @@ impl Read for KeepAliveStream {
 }
 
 impl Write for KeepAliveStream {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+    fn write(&mut self, in_buf: &[u8]) -> io::Result<usize> {
+        let len = in_buf.len();
+        if self.write_buf.len() < len {
+            self.write_buf.resize(len, 0);
+        }
+
+        self.write_buf[..len].copy_from_slice(in_buf);
+        // Move the buffer to avoid lifetime or ownership issues.
+        let write_buf = std::mem::take(&mut self.write_buf);
+
         self.message_tx
-            .send(KeepAliveStreamMessage::Write(Vec::from(buf)))
+            .send(KeepAliveStreamMessage::Write {
+                len,
+                buf: write_buf,
+            })
             .map_err(|e| {
                 io::Error::other(format!("Unable to send message to KeepAliveWorker: {e}"))
             })?;
 
         match self.answer_rx.recv() {
-            Ok(KeepAliveStreamAnswer::Write(result)) => result,
+            Ok(KeepAliveStreamAnswer::Write(result)) => match result {
+                Ok((buf, len)) => {
+                    self.write_buf = buf;
+                    Ok(len)
+                }
+                Err(e) => Err(e),
+            },
             Ok(a) => Err(io::Error::other(format!(
                 "Received unexpected answer: {a:?}. This is most likely a bug!",
             ))),
@@ -226,10 +260,14 @@ impl Write for KeepAliveStream {
 impl ReadVolatile for KeepAliveStream {
     fn read_volatile<B: BitmapSlice>(
         &mut self,
-        buf: &mut VolatileSlice<B>,
+        vs: &mut VolatileSlice<B>,
     ) -> result::Result<usize, VolatileMemoryError> {
+        let len = vs.len();
+        // Move the buffer to avoid lifetime or ownership issues.
+        let read_buf = std::mem::take(&mut self.read_buf);
+
         self.message_tx
-            .send(KeepAliveStreamMessage::Read(buf.len()))
+            .send(KeepAliveStreamMessage::Read { len, buf: read_buf })
             .map_err(|e| {
                 io::Error::other(format!("Unable to send message to KeepAliveWorker: {e}"))
             })
@@ -237,8 +275,9 @@ impl ReadVolatile for KeepAliveStream {
 
         match self.answer_rx.recv() {
             Ok(KeepAliveStreamAnswer::Read(result)) => match result {
-                Ok((recv_buf, len)) => {
-                    buf.copy_from(&recv_buf);
+                Ok((buf, len)) => {
+                    self.read_buf = buf;
+                    vs.copy_from(&self.read_buf[..len]);
                     Ok(len)
                 }
                 Err(e) => Err(VolatileMemoryError::IOError(e)),
@@ -256,21 +295,35 @@ impl ReadVolatile for KeepAliveStream {
 impl WriteVolatile for KeepAliveStream {
     fn write_volatile<B: BitmapSlice>(
         &mut self,
-        buf: &VolatileSlice<B>,
+        vs: &VolatileSlice<B>,
     ) -> result::Result<usize, VolatileMemoryError> {
-        let mut send_buf = vec![0u8; buf.len()];
-        buf.copy_to(&mut send_buf);
+        let len = vs.len();
+        if self.write_buf.len() < len {
+            self.write_buf.resize(len, 0);
+        }
+
+        let len = vs.copy_to(&mut self.write_buf[..len]);
+        // Move the buffer to avoid lifetime or ownership issues.
+        let write_buf = std::mem::take(&mut self.write_buf);
+
         self.message_tx
-            .send(KeepAliveStreamMessage::Write(send_buf))
+            .send(KeepAliveStreamMessage::Write {
+                len,
+                buf: write_buf,
+            })
             .map_err(|e| {
                 io::Error::other(format!("Unable to send message to KeepAliveWorker: {e}"))
             })
             .map_err(VolatileMemoryError::IOError)?;
 
         match self.answer_rx.recv() {
-            Ok(KeepAliveStreamAnswer::Write(result)) => {
-                result.map_err(VolatileMemoryError::IOError)
-            }
+            Ok(KeepAliveStreamAnswer::Write(result)) => match result {
+                Ok((buf, len)) => {
+                    self.write_buf = buf;
+                    Ok(len)
+                }
+                Err(e) => Err(VolatileMemoryError::IOError(e)),
+            },
             Ok(a) => Err(VolatileMemoryError::IOError(io::Error::other(format!(
                 "Received unexpected answer: {a:?}. This is most likely a bug!",
             )))),

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -183,8 +183,19 @@ impl Request {
 
     pub fn read_from(fd: &mut dyn Read) -> Result<Request, MigratableError> {
         let mut request = Request::default();
-        fd.read_exact(Self::as_mut_slice(&mut request))
-            .map_err(MigratableError::MigrateSocket)?;
+
+        loop {
+            fd.read_exact(Self::as_mut_slice(&mut request))
+                .map_err(MigratableError::MigrateSocket)?;
+
+            // If we read a keep alive message, we throw it away and keep reading.
+            if request.command() == Command::KeepAlive {
+                request = Request::default();
+                continue;
+            }
+
+            break;
+        }
 
         Ok(request)
     }

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -213,6 +213,7 @@ pub enum Status {
     Invalid,
     Ok,
     Error,
+    KeepAlive,
 }
 
 #[repr(C)]
@@ -243,6 +244,10 @@ impl Response {
         Self::new(Status::Error, 0)
     }
 
+    pub fn keep_alive() -> Self {
+        Self::new(Status::KeepAlive, 0)
+    }
+
     pub fn status(&self) -> Status {
         self.status
     }
@@ -253,8 +258,19 @@ impl Response {
 
     pub fn read_from(fd: &mut dyn Read) -> Result<Response, MigratableError> {
         let mut response = Response::default();
-        fd.read_exact(Self::as_mut_slice(&mut response))
-            .map_err(MigratableError::MigrateSocket)?;
+
+        loop {
+            fd.read_exact(Self::as_mut_slice(&mut response))
+                .map_err(MigratableError::MigrateSocket)?;
+
+            // If we read a keep alive message, we throw it away and keep reading.
+            if response.status() == Status::KeepAlive {
+                response = Response::default();
+                continue;
+            }
+
+            break;
+        }
 
         Ok(response)
     }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -300,6 +300,17 @@ impl From<u64> for EpollDispatch {
 // TODO make this a member of Vmm?
 static MIGRATION_PROGRESS_SNAPSHOT: Mutex<Option<MigrationProgress>> = Mutex::new(None);
 
+// The time a writer may block on a socket until it throws an error.
+// Also the interval at which the [`KeepAliveStream`] sends keep alive messages.
+// This timeout has to be smaller than [`MIGRATION_READ_TIMEOUT_DURATION`],
+// otherwise spurious timeouts may happen.
+const MIGRATION_WRITE_TIMEOUT_DURATION: Duration = Duration::from_secs(5);
+
+/// The time a reader may block on a socket until it throws an error.
+/// This timeout has to be larger than [`MIGRATION_WRITE_TIMEOUT_DURATION`],
+/// otherwise spurious timeouts may happen.
+const MIGRATION_READ_TIMEOUT_DURATION: Duration = Duration::from_secs(10);
+
 enum SocketStream {
     Unix(UnixStream),
     Tcp(TcpStream),
@@ -1075,20 +1086,17 @@ impl AsFd for ReceiveListener {
 }
 
 impl ReceiveListener {
-    /// The time the receiver side may read on a socket until it throws an error.
-    /// This timeout has to be larger than `TIMEOUT_DURATION` in `send_migration_timeout`,
-    /// otherwise spurious timeouts may happen.
-    const TIMEOUT_DURATION: Duration = Duration::from_secs(10);
-
     /// Block until a connection is accepted.
     fn accept(&mut self) -> std::result::Result<SocketStream, std::io::Error> {
         match self {
             ReceiveListener::Tcp(listener) => {
-                Self::accept_with_timeout(listener, Self::TIMEOUT_DURATION).map(|(socket, _)| {
-                    socket.set_read_timeout(Some(Self::TIMEOUT_DURATION))?;
-                    socket.set_write_timeout(Some(Self::TIMEOUT_DURATION))?;
-                    Ok(SocketStream::Tcp(socket))
-                })?
+                Self::accept_with_timeout(listener, MIGRATION_READ_TIMEOUT_DURATION).map(
+                    |(socket, _)| {
+                        socket.set_read_timeout(Some(MIGRATION_READ_TIMEOUT_DURATION))?;
+                        socket.set_write_timeout(Some(MIGRATION_WRITE_TIMEOUT_DURATION))?;
+                        Ok(SocketStream::Tcp(socket))
+                    },
+                )?
             }
             ReceiveListener::Unix(listener, opt_path) => {
                 let socket = listener
@@ -1107,14 +1115,16 @@ impl ReceiveListener {
                 Ok(socket)
             }
             ReceiveListener::Tls(listener, conn) => {
-                Self::accept_with_timeout(listener, Self::TIMEOUT_DURATION).map(|(socket, _)| {
-                    socket.set_read_timeout(Some(Self::TIMEOUT_DURATION))?;
-                    socket.set_write_timeout(Some(Self::TIMEOUT_DURATION))?;
-                    conn.wrap(socket)
-                        .map(Box::new)
-                        .map(SocketStream::Tls)
-                        .map_err(std::io::Error::other)
-                })?
+                Self::accept_with_timeout(listener, MIGRATION_READ_TIMEOUT_DURATION).map(
+                    |(socket, _)| {
+                        socket.set_read_timeout(Some(MIGRATION_READ_TIMEOUT_DURATION))?;
+                        socket.set_write_timeout(Some(MIGRATION_WRITE_TIMEOUT_DURATION))?;
+                        conn.wrap(socket)
+                            .map(Box::new)
+                            .map(SocketStream::Tls)
+                            .map_err(std::io::Error::other)
+                    },
+                )?
             }
         }
     }
@@ -1735,12 +1745,6 @@ fn send_migration_socket(
     send_data_migration: &VmSendMigrationData,
     main_connection: bool,
 ) -> std::result::Result<SocketStream, MigratableError> {
-    // The time the sender side may block on a socket, until it throws an error.
-    // Also the interval at which the {`KeepAliveStream`] sends keep alive messages.
-    // This timeout has to be smaller than [`ReceiveListener::TIMEOUT_DURATION`],
-    // otherwise spurious timeouts may happen.
-    const TIMEOUT_DURATION: Duration = Duration::from_secs(5);
-
     if let Some(address) = send_data_migration.destination_url.strip_prefix("tcp:") {
         let socket = {
             info!("Connecting to TCP socket at {address}");
@@ -1749,11 +1753,11 @@ fn send_migration_socket(
                 .context("Error connecting to TCP socket")
                 .map_err(MigratableError::MigrateSend)?;
             socket
-                .set_read_timeout(Some(TIMEOUT_DURATION))
+                .set_read_timeout(Some(MIGRATION_READ_TIMEOUT_DURATION))
                 .context("Error setting read timeout on TCP socket")
                 .map_err(MigratableError::MigrateSend)?;
             socket
-                .set_write_timeout(Some(TIMEOUT_DURATION))
+                .set_write_timeout(Some(MIGRATION_WRITE_TIMEOUT_DURATION))
                 .context("Error setting write timeout on TCP socket")
                 .map_err(MigratableError::MigrateSend)?;
             if let Some(tls_dir) = &send_data_migration.tls_dir {
@@ -1775,7 +1779,7 @@ fn send_migration_socket(
         // If we use multiple TCP connections, we have to send periodic keep alive messages. Thus, we create a KeepAliveStream.
         if send_data_migration.connections.get() > 1 && main_connection {
             return Ok(SocketStream::KeepAlive(
-                KeepAliveStream::new(socket, TIMEOUT_DURATION)
+                KeepAliveStream::new(socket, MIGRATION_WRITE_TIMEOUT_DURATION)
                     .context("Error creating keep alive sender")
                     .map_err(MigratableError::MigrateSend)?,
             ));

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -4084,10 +4084,6 @@ impl RequestHandler for Vmm {
             let req = Request::read_from(&mut socket)?;
             trace!("Command {:?} received", req.command());
 
-            if req.command() == Command::KeepAlive {
-                continue;
-            }
-
             let (response, new_state, mut maybe_error) = match self.vm_receive_migration_step(
                 &listener,
                 &mut socket,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1779,7 +1779,7 @@ fn send_migration_socket(
         // If we use multiple TCP connections, we have to send periodic keep alive messages. Thus, we create a KeepAliveStream.
         if send_data_migration.connections.get() > 1 && main_connection {
             return Ok(SocketStream::KeepAlive(
-                KeepAliveStream::new(socket, MIGRATION_WRITE_TIMEOUT_DURATION)
+                KeepAliveStream::new(socket, MIGRATION_WRITE_TIMEOUT_DURATION, true)
                     .context("Error creating keep alive sender")
                     .map_err(MigratableError::MigrateSend)?,
             ));

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1087,16 +1087,29 @@ impl AsFd for ReceiveListener {
 
 impl ReceiveListener {
     /// Block until a connection is accepted.
-    fn accept(&mut self) -> std::result::Result<SocketStream, std::io::Error> {
+    fn accept(
+        &mut self,
+        main_connection: bool,
+    ) -> std::result::Result<SocketStream, std::io::Error> {
         match self {
             ReceiveListener::Tcp(listener) => {
-                Self::accept_with_timeout(listener, MIGRATION_READ_TIMEOUT_DURATION).map(
-                    |(socket, _)| {
-                        socket.set_read_timeout(Some(MIGRATION_READ_TIMEOUT_DURATION))?;
-                        socket.set_write_timeout(Some(MIGRATION_WRITE_TIMEOUT_DURATION))?;
-                        Ok(SocketStream::Tcp(socket))
-                    },
-                )?
+                let socket = {
+                    let socket =
+                        Self::accept_with_timeout(listener, MIGRATION_READ_TIMEOUT_DURATION)?;
+
+                    socket.set_read_timeout(Some(MIGRATION_READ_TIMEOUT_DURATION))?;
+                    socket.set_write_timeout(Some(MIGRATION_WRITE_TIMEOUT_DURATION))?;
+                    SocketStream::Tcp(socket)
+                };
+
+                if main_connection {
+                    return Ok(SocketStream::KeepAlive(KeepAliveStream::new(
+                        socket,
+                        MIGRATION_WRITE_TIMEOUT_DURATION,
+                        false,
+                    )?));
+                }
+                Ok(socket)
             }
             ReceiveListener::Unix(listener, opt_path) => {
                 let socket = listener
@@ -1115,16 +1128,25 @@ impl ReceiveListener {
                 Ok(socket)
             }
             ReceiveListener::Tls(listener, conn) => {
-                Self::accept_with_timeout(listener, MIGRATION_READ_TIMEOUT_DURATION).map(
-                    |(socket, _)| {
-                        socket.set_read_timeout(Some(MIGRATION_READ_TIMEOUT_DURATION))?;
-                        socket.set_write_timeout(Some(MIGRATION_WRITE_TIMEOUT_DURATION))?;
-                        conn.wrap(socket)
-                            .map(Box::new)
-                            .map(SocketStream::Tls)
-                            .map_err(std::io::Error::other)
-                    },
-                )?
+                let socket = {
+                    let socket =
+                        Self::accept_with_timeout(listener, MIGRATION_READ_TIMEOUT_DURATION)?;
+                    socket.set_read_timeout(Some(MIGRATION_READ_TIMEOUT_DURATION))?;
+                    socket.set_write_timeout(Some(MIGRATION_WRITE_TIMEOUT_DURATION))?;
+                    conn.wrap(socket)
+                        .map(Box::new)
+                        .map(SocketStream::Tls)
+                        .map_err(io::Error::other)?
+                };
+
+                if main_connection {
+                    return Ok(SocketStream::KeepAlive(KeepAliveStream::new(
+                        socket,
+                        MIGRATION_WRITE_TIMEOUT_DURATION,
+                        false,
+                    )?));
+                }
+                Ok(socket)
             }
         }
     }
@@ -1135,7 +1157,7 @@ impl ReceiveListener {
         eventfd: &EventFd,
     ) -> std::result::Result<Option<SocketStream>, std::io::Error> {
         wait_for_readable(&self, eventfd)?
-            .then(|| self.accept())
+            .then(|| self.accept(false))
             .transpose()
     }
 
@@ -1143,14 +1165,17 @@ impl ReceiveListener {
     fn accept_with_timeout(
         listener: &TcpListener,
         timeout: Duration,
-    ) -> result::Result<(TcpStream, std::net::SocketAddr), std::io::Error> {
+    ) -> result::Result<TcpStream, std::io::Error> {
         let mut timer_fd = TimerFd::new()?;
         timer_fd
             .reset(timeout, None)
             .map_err(|e| io::Error::from_raw_os_error(e.errno()))?;
 
         wait_for_readable(&listener, &timer_fd)?
-            .then(|| listener.accept())
+            .then(|| {
+                let (stream, _) = listener.accept()?;
+                Ok(stream)
+            })
             .ok_or_else(|| {
                 io::Error::new(
                     io::ErrorKind::TimedOut,
@@ -4070,7 +4095,7 @@ impl RequestHandler for Vmm {
         let mut listener = receive_migration_listener(&receive_data_migration)?;
         // Accept the connection and get the socket
         let mut socket = listener
-            .accept()
+            .accept(true)
             .context("Failed to accept migration connection")
             .map_err(|e| {
                 warn!("{e}");

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1776,8 +1776,7 @@ fn send_migration_socket(
             }
         };
 
-        // If we use multiple TCP connections, we have to send periodic keep alive messages. Thus, we create a KeepAliveStream.
-        if send_data_migration.connections.get() > 1 && main_connection {
+        if main_connection {
             return Ok(SocketStream::KeepAlive(
                 KeepAliveStream::new(socket, MIGRATION_WRITE_TIMEOUT_DURATION, true)
                     .context("Error creating keep alive sender")

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -344,9 +344,7 @@ impl AsFd for SocketStream {
             SocketStream::Unix(s) => s.as_fd(),
             SocketStream::Tcp(s) => s.as_fd(),
             SocketStream::Tls(s) => s.as_fd(),
-            SocketStream::KeepAlive(_) => unimplemented!(
-                "AsFd should not be used by a sender, and the KeepAliveStream should only be used by senders."
-            ),
+            SocketStream::KeepAlive(s) => s.as_fd(),
         }
     }
 }


### PR DESCRIPTION
This PR fixes timeout errors if the receiver side of a migration takes a long time applying the VM config (e.g. because prefaulting the memory takes a long time). It does that by making the receiver send keep alive messages during times where the receiver does not listen for new requests.

Unfortunately, this is not easy to test, because we'd need some mechanism that makes the receiver wait for some time at a certain point in the migration. But we tested this at SAP and it worked.