### PR TITLE
Add version negotiation for migration protocol

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -886,6 +886,11 @@ fn main() {
 
     if cmd_arguments.get_flag("version") {
         println!("{} {}", env!("CARGO_BIN_NAME"), env!("BUILD_VERSION"));
+        println!(
+            "vm-migration protocol versions v{} and v{}",
+            vm_migration::protocol::PRIOR_PROTOCOL_VERSION,
+            vm_migration::protocol::CURRENT_PROTOCOL_VERSION
+        );
 
         if cmd_arguments.get_count("v") != 0 {
             println!("Enabled features: {:?}", vmm::feature_list());

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -73,6 +73,18 @@
 //!    Source->>Destination: Complete
 //!    Destination-->>Source: OK
 //! ```
+//!
+//! ## Protocol Versioning
+//!
+//! `Start` carries the sender's migration protocol version.
+//! A zeroed version field is treated as legacy protocol `v0`.
+//!
+//! The destination validates that version and replies with a plain `OK` or
+//! `Error`.
+//!
+//! Only the current and immediately previous protocol versions are
+//! supported. Compatibility is one-way, from older protocol versions
+//! to newer ones.
 
 use std::io::{Read, Write};
 
@@ -124,15 +136,33 @@ pub enum Command {
     KeepAlive,
 }
 
+/// Migration protocol version used during the `Start` handshake.
+pub type MigrationProtocolVersion = u16;
+
+/// Newest migration protocol version sent by this implementation.
+pub const CURRENT_PROTOCOL_VERSION: MigrationProtocolVersion = 0;
+// TODO change to checked_sub once current version is > 0
+/// Oldest migration protocol version still accepted for backward compatibility.
+pub const PRIOR_PROTOCOL_VERSION: MigrationProtocolVersion =
+    CURRENT_PROTOCOL_VERSION.saturating_sub(1);
+
 #[repr(C)]
 #[derive(Default, Copy, Clone, Immutable, IntoBytes, KnownLayout, TryFromBytes)]
 pub struct Request {
     command: Command,
-    padding: [u8; 6],
+    command_headers: [u8; 6],
     length: u64, // Length of payload for command excluding the Request struct
 }
 
 impl Request {
+    /// Encodes a sender protocol version into the `command_headers` bytes of a
+    /// `Start` request.
+    fn encode_sender_version(version: MigrationProtocolVersion) -> [u8; 6] {
+        let mut command_headers = [0; 6];
+        command_headers[..2].copy_from_slice(&version.to_le_bytes());
+        command_headers
+    }
+
     pub fn new(command: Command, length: u64) -> Self {
         Self {
             command,
@@ -143,6 +173,14 @@ impl Request {
 
     pub fn start() -> Self {
         Self::new(Command::Start, 0)
+    }
+
+    pub fn start_with_version() -> Self {
+        Self {
+            command: Command::Start,
+            command_headers: Self::encode_sender_version(CURRENT_PROTOCOL_VERSION),
+            length: 0,
+        }
     }
 
     pub fn state(length: u64) -> Self {
@@ -179,6 +217,13 @@ impl Request {
 
     pub fn length(&self) -> u64 {
         self.length
+    }
+
+    /// Returns the raw 6-byte command-specific header field.
+    ///
+    /// For `Start`, the first two bytes encode the sender protocol version.
+    pub fn command_headers(&self) -> &[u8; 6] {
+        &self.command_headers
     }
 
     pub fn read_from(fd: &mut dyn Read) -> Result<Request, MigratableError> {
@@ -494,7 +539,21 @@ impl MemoryRangeTable {
 
 #[cfg(test)]
 mod unit_tests {
-    use crate::protocol::{MemoryRange, MemoryRangeTable};
+    use crate::protocol::{Command, MemoryRange, MemoryRangeTable, Request};
+
+    #[test]
+    fn test_start_request_ignores_residual_command_headers_bytes() {
+        let request = Request {
+            command: Command::Start,
+            command_headers: [1, 0, 0xaa, 0xbb, 0xcc, 0xdd],
+            length: 0,
+        };
+
+        assert_eq!(
+            u16::from_le_bytes([request.command_headers()[0], request.command_headers()[1]]),
+            1
+        );
+    }
 
     #[test]
     fn test_memory_range_table_from_dirty_ranges_iter() {

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -172,10 +172,6 @@ impl Request {
     }
 
     pub fn start() -> Self {
-        Self::new(Command::Start, 0)
-    }
-
-    pub fn start_with_version() -> Self {
         Self {
             command: Command::Start,
             command_headers: Self::encode_sender_version(CURRENT_PROTOCOL_VERSION),
@@ -224,6 +220,25 @@ impl Request {
     /// For `Start`, the first two bytes encode the sender protocol version.
     pub fn command_headers(&self) -> &[u8; 6] {
         &self.command_headers
+    }
+
+    /// Returns the sender protocol version from a `Start` request if it is supported.
+    pub fn sender_protocol_version(&self) -> Result<MigrationProtocolVersion, MigratableError> {
+        assert_eq!(
+            self.command(),
+            Command::Start,
+            "sender_protocol_version() must only be called for Start requests",
+        );
+
+        // The protocol version is stored in the first two header bytes, the remaining bytes are ignored.
+        let sender_version = u16::from_le_bytes([self.command_headers[0], self.command_headers[1]]);
+        if sender_version != PRIOR_PROTOCOL_VERSION && sender_version != CURRENT_PROTOCOL_VERSION {
+            return Err(MigratableError::MigrateReceive(anyhow!(
+                "Migration protocol version {sender_version} doesn't match supported versions: {PRIOR_PROTOCOL_VERSION}, {CURRENT_PROTOCOL_VERSION}"
+            )));
+        }
+
+        Ok(sender_version)
     }
 
     pub fn read_from(fd: &mut dyn Read) -> Result<Request, MigratableError> {
@@ -553,6 +568,16 @@ mod unit_tests {
             u16::from_le_bytes([request.command_headers()[0], request.command_headers()[1]]),
             1
         );
+    }
+    #[test]
+    fn test_sender_protocol_version_rejects_unsupported_version() {
+        let request = Request {
+            command: Command::Start,
+            command_headers: [2, 0, 0, 0, 0, 0],
+            length: 0,
+        };
+
+        request.sender_protocol_version().unwrap_err();
     }
 
     #[test]

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2233,7 +2233,11 @@ impl Vmm {
 
         match state {
             Established => match req.command() {
-                Command::Start => Ok(Started),
+                Command::Start => {
+                    let migration_protocol_version = req.sender_protocol_version()?;
+                    info!("Using migration protocol v{migration_protocol_version}");
+                    Ok(Started)
+                }
                 _ => invalid_command(),
             },
             Started => match req.command() {
@@ -2832,6 +2836,7 @@ impl Vmm {
         Response::read_from(&mut socket)?.ok_or_error(MigratableError::MigrateSend(anyhow!(
             "Error starting migration (got bad response)"
         )))?;
+        info!("Using migration protocol v{CURRENT_PROTOCOL_VERSION}");
 
         return_if_cancelled_cb(&mut socket)?;
 


### PR DESCRIPTION
This PR implements https://github.com/cobaltcore-dev/cobaltcore/issues/464 and introduces version negotiation for the migration protocol.

### Steps before Merging

- [ ] Add testing: migration between two CHV versions (one with version negotiation and one without)