### PR TITLE
Add option to skip zero pages during VM migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2805,7 +2805,9 @@ name = "vm-migration"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "arch",
  "itertools 0.14.0",
+ "libc",
  "rustls",
  "serde",
  "serde_json",

--- a/cloud-hypervisor/src/bin/ch-remote.rs
+++ b/cloud-hypervisor/src/bin/ch-remote.rs
@@ -536,6 +536,11 @@ fn rest_api_do_command(matches: &ArgMatches, socket: &mut UnixStream) -> ApiResu
                     .get_one::<PathBuf>("tls-dir")
                     .cloned(),
                 wait_for_migration,
+                *matches
+                    .subcommand_matches("send-migration")
+                    .unwrap()
+                    .get_one::<bool>("skip-zero-pages")
+                    .unwrap(),
             );
 
             simple_api_command(socket, "PUT", "send-migration", Some(&send_migration_data))
@@ -1032,6 +1037,7 @@ fn receive_migration_data(url: String, tls_dir: Option<PathBuf>) -> String {
     serde_json::to_string(&receive_migration_data).unwrap()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn send_migration_data(
     url: String,
     local: bool,
@@ -1040,6 +1046,7 @@ fn send_migration_data(
     connections: NonZeroU32,
     tls_dir: Option<PathBuf>,
     keep_alive: bool,
+    skip_zero_pages: bool,
 ) -> String {
     let send_migration_data = vmm::api::VmSendMigrationData {
         destination_url: url,
@@ -1049,6 +1056,7 @@ fn send_migration_data(
         connections,
         tls_dir,
         keep_alive,
+        skip_zero_pages,
     };
 
     serde_json::to_string(&send_migration_data).unwrap()
@@ -1274,6 +1282,12 @@ fn get_cli_commands_sorted() -> Box<[Command]> {
                     .long("local")
                     .num_args(0)
                     .action(ArgAction::SetTrue),
+            )
+            .arg(
+                Arg::new("skip-zero-pages")
+                    .long("skip-zero-pages")
+                    .help("skip zero-filled pages when sending VM memory to the receiver")
+                    .num_args(0),
             )
             .arg(
                 Arg::new("tls-dir")

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -6,13 +6,18 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = { workspace = true }
+arch = { path = "../arch" }
 itertools = { workspace = true }
+libc = { workspace = true }
 rustls = { workspace = true }
 serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 vm-memory = { workspace = true, features = ["backend-atomic", "backend-mmap"] }
 zerocopy = { workspace = true, features = ["derive", "std"] }
+
+[dev-dependencies]
+vm-memory = { workspace = true, features = ["backend-bitmap"] }
 
 [lints]
 workspace = true

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -77,8 +77,10 @@
 use std::io::{Read, Write};
 
 use anyhow::anyhow;
+use arch::PAGE_SIZE;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
+use vm_memory::{Address, GuestAddress, GuestAddressSpace, GuestMemory};
 use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
 
 use crate::MigratableError;
@@ -309,6 +311,33 @@ pub struct MemoryRange {
     pub length: u64,
 }
 
+/// Checks whether a guest memory region is equal to the provided `comparison_memory`.
+fn guest_memory_is_equal<M>(
+    guest_memory_start: u64,
+    comparison_memory: &[u8],
+    guest_memory: &M,
+) -> Result<bool, vm_memory::guest_memory::Error>
+where
+    M: GuestAddressSpace,
+{
+    let cmp_mem_length = comparison_memory.len();
+    let guest_memory = guest_memory.memory();
+    let volatile_slice =
+        guest_memory.get_slice(GuestAddress::new(guest_memory_start), cmp_mem_length)?;
+    let slice_ptr = volatile_slice.ptr_guard();
+    // Shadow `slice_ptr` so the guard cannot be dropped until the end of the scope.
+    let slice_ptr = slice_ptr.as_ptr().cast();
+    let comparison_memory_ptr = comparison_memory.as_ptr().cast();
+
+    // Potential data races between the guest writing to memory and the check whether
+    // a page is all zero are handled by the page dirty logging.
+    // SAFETY: Both pointers point to valid memory of length `cmp_mem_length` and
+    // neither are modified by `memcmp`.
+    // See: https://man7.org/linux/man-pages/man3/memcmp.3.html
+    let memory_is_equal = unsafe { libc::memcmp(slice_ptr, comparison_memory_ptr, cmp_mem_length) };
+    Ok(memory_is_equal == 0)
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct MemoryRangeTable {
     data: Vec<MemoryRange>,
@@ -490,11 +519,123 @@ impl MemoryRangeTable {
         }
         Self { data }
     }
+
+    /// Creates a new `MemoryRangeTable` from `Self` with all zero-pages removed.
+    ///
+    /// Also removes non-page aligned parts of any `MemoryRange` that is zero-filled in the
+    /// `guest_memory`.
+    pub fn remove_zero_pages<M>(
+        &self,
+        guest_memory: &M,
+    ) -> Result<Self, vm_memory::guest_memory::Error>
+    where
+        M: GuestAddressSpace,
+    {
+        let mut processed_data = Vec::new();
+        const ZERO_PAGE: [u8; PAGE_SIZE] = [0_u8; PAGE_SIZE];
+
+        self.data
+            .iter()
+            .try_for_each::<_, Result<(), vm_memory::guest_memory::Error>>(|memory_range| {
+                // Avoids a bunch of `as u64` in the code.
+                let page_size_u64 = PAGE_SIZE as u64;
+
+                // As far as I can tell, `MemoryRange` should always start and end on page boundaries,
+                // but there are no type-level guarantees, so we handle page boundaries and overshoot
+                // to be safe.
+
+                // Amount of bytes by which the gpa undershoots the page boundary.
+                let gpa_page_undershoot = {
+                    // Amount of bytes by which the gpa overshoots the page boundary.
+                    let offset = memory_range.gpa % page_size_u64;
+                    if offset > 0 {
+                        page_size_u64 - offset
+                    } else {
+                        0
+                    }
+                };
+
+                // Amount of bytes by which the length overshoots the page boundary.
+                let length_page_overshoot =
+                    (memory_range.length - gpa_page_undershoot) % page_size_u64;
+
+                let first_page_boundary = memory_range.gpa + gpa_page_undershoot;
+                let last_page_boundary =
+                    memory_range.gpa + memory_range.length - length_page_overshoot;
+                let page_amount = (last_page_boundary - first_page_boundary) / page_size_u64;
+
+                // The gpa of the memory range currently being built.
+                let mut current_gpa = memory_range.gpa;
+                // The length of memory range currently being built.
+                // Initially set to the gpa page overshoot, which will be combined with the first
+                // page if it is non-zero or added to `processed_data` if the next page is zero.
+                let mut current_length = 0;
+
+                if gpa_page_undershoot != 0 {
+                    if guest_memory_is_equal(
+                        current_gpa,
+                        &ZERO_PAGE[..gpa_page_undershoot as usize],
+                        guest_memory,
+                    )? {
+                        current_gpa += gpa_page_undershoot;
+                    } else {
+                        current_length += gpa_page_undershoot;
+                    }
+                }
+
+                for page_start in (0..page_amount)
+                    .map(|page_index| page_index * page_size_u64 + first_page_boundary)
+                {
+                    // If the current page is zero, we push all previous non-zero pages to
+                    // `processed_data` and set `current_gpa` to the end of the zero page while
+                    // resetting the length.
+                    if guest_memory_is_equal(page_start, &ZERO_PAGE, guest_memory)? {
+                        if current_length != 0 {
+                            processed_data.push(MemoryRange {
+                                gpa: current_gpa,
+                                length: current_length,
+                            });
+                        }
+                        current_gpa += current_length + page_size_u64;
+                        current_length = 0;
+                    } else {
+                        current_length += page_size_u64;
+                    }
+                }
+
+                if length_page_overshoot != 0
+                    && !guest_memory_is_equal(
+                        current_gpa,
+                        &ZERO_PAGE[..length_page_overshoot as usize],
+                        guest_memory,
+                    )?
+                {
+                    current_length += length_page_overshoot;
+                }
+
+                // If the current length is zero, the last page was a zero page.
+                if current_length != 0 {
+                    processed_data.push(MemoryRange {
+                        gpa: current_gpa,
+                        length: current_length,
+                    });
+                }
+                Ok(())
+            })?;
+
+        Ok(Self {
+            data: processed_data,
+        })
+    }
 }
 
 #[cfg(test)]
 mod unit_tests {
-    use crate::protocol::{MemoryRange, MemoryRangeTable};
+    use arch::PAGE_SIZE;
+    use vm_memory::bitmap::AtomicBitmap;
+    use vm_memory::{Address, GuestAddress, GuestMemory, GuestMemoryAtomic, GuestMemoryMmap};
+
+    use crate::protocol::{MemoryRange, MemoryRangeTable, guest_memory_is_equal};
 
     #[test]
     fn test_memory_range_table_from_dirty_ranges_iter() {
@@ -624,5 +765,423 @@ mod unit_tests {
                 ]
             );
         }
+    }
+
+    #[test]
+    fn test_guest_memory_is_equal_success() {
+        let start_gpa = 0x1000;
+        let page_size = PAGE_SIZE as u64;
+
+        let expected_regions = vec![MemoryRange {
+            gpa: start_gpa,
+            length: page_size * 2,
+        }];
+
+        let memory_range_table = MemoryRangeTable {
+            data: expected_regions,
+        };
+
+        let ranges: Vec<_> = memory_range_table
+            .ranges()
+            .iter()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize))
+            .collect();
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        let result = guest_memory_is_equal(
+            start_gpa,
+            &vec![0; page_size as usize],
+            &atomic_guest_memory_map,
+        )
+        .unwrap();
+
+        assert!(result);
+    }
+
+    #[test]
+    fn test_guest_memory_is_equal_invalid_memory_range() {
+        let start_gpa = 0x1000;
+        let page_size = PAGE_SIZE as u64;
+
+        let memory_ranges = vec![MemoryRange {
+            gpa: start_gpa,
+            length: page_size * 2,
+        }];
+
+        let memory_range_table = MemoryRangeTable {
+            data: memory_ranges,
+        };
+
+        let ranges: Vec<_> = memory_range_table
+            .ranges()
+            .iter()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize))
+            .collect();
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        let result = guest_memory_is_equal(
+            start_gpa - 10,
+            &vec![0; page_size as usize],
+            &atomic_guest_memory_map,
+        )
+        .unwrap_err();
+
+        if let vm_memory::guest_memory::Error::InvalidGuestAddress(GuestAddress(guest_address)) =
+            result
+        {
+            assert_eq!(guest_address, 4086);
+        } else {
+            panic!("`guest_memory_is_equal` returned wrong error")
+        }
+    }
+
+    #[test]
+    fn test_memory_range_table_remove_zero_pages() {
+        let start_gpa = 0x1000;
+        let page_size = PAGE_SIZE as u64;
+
+        let expected_regions = vec![MemoryRange {
+            gpa: start_gpa,
+            length: page_size * 2,
+        }];
+
+        let memory_range_table = MemoryRangeTable {
+            data: expected_regions,
+        };
+
+        let ranges: Vec<_> = memory_range_table
+            .ranges()
+            .iter()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize))
+            .collect();
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        let result = memory_range_table.remove_zero_pages(&atomic_guest_memory_map);
+
+        assert!(result.unwrap().ranges().is_empty());
+    }
+
+    #[test]
+    fn test_memory_range_table_remove_zero_pages_all() {
+        let input = [0b11_0011_0011_0011];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        let expected_regions = [
+            MemoryRange {
+                gpa: start_gpa,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 4 * page_size,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 8 * page_size,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 12 * page_size,
+                length: page_size * 2,
+            },
+        ];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress::new(range.gpa), range.length as usize));
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        assert!(
+            table
+                .remove_zero_pages(&atomic_guest_memory_map)
+                .unwrap()
+                .is_empty()
+        );
+    }
+    #[test]
+    fn test_memory_range_table_remove_zero_pages_some() {
+        let input = [0b11_0011_0011_0011];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        let expected_regions = [
+            MemoryRange {
+                gpa: start_gpa,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 4 * page_size,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 8 * page_size,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 12 * page_size,
+                length: page_size * 2,
+            },
+        ];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize));
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+
+        expected_regions.iter().step_by(2).for_each(|memory_range| {
+            let buffer = vec![1_u8; memory_range.length as usize];
+            guest_memory_map
+                .read_volatile_from(
+                    GuestAddress::new(memory_range.gpa),
+                    &mut buffer.as_slice(),
+                    memory_range.length as usize,
+                )
+                .unwrap();
+        });
+
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        assert_eq!(
+            table
+                .remove_zero_pages(&atomic_guest_memory_map)
+                .unwrap()
+                .ranges(),
+            &[
+                MemoryRange {
+                    gpa: start_gpa,
+                    length: page_size * 2,
+                },
+                MemoryRange {
+                    gpa: start_gpa + 8 * page_size,
+                    length: page_size * 2,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_memory_range_table_remove_zero_pages_within_range_table() {
+        let input = [0b0111];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        let expected_regions = [MemoryRange {
+            gpa: start_gpa,
+            length: page_size * 3,
+        }];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize));
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+
+        let buffer = vec![1_u8; page_size as usize];
+
+        guest_memory_map
+            .read_volatile_from(
+                GuestAddress::new(expected_regions[0].gpa),
+                &mut buffer.as_slice(),
+                page_size as usize,
+            )
+            .unwrap();
+
+        guest_memory_map
+            .read_volatile_from(
+                GuestAddress::new(expected_regions[0].gpa + 2 * page_size),
+                &mut buffer.as_slice(),
+                page_size as usize,
+            )
+            .unwrap();
+
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        assert_eq!(
+            table
+                .remove_zero_pages(&atomic_guest_memory_map)
+                .unwrap()
+                .ranges(),
+            &[
+                MemoryRange {
+                    gpa: start_gpa,
+                    length: page_size
+                },
+                MemoryRange {
+                    gpa: start_gpa + 2 * page_size,
+                    length: page_size
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn test_memory_range_table_remove_zero_pages_non_page_boundaries_all_zero() {
+        let input = [0b11_0011_0000_1111];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let mut table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        table.data.iter_mut().for_each(|entry| {
+            entry.gpa += 10;
+        });
+        let expected_regions = [
+            MemoryRange {
+                gpa: start_gpa + 10,
+                length: page_size * 4,
+            },
+            MemoryRange {
+                gpa: start_gpa + 8 * page_size + 10,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 12 * page_size + 10,
+                length: page_size * 2,
+            },
+        ];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize));
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        assert!(
+            table
+                .remove_zero_pages(&atomic_guest_memory_map)
+                .unwrap()
+                .ranges()
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn test_memory_range_table_remove_zero_pages_non_page_boundaries_all_non_zero() {
+        let input = [0b11_0011_0000_1111];
+
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let mut table = MemoryRangeTable::from_dirty_bitmap(input, start_gpa, page_size);
+        table.data.iter_mut().for_each(|entry| {
+            entry.gpa += 10;
+        });
+        let expected_regions = [
+            MemoryRange {
+                gpa: start_gpa + 10,
+                length: page_size * 4,
+            },
+            MemoryRange {
+                gpa: start_gpa + 8 * page_size + 10,
+                length: page_size * 2,
+            },
+            MemoryRange {
+                gpa: start_gpa + 12 * page_size + 10,
+                length: page_size * 2,
+            },
+        ];
+        assert_eq!(table.regions(), &expected_regions);
+
+        let ranges = expected_regions
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize));
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+
+        expected_regions.iter().for_each(|memory_range| {
+            let buffer = vec![1_u8; memory_range.length as usize];
+
+            guest_memory_map
+                .read_volatile_from(
+                    GuestAddress::new(memory_range.gpa),
+                    &mut buffer.as_slice(),
+                    memory_range.length as usize,
+                )
+                .unwrap();
+        });
+
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        assert_eq!(
+            table
+                .remove_zero_pages(&atomic_guest_memory_map)
+                .unwrap()
+                .ranges(),
+            expected_regions
+        );
+    }
+
+    #[test]
+    fn test_memory_range_table_remove_zero_pages_within_memory_range() {
+        let start_gpa = 0x1000;
+        let page_size = 0x1000;
+
+        let table = MemoryRangeTable {
+            data: vec![MemoryRange {
+                gpa: start_gpa - 0x800,
+                length: 0x800 + 2 * page_size,
+            }],
+        };
+
+        let ranges: Vec<(GuestAddress, usize)> = table
+            .ranges()
+            .iter()
+            .clone()
+            .map(|range| (GuestAddress(range.gpa), range.length as usize))
+            .collect();
+
+        let guest_memory_map: GuestMemoryMmap<AtomicBitmap> =
+            GuestMemoryMmap::from_ranges(&ranges).unwrap();
+
+        let buffer = vec![1_u8; page_size as usize];
+
+        guest_memory_map
+            .read_volatile_from(
+                GuestAddress::new(start_gpa),
+                &mut buffer.as_slice(),
+                page_size as usize,
+            )
+            .unwrap();
+
+        let atomic_guest_memory_map = GuestMemoryAtomic::new(guest_memory_map);
+
+        assert_eq!(
+            table
+                .remove_zero_pages(&atomic_guest_memory_map)
+                .unwrap()
+                .ranges(),
+            [MemoryRange {
+                gpa: start_gpa,
+                length: page_size,
+            },]
+        );
     }
 }

--- a/vmm/src/api/mod.rs
+++ b/vmm/src/api/mod.rs
@@ -310,6 +310,9 @@ pub struct VmSendMigrationData {
     pub tls_dir: Option<PathBuf>,
     /// Keep the VMM alive.
     pub keep_alive: bool,
+    /// Skip zero-filled pages when sending VM memory to the receiver.
+    #[serde(default)]
+    pub skip_zero_pages: bool,
 }
 
 // Default value for downtime the same as qemu.

--- a/vmm/src/api/openapi/cloud-hypervisor.yaml
+++ b/vmm/src/api/openapi/cloud-hypervisor.yaml
@@ -508,7 +508,7 @@ components:
           $ref: "#/components/schemas/VmConfig"
         state:
           type: string
-          enum: [Created, Running, Shutdown, Paused]
+          enum: [ Created, Running, Shutdown, Paused ]
         memory_actual_size:
           type: integer
           format: int64
@@ -967,7 +967,7 @@ components:
           default: true
         image_type:
           type: string
-          enum: [FixedVhd, Qcow2, Raw, Vhdx, Unknown]
+          enum: [ FixedVhd, Qcow2, Raw, Vhdx, Unknown ]
 
 
     NetConfig:
@@ -1108,7 +1108,7 @@ components:
           type: string
         mode:
           type: string
-          enum: ["Off", "Pty", "Tty", "File", "Socket", "Null"]
+          enum: [ "Off", "Pty", "Tty", "File", "Socket", "Null" ]
         iommu:
           type: boolean
           default: false
@@ -1122,7 +1122,7 @@ components:
           type: string
         mode:
           type: string
-          enum: ["Off", "Pty", "Tty", "File", "Null"]
+          enum: [ "Off", "Pty", "Tty", "File", "Null" ]
         iobase:
           type: integer
 
@@ -1332,6 +1332,8 @@ components:
           format: int64
           description: Total timeout for migration in milliseconds (0 = no limit)
           default: 0
+        skip_zero_pages:
+          type: boolean
 
     VmAddUserDevice:
       required:

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2759,8 +2759,10 @@ impl Vmm {
         s.total_transferred_bytes += s.bytes_to_transmit;
         s.total_transferred_pages += s.pages_to_transmit;
 
+        let migration_duration = s.migration_start_time.elapsed();
         info!(
-            "Memory Migration finished: iter={},throttle={}%,size={}MiB,dirtyrate={}pps,bandwidth={:.2}MiBs,downtime(expected)={}ms",
+            "Memory Migration finished: took={}ms,iter={},throttle={}%,size={}MiB,dirtyrate={}pps,bandwidth={:.2}MiBs,downtime(expected)={}ms",
+            migration_duration.as_millis(),
             (s.iteration_duration - s.transmit_duration).as_millis(),
             vm.throttle_percent(),
             s.bytes_to_transmit.div_ceil(1024).div_ceil(1024),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2734,8 +2734,7 @@ impl Vmm {
             migrate_downtime_limit,
             postponed_lifecycle_event,
             return_if_cancelled_cb,
-            // Add to API in next commit, for now never skip zero pages.
-            false,
+            send_data_migration.skip_zero_pages,
         )?;
 
         info!("Entering downtime phase");

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1438,8 +1438,8 @@ impl ReceiveMigrationState {
 #[derive(Debug)]
 enum SendMemoryThreadMessage {
     /// A chunk of memory that the thread should send to the receiving side of the live
-    /// migration.
-    Memory(MemoryRangeTable),
+    /// migration. The boolean indicates whether zero pages should be skipped.
+    Memory(MemoryRangeTable, bool),
     /// A synchronization point after each iteration of sending memory. That way the main
     /// thread knows when all memory is sent and acknowledged.
     Gate(Arc<Gate>),
@@ -1479,9 +1479,21 @@ fn vm_send_memory(
     guest_memory: &GuestMemoryAtomic<GuestMemoryMmap>,
     socket: &mut SocketStream,
     table: &MemoryRangeTable,
+    skip_zero_pages: bool,
 ) -> result::Result<(), MigratableError> {
     if table.regions().is_empty() {
         return Ok(());
+    }
+
+    // Allows us to conditionally replace the table reference.
+    let mut table = table;
+
+    let zero_page_removed_table;
+    if skip_zero_pages {
+        zero_page_removed_table = table.remove_zero_pages(guest_memory).map_err(|error| {
+            MigratableError::MigrateSend(anyhow!("Error during zero page scanning: {error:?}"))
+        })?;
+        table = &zero_page_removed_table;
     }
 
     Request::memory(table.length()).write_to(socket)?;
@@ -1581,13 +1593,13 @@ impl SendAdditionalConnections {
                     // TODO: Verify whether lock contention is negligible compared to network time.
                     let msg = recv.lock().unwrap().recv().unwrap();
                     match msg {
-                        SendMemoryThreadMessage::Memory(table) => {
+                        SendMemoryThreadMessage::Memory(table, skip_zero_pages) => {
                             if external_cancel.load(Ordering::Acquire) {
                                 // We drain all Memory messages and then wait for the Disconnect
                                 continue;
                             }
 
-                            match vm_send_memory(&guest_mem, &mut socket, &table) {
+                            match vm_send_memory(&guest_mem, &mut socket, &table, skip_zero_pages) {
                                 Ok(()) => {
                                     total_sent += table
                                         .ranges()
@@ -1699,6 +1711,7 @@ impl SendAdditionalConnections {
     fn send_memory(
         &self,
         table: &MemoryRangeTable,
+        skip_zero_pages: bool,
         socket: &mut SocketStream,
         return_if_cancelled_cb: &impl Fn(&mut SocketStream) -> result::Result<(), MigratableError>,
     ) -> std::result::Result<(), MigratableError> {
@@ -1712,7 +1725,7 @@ impl SendAdditionalConnections {
             for chunk in table.partition(Self::CHUNK_SIZE) {
                 return_if_cancelled_cb(socket)
                     .inspect_err(|_| info!("cancelling migration during memory iteration"))?;
-                vm_send_memory(&self.guest_memory, socket, &chunk)?;
+                vm_send_memory(&self.guest_memory, socket, &chunk, skip_zero_pages)?;
             }
             return Ok(());
         }
@@ -1720,7 +1733,7 @@ impl SendAdditionalConnections {
         // The chunk size is chosen to be big enough so that even very fast
         // links need some milliseconds to send it.
         'next_chunk: for chunk in table.partition(Self::CHUNK_SIZE) {
-            let mut chunk = SendMemoryThreadMessage::Memory(chunk);
+            let mut chunk = SendMemoryThreadMessage::Memory(chunk, skip_zero_pages);
             // The channel we put work into has a limited size. Thus it may happen that we have to
             // retry putting this chunk into it.
             'retry_chunk: loop {
@@ -2504,6 +2517,7 @@ impl Vmm {
         migrate_downtime_limit: Duration,
         postponed_lifecycle_event: &Mutex<Option<PostMigrationLifecycleEvent>>,
         return_if_cancelled_cb: &impl Fn(&mut SocketStream) -> result::Result<(), MigratableError>,
+        skip_zero_pages: bool,
     ) -> result::Result<MemoryRangeTable, MigratableError> {
         let mut iteration_table;
         let total_memory_size_bytes = vm
@@ -2635,7 +2649,16 @@ impl Vmm {
 
             // Send the current dirty pages
             s.transmit_start_time = Instant::now();
-            mem_send.send_memory(&iteration_table, socket, return_if_cancelled_cb)?;
+            // Only skip zero pages on first iteration.
+            // If we skip dirty logged zero pages, we don't send newly zeroed pages to the
+            // destination.
+            let skip_zero_pages = s.iteration == 0 && skip_zero_pages;
+            mem_send.send_memory(
+                &iteration_table,
+                skip_zero_pages,
+                socket,
+                return_if_cancelled_cb,
+            )?;
             s.transmit_duration = s.transmit_start_time.elapsed();
 
             s.total_transferred_bytes += s.bytes_to_transmit;
@@ -2711,6 +2734,8 @@ impl Vmm {
             migrate_downtime_limit,
             postponed_lifecycle_event,
             return_if_cancelled_cb,
+            // Add to API in next commit, for now never skip zero pages.
+            false,
         )?;
 
         info!("Entering downtime phase");
@@ -2726,7 +2751,7 @@ impl Vmm {
         // Send last batch of dirty pages
         let mut final_table = vm.dirty_log()?;
         final_table.extend(iteration_table.clone());
-        mem_send.send_memory(&final_table, socket, return_if_cancelled_cb)?;
+        mem_send.send_memory(&final_table, false, socket, return_if_cancelled_cb)?;
 
         // Update statistics
         s.bytes_to_transmit = final_table.regions().iter().map(|range| range.length).sum();


### PR DESCRIPTION
> [!IMPORTANT]
> Drafted for now until we have a clearer picture how to incorporate this into the stats tracking.


Improvement of https://github.com/cyberus-technology/cloud-hypervisor/pull/112.

A VM may have previously unused memory that is still zeroed (or memory zeroed by the guest, but that's more unlikely). This memory doesn't need to be transferred during a migration as the migration destination provides zeroed memory to the VM anyway. This PR adds the option to skip zero pages during migration.

The zero page skipping now scales with the number of connections because it's done in the connection thread. I think that's an intuitive way to scale without adding an additional parameter to configure the amount of zero page skip threads.
By moving to the connection threads, we also don't require all memory to be scanned for zero pages before sending the first byte of memory to the destination. Memory is scanned in chunks as it's passed to the connection threads.

All benchmarks were done between `livemig-dellemc-2tb-1` and `livemig-dellemc-2tb-2
` and run only once per setup, so expect some variation between runs.

| Setup | Migration time | % of no skip |
|--------|--------|--------|
| 32GiB, 4 vCPU, no memtouch, no skip, 1 connection | 18666ms | 100% |
| 32GiB, 4vCPU, no memtouch, with skip, 1 connection | 2297ms | 12% |
| 1TiB, 32vCPU, no memtouch, no skip, 8 connections | 90462ms | 100% |
| 1TiB, 32vCPU, no memtouch, with skip, 8 connections | 7855ms | 9% |
| 32GiB, 4 vCPU, with 50% memtouch, no skip, 1 connection | 16700ms | 100%
| 32GiB, 4 vCPU, with 50% memtouch, with skip, 1 connection | 10991ms | 66% |
| 1TiB, 32vCPU, with 50% memtouch, no skip, 8 connections | 95710ms | 100% |
| 1TiB, 32vCPU, with 50% memtouch, with skip, 8 connections | 56691ms | 59% |
| 32GiB, 4 vCPU, with 100% memtouch, no skip, 1 connection | 18350ms | 100%
| 32GiB, 4 vCPU, with 100% memtouch, with skip, 1 connection | 19221ms | 105% |
| 1TiB, 32vCPU, with 100% memtouch, no skip, 8 connections | 114490ms | 100% |
| 1TiB, 32vCPU, with 100% memtouch, with skip, 8 connections | 108835ms | 95% |
| 32GiB, 4 vCPU, with 100% memtouch, no skip, 2 connection | 11604ms | 100% |
| 32GiB, 4 vCPU, with 100% memtouch, with skip, 2 connection | 9708ms | 84% |


<details>
  <summary>Benchmark commands</summary>

- 32GiB, 4 vCPU, no memtouch, no skip, 1 connection

    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000
    ```
- 32GiB, 4vCPU, no memtouch, with skip, 1 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --skip-zero-pages
    ```
- 1TiB, 32vCPU, no memtouch, no skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8
    ```
- 1TiB, 32vCPU, no memtouch, with skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8 --skip-zero-pages
    ```
- 32GiB, 4 vCPU, with 50% memtouch, no skip, 1 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000
    > memtouch --rw_ratio 100 --thread_mem 4096 --num_threads 4 --once
    ```
- 32GiB, 4 vCPU, with 50% memtouch, with skip, 1 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --skip-zero-pages
    > memtouch --rw_ratio 100 --thread_mem 4096 --num_threads 4 --once
    ```
- 1TiB, 32vCPU, with 50% memtouch, no skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8
    > memtouch --rw_ratio 100 --thread_mem 16192 --num_threads 32 --once
    ```
- 1TiB, 32vCPU, with 50% memtouch, with skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8 --skip-zero-pages
    > memtouch --rw_ratio 100 --thread_mem 16192 --num_threads 32 --once
    ```
- 32GiB, 4 vCPU, with 100% memtouch, no skip, 1 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000
    > memtouch --rw_ratio 100 --thread_mem 8128 --num_threads 4 --once
    ```
- 32GiB, 4 vCPU, with 100% memtouch, with skip, 1 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --skip-zero-pages
    > memtouch --rw_ratio 100 --thread_mem 8128 --num_threads 4 --once
    ```
- 1TiB, 32vCPU, with 100% memtouch, no skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8
    > memtouch --rw_ratio 100 --thread_mem 32512 --num_threads 32 --once
    ```
- 1TiB, 32vCPU, with 100% memtouch, with skip, 8 connections
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=1024G --cpus boot=32
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 8 --skip-zero-pages
    > memtouch --rw_ratio 100 --thread_mem 32512 --num_threads 32 --once
    ```
- 32GiB, 4 vCPU, 100% memtouch, no skip, 2 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 2
    > memtouch --rw_ratio 100 --thread_mem 8128 --num_threads 4 --once
    ```
- 32GiB, 4 vCPU, 100% memtouch, with skip, 2 connection
    ```command
    > cargo run --release --bin cloud-hypervisor -- --api-socket /tmp/jschindel_chv1.sock --kernel result/linux_6_19.bzImage --cmdline "console=ttyS0" --serial tty --console off --initramfs result/initrd_default --seccomp log -vv --memory size=32G --cpus boot=4
    > cargo run --release --bin ch-remote -- --api-socket /tmp/jschindel_chv1.sock send-migration tcp:192.168.123.2:7868 --downtime 200 --migration-timeout 12000 --connections 2 --skip-zero-pages
    > memtouch --rw_ratio 100 --thread_mem 8128 --num_threads 4 --once
    ```

</details>
