### PR TITLE
vmm: migration: gracefully tear down old VM (threads etc)

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -4283,26 +4283,24 @@ impl RequestHandler for Vmm {
         }
 
         // When spawning the thread fails, the VM keeps running normally.
-        let migration_worker = match MigrationWorker::spawn(
+        let migration_worker = MigrationWorker::spawn(
             vm,
             self.check_migration_evt.try_clone().unwrap(),
             send_data_migration,
             self.postponed_lifecycle_event.clone(),
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             self.hypervisor.clone(),
-        ) {
-            Ok(worker) => worker,
-            Err((vm, e)) => {
-                self.vm = MaybeVmOwnership::Vmm(vm);
+        )
+        .map_err(|(vm, e)| {
+            self.vm = MaybeVmOwnership::Vmm(vm);
 
-                let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
-                lock.as_mut()
-                    .expect("live migration should be ongoing")
-                    .mark_as_failed(&e);
+            let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+            lock.as_mut()
+                .expect("live migration should be ongoing")
+                .mark_as_failed(&e);
 
-                return Err(e);
-            }
-        };
+            e
+        })?;
         let old = self.migration_thread_handle.replace(migration_worker);
         // If this fails, we messed up the thread lifecycle management.
         debug_assert!(old.is_none());

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3153,14 +3153,23 @@ impl Vmm {
 
         match migration_res {
             Ok(()) => {
-                self.vm = MaybeVmOwnership::None;
-                drop(vm);
-
                 {
                     let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
                     lock.as_mut()
                         .expect("live migration should be ongoing")
                         .mark_as_finished();
+                }
+
+                // Give VMM ownership to delete, i.e., gracefully clean up
+                // threads and free resources.
+                self.vm = MaybeVmOwnership::Vmm(vm);
+                match self.vm_delete() {
+                    Ok(()) => {
+                        info!("VM deleted after successful migration");
+                    }
+                    Err(e) => {
+                        error!("Failed to delete VM after successful migration: {e}");
+                    }
                 }
 
                 if migration_cfg.keep_alive {
@@ -3239,7 +3248,7 @@ impl Vmm {
                         warn!("Unknown VMM loop event: {event}");
                     }
                     EpollDispatch::Exit => {
-                        info!("VM exit event");
+                        info!("VMM exit event");
                         // Consume the event.
                         self.exit_evt.read().map_err(Error::EventFdRead)?;
                         self.vmm_shutdown().map_err(Error::VmmShutdown)?;


### PR DESCRIPTION
TL;DR: This _might_ be a bug fix. But in any case, the proposed change is a more graceful way to handle things.

**CI pipeline**: https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/merge_requests/149

There is no drop implementation for a Vm: threads and other resources
are just left as they are. We are not 100% sure but this might cause
some interference and hangs from transitive drops. We therefore do a
graceful Vm deletion now: in short, joining all threads.

This happens when the VM is already on the receiver side, so we are not
increasing the downtime or so.

New last log lines on sender (simplified):

```
<vmm> INFO:vmm/src/lib.rs -- VM migration check event
<vmm> INFO:event_monitor/src/lib.rs -- Event: source = vm event = deleted
<vmm> INFO:virtio-devices/src/device.rs -- Resuming virtio-rng
<vmm> INFO:virtio-devices/src/device.rs -- Resuming virtio-rng
<serial-manager> INFO:vmm/src/serial_manager.rs -- KILL_EVENT received, stopping epoll loop
<__rng> INFO:virtio-devices/src/epoll_helper.rs -- KILL_EVENT received, stopping epoll loop
<vmm> INFO:event_monitor/src/lib.rs -- Event: source = vm event = shutdown
<vmm> INFO:vmm/src/lib.rs -- VM deleted after successful migration
<vmm> INFO:vmm/src/lib.rs -- Keeping VMM alive as requested
<vmm> INFO:vmm/src/api/mod.rs -- API request event: VmmShutdown
<vmm> INFO:event_monitor/src/lib.rs -- Event: source = vmm event = shutdown
<main> INFO:cloud-hypervisor/src/main.rs -- Cloud Hypervisor exited successfully
```

where these are the new messages:

```
1a2,3
> <vmm> INFO:event_monitor/src/lib.rs -- Event: source = vm event = deleted
> <vmm> INFO:virtio-devices/src/device.rs -- Resuming virtio-rng
4a7,8
> <vmm> INFO:event_monitor/src/lib.rs -- Event: source = vm event = shutdown
> <vmm> INFO:vmm/src/lib.rs -- VM deleted after successful migration
```

On-behalf-of: SAP philipp.schuster@sap.com
Signed-off-by: Philipp Schuster <philipp.schuster@cyberus-technology.de>