### PR TITLE
Add option to skip zero pages during VM migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,6 +2806,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "itertools 0.14.0",
+ "libc",
  "rustls",
  "serde",
  "serde_json",

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -536,6 +536,11 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .get_one::<PathBuf>("tls-dir")
                     .cloned(),
                 wait_for_migration,
+                *matches
+                    .subcommand_matches("send-migration")
+                    .unwrap()
+                    .get_one::<bool>("skip-zero-pages")
+                    .unwrap(),
             );
 
             simple_api_command(socket, "PUT", "send-migration", Some(&send_migration_data))
@@ -1032,6 +1037,7 @@ fn receive_migration_data(url: String, tls_dir: Option<PathBuf>) -> String {
     serde_json::to_string(&receive_migration_data).unwrap()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn send_migration_data(
     url: String,
     local: bool,
@@ -1040,6 +1046,7 @@ fn send_migration_data(
     connections: NonZeroU32,
     tls_dir: Option<PathBuf>,
     keep_alive: bool,
+    skip_zero_pages: bool,
 ) -> String {
     let send_migration_data = vmm::api::VmSendMigrationData {
         destination_url: url,
@@ -1049,6 +1056,7 @@ fn send_migration_data(
         connections,
         tls_dir,
         keep_alive,
+        skip_zero_pages,
     };
 
     serde_json::to_string(&send_migration_data).unwrap()
@@ -1274,6 +1282,12 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
                     .long("local")
                     .num_args(0)
                     .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("skip-zero-pages")
+                    .long("skip-zero-pages")
+                    .help("skip zero-filled pages when sending VM memory to the receiver")
+                    .num_args(0),
             )
             .arg(
                 Arg::new("tls-dir")

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -7,11 +7,15 @@ version = "0.1.0"
 [dependencies]
 anyhow = { workspace = true }
 itertools = { workspace = true }
+libc = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 vm-memory = { workspace = true, features = ["backend-atomic", "backend-mmap"] }
+
+[dev-dependencies]
+vm-memory = { workspace = true, features = ["backend-bitmap"] }
 
 [lints]
 workspace = true

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -665,7 +665,7 @@ impl MemoryRangeTable {
 #[cfg(test)]
 mod unit_tests {
     use vm_memory::bitmap::AtomicBitmap;
-    use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+    use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap};
 
     use crate::protocol::{MemoryRange, MemoryRangeTable};
 
@@ -812,5 +812,282 @@ mod unit_tests {
                 ]
             );
         }
+    }
+
+    #[test]
+    fn test_memory_range_table_iter_skip_zero_pages_all() {
+        let input = [0b11_0011_0011_0011];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        let expected_regions = [
+            MemoryRange {
+                gpa: start_gpa,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 4 * page_size,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 8 * page_size,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 12 * page_size,
+                length: page_size * 2,
+            },
+        ];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress::new(range.gpa), range.length as usize));
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        let chunks = table
+            .partition(page_size * 2, page_size, true, &atomic_guest_memory_map)
+            .map(|table| table.data)
+            .collect::<Vec<_>>();
+
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn test_memory_range_table_iter_skip_zero_pages_some() {
+        let input = [0b11_0011_0011_0011];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        let expected_regions = [
+            MemoryRange {
+                gpa: start_gpa,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 4 * page_size,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 8 * page_size,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 12 * page_size,
+                length: page_size * 2,
+            },
+        ];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize));
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+
+        expected_regions.iter().step_by(2).for_each(|memory_range| {
+            let buffer = vec![1_u8; memory_range.length as usize];
+            guest_memory_map
+                .read_volatile_from(
+                    GuestAddress::new(memory_range.gpa),
+                    &mut buffer.as_slice(),
+                    memory_range.length as usize,
+                )
+                .unwrap();
+        });
+
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        // Use a large chunk_size to only return one vector.
+        let chunks = table
+            .partition(page_size * 20, page_size, true, &atomic_guest_memory_map)
+            .map(|table| table.data)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            chunks,
+            &[vec![
+                MemoryRange {
+                    gpa: start_gpa + 8 * page_size,
+                    length: page_size * 2,
+                },
+                MemoryRange {
+                    gpa: start_gpa,
+                    length: page_size * 2,
+                },
+            ],]
+        );
+    }
+
+    #[test]
+    fn test_memory_range_table_iter_skip_zero_pages_within_range_table() {
+        let input = [0b0111];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        let expected_regions = [MemoryRange {
+            gpa: start_gpa,
+            length: page_size * 3,
+        }];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize));
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+
+        let buffer = vec![1_u8; page_size as usize];
+
+        guest_memory_map
+            .read_volatile_from(
+                GuestAddress::new(expected_regions[0].gpa),
+                &mut buffer.as_slice(),
+                page_size as usize,
+            )
+            .unwrap();
+
+        guest_memory_map
+            .read_volatile_from(
+                GuestAddress::new(expected_regions[0].gpa + 2 * page_size),
+                &mut buffer.as_slice(),
+                page_size as usize,
+            )
+            .unwrap();
+
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        // Use a large chunk_size to only return one vector.
+        let chunks = table
+            .partition(page_size * 20, page_size, true, &atomic_guest_memory_map)
+            .map(|table| table.data)
+            .collect::<Vec<_>>();
+
+        assert_eq!(
+            chunks,
+            &[vec![
+                MemoryRange {
+                    gpa: start_gpa + 2 * page_size,
+                    length: page_size
+                },
+                MemoryRange {
+                    gpa: start_gpa,
+                    length: page_size
+                }
+            ],]
+        );
+    }
+
+    #[test]
+    fn test_memory_range_table_iter_skip_zero_pages_non_page_boundaries_all_zero() {
+        let input = [0b11_0011_0000_1111];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let mut table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        table.data.iter_mut().for_each(|entry| {
+            entry.gpa += 10;
+        });
+        let expected_regions = [
+            MemoryRange {
+                gpa: start_gpa + 10,
+                length: page_size * 4,
+            },
+            MemoryRange {
+                gpa: start_gpa + 8 * page_size + 10,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 12 * page_size + 10,
+                length: page_size * 2,
+            },
+        ];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize));
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        // Use a large chunk_size to only return one vector.
+        let chunks = table
+            .partition(page_size * 20, page_size, true, &atomic_guest_memory_map)
+            .map(|table| table.data)
+            .collect::<Vec<_>>();
+
+        assert!(chunks.is_empty());
+    }
+
+    #[test]
+    fn test_memory_range_table_iter_skip_zero_pages_non_page_boundaries_all_non_zero() {
+        let input = [0b11_0011_0000_1111];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let mut table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        table.data.iter_mut().for_each(|entry| {
+            entry.gpa += 10;
+        });
+        let expected_regions = [
+            MemoryRange {
+                gpa: start_gpa + 10,
+                length: page_size * 4,
+            },
+            MemoryRange {
+                gpa: start_gpa + 8 * page_size + 10,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 12 * page_size + 10,
+                length: page_size * 2,
+            },
+        ];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize));
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+
+        expected_regions.iter().for_each(|memory_range| {
+            let buffer = vec![1_u8; memory_range.length as usize];
+
+            guest_memory_map
+                .read_volatile_from(
+                    GuestAddress::new(memory_range.gpa),
+                    &mut buffer.as_slice(),
+                    memory_range.length as usize,
+                )
+                .unwrap();
+        });
+
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        // Use a large chunk_size to only return one vector.
+        let chunks = table
+            .partition(page_size * 20, page_size, true, &atomic_guest_memory_map)
+            .map(|table| table.data)
+            .collect::<Vec<_>>();
+
+        let mut expected_chunks = expected_regions.clone();
+        expected_chunks.reverse();
+        assert_eq!(chunks, &[expected_chunks]);
     }
 }

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -78,7 +78,7 @@ use std::io::{Read, Write};
 
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use vm_memory::ByteValued;
+use vm_memory::{Address, ByteValued, GuestAddress, GuestAddressSpace, GuestMemory};
 
 use crate::MigratableError;
 use crate::bitpos_iterator::BitposIteratorExt;
@@ -282,29 +282,218 @@ pub struct MemoryRangeTable {
     data: Vec<MemoryRange>,
 }
 
-#[derive(Debug, Clone, Default)]
-struct MemoryRangeTableIterator {
+/// Iterator that returns the next memory range in the table,
+/// making sure that the returned range is not larger than `chunk_size`.
+///
+/// If the iterator was configured to remove zero pages,
+/// memory pages filled with only zeroes are omitted to reduce the
+/// amount of data to be transmitted in a migration.
+/// This relies on the migration receiver to initialize the guest
+/// memory with zeroed pages.
+///
+/// **Note**: Do not rely on the order of the ranges returned by this
+/// iterator. This allows for a more efficient implementation.
+#[derive(Debug, Clone)]
+struct MemoryRangeTableIterator<'a, M>
+where
+    M: GuestAddressSpace,
+{
+    /// Maximum size of a [`MemoryRange`] returned by the iterator.
     chunk_size: u64,
-    data: Vec<MemoryRange>,
+    /// A zero filled vector of the size of one memory page.
+    /// Used to compare guest memory pages to via [`libc::memcmp`].
+    zero_page: Vec<u8>,
+    /// [`MemoryRange`]s that haven't been checked for zero pages yet.
+    /// Only used if `self.skip_zero_pages == true`.
+    unprocessed_data: Vec<MemoryRange>,
+    /// Indicates whether zero pages should be skipped or not.
+    skip_zero_pages: bool,
+    /// [`MemoryRange`]s to be given out by the iterator.
+    /// Depending on whether zero pages should be skipped, this contains all or just zero page
+    /// removed [`MemoryRange`]s.
+    processed_data: Vec<MemoryRange>,
+    /// A reference to the memory of the guest.
+    /// Used to check whether a [`MemoryRange`] contains zero pages.
+    guest_memory: &'a M,
 }
 
-impl MemoryRangeTableIterator {
-    pub fn new(table: &MemoryRangeTable, chunk_size: u64) -> Self {
-        MemoryRangeTableIterator {
-            chunk_size,
-            data: table.data.clone(),
+impl<'a, M> MemoryRangeTableIterator<'a, M>
+where
+    M: GuestAddressSpace,
+{
+    /// Creates a new [`MemoryRangeTableIterator`].
+    ///
+    /// The size of [`MemoryRangeTable`]s returned by the iterator is limited by `chunk_size`.
+    ///
+    /// If `skip_zero_pages == true`, the iterator checks whether a memory
+    /// page is filled with zeroes and omits all zero filled pages.
+    pub fn new(
+        table: &MemoryRangeTable,
+        chunk_size: u64,
+        page_size: u64,
+        skip_zero_pages: bool,
+        guest_memory: &'a M,
+    ) -> Self {
+        if skip_zero_pages {
+            MemoryRangeTableIterator {
+                chunk_size,
+                zero_page: vec![0; page_size as usize],
+                unprocessed_data: table.data.clone(),
+                skip_zero_pages,
+                processed_data: Vec::new(),
+                guest_memory,
+            }
+        } else {
+            MemoryRangeTableIterator {
+                chunk_size,
+                zero_page: Vec::new(),
+                unprocessed_data: Vec::new(),
+                skip_zero_pages,
+                processed_data: table.data.clone(),
+                guest_memory,
+            }
+        }
+    }
+
+    /// Removes all-zero-pages from [`MemoryRangeTableIterator::data`] and populates
+    /// [`MemoryRangeTableIterator::zero_removed_data`] with the non-zero-pages.
+    ///
+    /// # Panics
+    ///
+    /// Panics if a memory range is not valid for [`MemoryRangeTableIterator::guest_memory`].
+    fn fill_zero_removed_data(&mut self) -> bool {
+        /// Checks whether a memory region completely equal to the provided `comparison_memory`.
+        ///
+        /// # Panics:
+        ///
+        /// Panics if the `guest_memory_start` and the `comparison_memory.len()` are not valid for
+        /// `guest_memory`.
+        fn memory_is_equal<M>(
+            guest_memory_start: u64,
+            comparison_memory: &[u8],
+            guest_memory: &M,
+        ) -> bool
+        where
+            M: GuestAddressSpace,
+        {
+            let page_size = comparison_memory.len();
+            let mem = guest_memory.memory();
+            let volatile_slice = mem
+                .get_slice(GuestAddress::new(guest_memory_start), page_size)
+                .unwrap();
+            let slice_ptr = volatile_slice.ptr_guard();
+            // Shadow `slice_ptr` so the guard cannot be dropped until the end of the scope.
+            let slice_ptr = slice_ptr.as_ptr().cast();
+            let zero_page_ptr = comparison_memory.as_ptr().cast();
+
+            // Potential data races between the guest writing to memory and the check whether
+            // a page is all zero are handled by the page dirty logging.
+            // SAFETY: Both pointers point to valid memory of length `PAGE_SIZE` and
+            // neither are modified by `memcmp`.
+            // See: https://man7.org/linux/man-pages/man3/memcmp.3.html
+            let page_is_zero = unsafe { libc::memcmp(slice_ptr, zero_page_ptr, page_size) };
+            page_is_zero == 0
+        }
+
+        if !self.skip_zero_pages {
+            return false;
+        }
+
+        if let Some(memory_range) = self.unprocessed_data.pop() {
+            let page_size = self.zero_page.len();
+            // Avoids a bunch of `as u64` in the code.
+            let page_size_u64 = page_size as u64;
+
+            // As far as I can tell, `MemoryRange` should always start and end on page boundaries,
+            // but there are not type-level guarantees, so we handle page boundaries and overshoot
+            // to be safe.
+
+            // Amount of bytes by which the gpa undershoots the page boundary.
+            let gpa_page_undershoot = {
+                // Amount of bytes by which the gpa overshoots the page boundary.
+                let offset = memory_range.gpa % page_size_u64;
+                if offset > 0 {
+                    page_size_u64 - offset
+                } else {
+                    0
+                }
+            };
+
+            // Amount of bytes by which the length overshoots the page boundary.
+            let length_page_overshoot = (memory_range.length - gpa_page_undershoot) % page_size_u64;
+
+            let first_page_boundary = memory_range.gpa + gpa_page_undershoot;
+            let last_page_boundary = memory_range.gpa + memory_range.length - length_page_overshoot;
+            let page_amount = (last_page_boundary - first_page_boundary) / page_size_u64;
+
+            // The gpa of the memory range currently being built.
+            let mut current_gpa = memory_range.gpa;
+            // The length of memory range currently being built.
+            // Initially set to the gpa page overshoot, which will be combined with the first
+            // page if it is non-zero or added to `zero_removed_data` if the next page is zero.
+            let mut current_length = 0;
+
+            if gpa_page_undershoot != 0
+                && !memory_is_equal(
+                    current_gpa,
+                    &self.zero_page[..gpa_page_undershoot as usize],
+                    self.guest_memory,
+                )
+            {
+                current_length += gpa_page_undershoot;
+            }
+
+            for page_start in
+                (0..page_amount).map(|page_index| page_index * page_size_u64 + first_page_boundary)
+            {
+                // If the current page is zero, we push all previous non-zero pages to
+                // `zero_removed_data` and set `current_gpa` to the end of the zero page while
+                // resetting the length.
+                if memory_is_equal(page_start, self.zero_page.as_slice(), self.guest_memory) {
+                    if current_length != 0 {
+                        self.processed_data.push(MemoryRange {
+                            gpa: current_gpa,
+                            length: current_length,
+                        });
+                    }
+                    current_gpa += current_length + page_size_u64;
+                    current_length = 0;
+                } else {
+                    current_length += page_size_u64;
+                }
+            }
+
+            if length_page_overshoot != 0
+                && !memory_is_equal(
+                    current_gpa,
+                    &self.zero_page[..length_page_overshoot as usize],
+                    self.guest_memory,
+                )
+            {
+                current_length += length_page_overshoot;
+            }
+
+            // If the current length is zero, the last page was a zero page.
+            if current_length != 0 {
+                self.processed_data.push(MemoryRange {
+                    gpa: current_gpa,
+                    length: current_length,
+                });
+            }
+
+            true
+        } else {
+            false
         }
     }
 }
 
-impl Iterator for MemoryRangeTableIterator {
+impl<'a, M> Iterator for MemoryRangeTableIterator<'a, M>
+where
+    M: GuestAddressSpace,
+{
     type Item = MemoryRangeTable;
 
-    /// Return the next memory range in the table, making sure that
-    /// the returned range is not larger than `chunk_size`.
-    ///
-    /// **Note**: Do not rely on the order of the ranges returned by this
-    /// iterator. This allows for a more efficient implementation.
     fn next(&mut self) -> Option<Self::Item> {
         let mut ranges: Vec<MemoryRange> = vec![];
         let mut ranges_size: u64 = 0;
@@ -312,11 +501,15 @@ impl Iterator for MemoryRangeTableIterator {
         loop {
             assert!(ranges_size <= self.chunk_size);
 
-            if ranges_size == self.chunk_size || self.data.is_empty() {
+            if self.processed_data.is_empty() && !self.fill_zero_removed_data() {
                 break;
             }
 
-            if let Some(range) = self.data.pop() {
+            if ranges_size == self.chunk_size {
+                break;
+            }
+
+            if let Some(range) = self.processed_data.pop() {
                 let next_range: MemoryRange = if ranges_size + range.length > self.chunk_size {
                     // How many bytes we need to put back into the table.
                     let leftover_bytes = ranges_size + range.length - self.chunk_size;
@@ -325,7 +518,7 @@ impl Iterator for MemoryRangeTableIterator {
                     assert!(returned_bytes <= range.length);
                     assert_eq!(leftover_bytes + returned_bytes, range.length);
 
-                    self.data.push(MemoryRange {
+                    self.processed_data.push(MemoryRange {
                         gpa: range.gpa + returned_bytes,
                         length: leftover_bytes,
                     });
@@ -356,8 +549,17 @@ impl MemoryRangeTable {
     }
 
     /// Partitions the table into chunks of at most `chunk_size` bytes.
-    pub fn partition(&self, chunk_size: u64) -> impl Iterator<Item = MemoryRangeTable> {
-        MemoryRangeTableIterator::new(self, chunk_size)
+    pub fn partition<M>(
+        &self,
+        chunk_size: u64,
+        page_size: u64,
+        skip_zero_pages: bool,
+        guest_memory: &M,
+    ) -> impl Iterator<Item = MemoryRangeTable>
+    where
+        M: GuestAddressSpace,
+    {
+        MemoryRangeTableIterator::new(self, chunk_size, page_size, skip_zero_pages, guest_memory)
     }
 
     /// Converts an iterator over a dirty bitmap into an iterator of dirty
@@ -462,6 +664,9 @@ impl MemoryRangeTable {
 
 #[cfg(test)]
 mod unit_tests {
+    use vm_memory::bitmap::AtomicBitmap;
+    use vm_memory::{Address, GuestAddress, GuestMemoryAtomic, GuestMemoryMmap};
+
     use crate::protocol::{MemoryRange, MemoryRangeTable};
 
     #[test]
@@ -521,11 +726,18 @@ mod unit_tests {
         ];
         assert_eq!(table.regions(), &expected_regions);
 
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress::new(range.gpa), range.length as usize));
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
         // In the first test, we expect to see the exact same result as above, as we use the length
         // of every region (which is fixed!).
         {
             let chunks = table
-                .partition(page_size * 2)
+                .partition(page_size * 2, page_size, false, &atomic_guest_memory_map)
                 .map(|table| table.data)
                 .collect::<Vec<_>>();
 
@@ -548,10 +760,18 @@ mod unit_tests {
             );
         }
 
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize));
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
         // Next, we have a more sophisticated test with a chunk size of 5 pages.
         {
             let chunks = table
-                .partition(page_size * 5)
+                .partition(page_size * 5, page_size, false, &atomic_guest_memory_map)
                 .map(|table| table.data)
                 .collect::<Vec<_>>();
 

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -310,6 +310,8 @@ pub struct VmSendMigrationData {
     pub tls_dir: Option<PathBuf>,
     /// Keep the VMM alive.
     pub keep_alive: bool,
+    /// Skip zero-filled pages when sending VM memory to the receiver.
+    pub skip_zero_pages: bool,
 }
 
 // Default value for downtime the same as qemu.

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -1332,6 +1332,8 @@ components:
           format: int64
           description: Total timeout for migration in milliseconds (0 = no limit)
           default: 0
+        skip-zero-pages:
+          type: boolean
 
     VmAddUserDevice:
       required:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2471,6 +2471,7 @@ impl Vmm {
         migrate_downtime_limit: Duration,
         postponed_lifecycle_event: &Mutex<Option<PostMigrationLifecycleEvent>>,
         return_if_cancelled_cb: &impl Fn(&mut SocketStream) -> result::Result<(), MigratableError>,
+        skip_zero_pages: bool,
     ) -> result::Result<MemoryRangeTable, MigratableError> {
         let mut iteration_table;
         let total_memory_size_bytes = vm
@@ -2607,7 +2608,7 @@ impl Vmm {
             // Only skip zero pages on first iteration.
             // If we skip dirty logged zero pages, we don't send newly zeroed pages to the
             // destination.
-            let skip_zero_pages = s.iteration == 0;
+            let skip_zero_pages = s.iteration == 0 && skip_zero_pages;
             mem_send.send_memory(
                 &iteration_table,
                 skip_zero_pages,
@@ -2689,6 +2690,7 @@ impl Vmm {
             migrate_downtime_limit,
             postponed_lifecycle_event,
             return_if_cancelled_cb,
+            send_data_migration.skip_zero_pages,
         )?;
 
         info!("Entering downtime phase");

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1648,6 +1648,7 @@ impl SendAdditionalConnections {
     fn send_memory(
         &self,
         table: &MemoryRangeTable,
+        skip_zero_pages: bool,
         socket: &mut SocketStream,
         return_if_cancelled_cb: &impl Fn(&mut SocketStream) -> result::Result<(), MigratableError>,
     ) -> std::result::Result<(), MigratableError> {
@@ -1658,7 +1659,12 @@ impl SendAdditionalConnections {
         // because we wait for a response after each chunk instead of sending
         // everything in one go.
         if thread_len == 0 {
-            for chunk in table.partition(Self::CHUNK_SIZE) {
+            for chunk in table.partition(
+                Self::CHUNK_SIZE,
+                PAGE_SIZE as u64,
+                skip_zero_pages,
+                &self.guest_memory,
+            ) {
                 return_if_cancelled_cb(socket)
                     .inspect_err(|_| info!("cancelling migration during memory iteration"))?;
                 vm_send_memory(&self.guest_memory, socket, &chunk)?;
@@ -1668,7 +1674,12 @@ impl SendAdditionalConnections {
 
         // The chunk size is chosen to be big enough so that even very fast
         // links need some milliseconds to send it.
-        'next_chunk: for chunk in table.partition(Self::CHUNK_SIZE) {
+        'next_chunk: for chunk in table.partition(
+            Self::CHUNK_SIZE,
+            PAGE_SIZE as u64,
+            skip_zero_pages,
+            &self.guest_memory,
+        ) {
             let mut chunk = SendMemoryThreadMessage::Memory(chunk);
             // The channel we put work into has a limited size. Thus it may happen that we have to
             // retry putting this chunk into it.
@@ -2593,7 +2604,16 @@ impl Vmm {
 
             // Send the current dirty pages
             s.transmit_start_time = Instant::now();
-            mem_send.send_memory(&iteration_table, socket, return_if_cancelled_cb)?;
+            // Only skip zero pages on first iteration.
+            // If we skip dirty logged zero pages, we don't send newly zeroed pages to the
+            // destination.
+            let skip_zero_pages = s.iteration == 0;
+            mem_send.send_memory(
+                &iteration_table,
+                skip_zero_pages,
+                socket,
+                return_if_cancelled_cb,
+            )?;
             s.transmit_duration = s.transmit_start_time.elapsed();
 
             s.total_transferred_bytes += s.bytes_to_transmit;
@@ -2684,7 +2704,7 @@ impl Vmm {
         // Send last batch of dirty pages
         let mut final_table = vm.dirty_log()?;
         final_table.extend(iteration_table.clone());
-        mem_send.send_memory(&final_table, socket, return_if_cancelled_cb)?;
+        mem_send.send_memory(&final_table, false, socket, return_if_cancelled_cb)?;
 
         // Update statistics
         s.bytes_to_transmit = final_table.regions().iter().map(|range| range.length).sum();

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2712,8 +2712,10 @@ impl Vmm {
         s.total_transferred_bytes += s.bytes_to_transmit;
         s.total_transferred_pages += s.pages_to_transmit;
 
+        let migration_duration = s.migration_start_time.elapsed();
         info!(
-            "Memory Migration finished: iter={},throttle={}%,size={}MiB,dirtyrate={}pps,bandwidth={:.2}MiBs,downtime(expected)={}ms",
+            "Memory Migration finished: took={}ms,iter={},throttle={}%,size={}MiB,dirtyrate={}pps,bandwidth={:.2}MiBs,downtime(expected)={}ms",
+            migration_duration.as_millis(),
             (s.iteration_duration - s.transmit_duration).as_millis(),
             vm.throttle_percent(),
             s.bytes_to_transmit.div_ceil(1024).div_ceil(1024),


### PR DESCRIPTION
A VM may have previously unused memory that is still zeroed (or memory zeroed by the guest, but that's more unlikely). This memory doesn't need to be transferred during a migration as the migration destination provides zeroed memory to the VM anyway. This PR adds the option to skip zero pages during migration.

~~I'll leave this PR as draft until benchmarking was done. Benchmarking is currently blocked on a bug in the timeout logic and will be added as soon as possible. Comments are already welcome.~~

Benchmarking was done with [this branch](https://github.com/arctic-alpaca/cloud-hypervisor/tree/omit-zero-pages-bench), which is based on https://github.com/cyberus-technology/cloud-hypervisor/pull/111.

All benchmarks were done between `livemig-dellemc-2tb-1` and `livemig-dellemc-2tb-2
` and run only once per setup.

| Setup | Migration time | % of no skip |
|--------|--------|--------|
| 32GiB, 4 vCPU, no memtouch, no skip, 1 connection | 47083ms | 100% |
| 32GiB, 4vCPU, no memtouch, with skip, 1 connection | 2245ms | 5% |
| 1TiB, 32vCPU, no memtouch, no skip, 8 connections | 90250ms | 100% |
| 1TiB, 32vCPU, no memtouch, with skip, 8 connections | 44176ms | 49% |
| 32GiB, 4 vCPU, with memtouch, no skip, 1 connection | 47634ms | 100%
| 32GiB, 4 vCPU, with memtouch, with skip, 1 connection | 50437ms | 106% |
| 1TiB, 32vCPU, with memtouch, no skip, 8 connections | 101556ms | 100% |
| 1TiB, 32vCPU, with memtouch, with skip, 8 connections | 179236ms | 176% |

In the `32GiB, 4 vCPU, with memtouch, with skip, 1 connection` and `1TiB, 32vCPU, with memtouch, with skip, 8 connections` cases, `memtouch` got OOM killed.

<details>
  <summary>Benchmark commands</summary>

- 32GiB, 4 vCPU, no memtouch, no skip, 1 connection

    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000
    ```
- 32GiB, 4vCPU, no memtouch, with skip, 1 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --skip-zero-pages
    ```
- 1TiB, 32vCPU, no memtouch, no skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8
    ```
- 1TiB, 32vCPU, no memtouch, with skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8 --skip-zero-pages
    ```
- 32GiB, 4 vCPU, with memtouch, no skip, 1 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000
    > memtouch --rw_ratio 100 --thread_mem 8128 --num_threads 4 --once
    ```
- 32GiB, 4 vCPU, with memtouch, with skip, 1 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --skip-zero-pages
    > memtouch --rw_ratio 100 --thread_mem 8128 --num_threads 4 --once
    ```
- 1TiB, 32vCPU, with memtouch, no skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8
    > memtouch --rw_ratio 100 --thread_mem 32512 --num_threads 32 --once
    ```
- 1TiB, 32vCPU, with memtouch, with skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8 --skip-zero-pages
    > memtouch --rw_ratio 100 --thread_mem 32512 --num_threads 32 --once
    ```

</details>

They numbers are good for unused machines, but don't look great for machines with full memory utilization. The obvious optimization would to split the zero page checking between multiple threads, but I don't want to make this PR more complex. Since the zero page skipping can be toggled, the optimization should only be applied for newly created or not heavily used VMs. Open to suggestions and opinions though.