### PR TITLE
vm-migration: fix UB in network parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2811,6 +2811,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.18",
  "vm-memory",
+ "zerocopy",
 ]
 
 [[package]]

--- a/vm-migration/Cargo.toml
+++ b/vm-migration/Cargo.toml
@@ -12,6 +12,7 @@ serde = { workspace = true, features = ["derive", "rc"] }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 vm-memory = { workspace = true, features = ["backend-atomic", "backend-mmap"] }
+zerocopy = { workspace = true, features = ["derive", "std"] }
 
 [lints]
 workspace = true

--- a/vm-migration/src/lib.rs
+++ b/vm-migration/src/lib.rs
@@ -62,6 +62,9 @@ pub enum MigratableError {
     #[error("Failed to release a disk lock")]
     UnlockError(#[source] anyhow::Error),
 
+    #[error("Failed to deserialize network data")]
+    DeserializeError(#[source] anyhow::Error),
+
     #[error("TLS error")]
     Tls(#[from] tls::TlsError),
 }

--- a/vm-migration/src/protocol.rs
+++ b/vm-migration/src/protocol.rs
@@ -76,9 +76,10 @@
 
 use std::io::{Read, Write};
 
+use anyhow::anyhow;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
-use vm_memory::ByteValued;
+use zerocopy::{Immutable, IntoBytes, KnownLayout, TryFromBytes};
 
 use crate::MigratableError;
 use crate::bitpos_iterator::BitposIteratorExt;
@@ -107,7 +108,9 @@ use crate::bitpos_iterator::BitposIteratorExt;
 ///
 /// [live-migration protocol]: super::protocol
 #[repr(u16)]
-#[derive(Debug, Copy, Clone, Default, PartialEq, Eq)]
+#[derive(
+    Debug, Copy, Clone, Default, PartialEq, Eq, Immutable, IntoBytes, KnownLayout, TryFromBytes,
+)]
 pub enum Command {
     #[default]
     Invalid,
@@ -122,15 +125,12 @@ pub enum Command {
 }
 
 #[repr(C)]
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, Immutable, IntoBytes, KnownLayout, TryFromBytes)]
 pub struct Request {
     command: Command,
     padding: [u8; 6],
     length: u64, // Length of payload for command excluding the Request struct
 }
-
-// SAFETY: Request contains a series of integers with no implicit padding
-unsafe impl ByteValued for Request {}
 
 impl Request {
     pub fn new(command: Command, length: u64) -> Self {
@@ -182,32 +182,40 @@ impl Request {
     }
 
     pub fn read_from(fd: &mut dyn Read) -> Result<Request, MigratableError> {
-        let mut request = Request::default();
+        /// A byte buffer that matches `Self` in size and alignment to allow deserializing `Self` into.
+        #[repr(C, align(8))]
+        struct RequestBuffer([u8; const { size_of::<Request>() }]);
+        const _: () = const {
+            // Check that the alignment of the buffer matches `Self`.
+            assert!(align_of::<RequestBuffer>() == align_of::<Request>());
+        };
+        let mut buffer = RequestBuffer([0; size_of::<Self>()]);
+        let RequestBuffer(request) = &mut buffer;
 
         loop {
-            fd.read_exact(Self::as_mut_slice(&mut request))
+            fd.read_exact(request)
                 .map_err(MigratableError::MigrateSocket)?;
+
+            let request = Self::try_mut_from_bytes(request)
+                .map_err(|error| MigratableError::DeserializeError(anyhow!("{error:?}")))?;
 
             // If we read a keep alive message, we throw it away and keep reading.
             if request.command() == Command::KeepAlive {
-                request = Request::default();
+                *request = Request::default();
                 continue;
             }
-
-            break;
+            return Ok(*request);
         }
-
-        Ok(request)
     }
 
     pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
-        fd.write_all(Self::as_slice(self))
+        fd.write_all(self.as_bytes())
             .map_err(MigratableError::MigrateSocket)
     }
 }
 
 #[repr(u16)]
-#[derive(Copy, Clone, PartialEq, Eq, Default)]
+#[derive(Copy, Clone, PartialEq, Eq, Default, Immutable, IntoBytes, KnownLayout, TryFromBytes)]
 pub enum Status {
     #[default]
     Invalid,
@@ -217,15 +225,12 @@ pub enum Status {
 }
 
 #[repr(C)]
-#[derive(Default, Copy, Clone)]
+#[derive(Default, Copy, Clone, Immutable, IntoBytes, KnownLayout, TryFromBytes)]
 pub struct Response {
     status: Status,
     padding: [u8; 6],
     length: u64, // Length of payload for command excluding the Response struct
 }
-
-// SAFETY: Response contains a series of integers with no implicit padding
-unsafe impl ByteValued for Response {}
 
 impl Response {
     pub fn new(status: Status, length: u64) -> Self {
@@ -257,22 +262,30 @@ impl Response {
     }
 
     pub fn read_from(fd: &mut dyn Read) -> Result<Response, MigratableError> {
-        let mut response = Response::default();
+        /// A byte buffer that matches `Self` in size and alignment to allow deserializing `Self` into.
+        #[repr(C, align(8))]
+        struct ResponseBuffer([u8; const { size_of::<Response>() }]);
+        const _: () = const {
+            // Check that the alignment of the buffer matches `Self`.
+            assert!(align_of::<ResponseBuffer>() == align_of::<Response>());
+        };
+        let mut buffer = ResponseBuffer([0; size_of::<Self>()]);
+        let ResponseBuffer(response) = &mut buffer;
 
         loop {
-            fd.read_exact(Self::as_mut_slice(&mut response))
+            fd.read_exact(response)
                 .map_err(MigratableError::MigrateSocket)?;
+
+            let response = Self::try_mut_from_bytes(response)
+                .map_err(|error| MigratableError::DeserializeError(anyhow!("{error:?}")))?;
 
             // If we read a keep alive message, we throw it away and keep reading.
             if response.status() == Status::KeepAlive {
-                response = Response::default();
+                *response = Response::default();
                 continue;
             }
-
-            break;
+            return Ok(*response);
         }
-
-        Ok(response)
     }
 
     pub fn ok_or_abandon<T>(
@@ -292,7 +305,7 @@ impl Response {
     }
 
     pub fn write_to(&self, fd: &mut dyn Write) -> Result<(), MigratableError> {
-        fd.write_all(Self::as_slice(self))
+        fd.write_all(self.as_bytes())
             .map_err(MigratableError::MigrateSocket)
     }
 }


### PR DESCRIPTION
Using a value that is not a valid discriminant for an enum is undefined behavior [0]. Uses the zerocopy crate to check the validity of the bytes before converting to the respective structs.

I'm not happy with the error type, but this is the fastest way to fix the UB, which takes priority here.

[0] https://doc.rust-lang.org/reference/behavior-considered-undefined.html#r-undefined.validity.enum
