### PR TITLE
vmm: migration: fix cancel call keeps VMM running without disk locks + fix panic when migration thread spawning fails

### DIFF
--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -759,7 +759,7 @@ impl VcpuState {
 
     /// Blocks until the vCPU thread has acknowledged the signal.
     ///
-    /// The signal is resent every 5ms until the vCPU thread acknowledges it.
+    /// The signal is resent every ms until the vCPU thread acknowledges it.
     /// A warning is emitted every 100ms while the acknowledgment is pending.
     ///
     /// The wait is bounded by a total timeout of 10 seconds. If the vCPU thread

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2861,6 +2861,8 @@ impl Vmm {
             )?;
         }
 
+        // Very last cancellation check. After this, we release the disk locks and we can't cancel
+        // anymore.
         return_if_cancelled_cb(&mut socket)?;
 
         // Update migration progress snapshot
@@ -2897,9 +2899,6 @@ impl Vmm {
         )))?;
         // Complete the migration
         // At this step, the receiving VMM will acquire disk locks again.
-
-        // Very last and final check:
-        return_if_cancelled_cb(&mut socket)?;
 
         Request::complete().write_to(&mut socket)?;
         Response::read_from(&mut socket)?.ok_or_error(MigratableError::MigrateSend(anyhow!(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -891,6 +891,7 @@ impl MigrationWorker {
         }
     }
 
+    #[expect(clippy::result_large_err)]
     fn spawn(
         vm: Vm,
         check_migration_evt: EventFd,
@@ -899,7 +900,7 @@ impl MigrationWorker {
         #[cfg(all(feature = "kvm", target_arch = "x86_64"))] hypervisor: Arc<
             dyn hypervisor::Hypervisor,
         >,
-    ) -> MigrationWorkerHandle {
+    ) -> result::Result<MigrationWorkerHandle, (Vm, MigratableError)> {
         let cancel = Arc::new(AtomicBool::new(false));
         let worker = MigrationWorker {
             vm,
@@ -911,17 +912,37 @@ impl MigrationWorker {
             cancel: cancel.clone(),
         };
 
+        // Cumbersome but we need this to take a value from the worker when
+        // thread spawning failed. Ownership of the worker is either by the
+        // thread or this function.
+        let worker = Arc::new(Mutex::new(Some(worker)));
+        let thread_worker = worker.clone();
+
         let inner_handle = thread::Builder::new()
             .name("migration".into())
-            .spawn(move || worker.run())
-            // For upstreaming, we should simply continue and return an
-            // error when this fails. For our PoC, this is fine.
-            .unwrap();
+            .spawn(move || {
+                thread_worker
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .expect("migration worker should only be taken once")
+                    .run()
+            })
+            .context("should spawn migration thread")
+            .map_err(|e| {
+                // Get the VM back from the worker.
+                let worker = worker
+                    .lock()
+                    .unwrap()
+                    .take()
+                    .expect("migration worker should remain available on spawn failure");
+                (worker.vm, MigratableError::MigrateSend(e))
+            })?;
 
-        MigrationWorkerHandle {
+        Ok(MigrationWorkerHandle {
             handle: Some(inner_handle),
             cancel,
-        }
+        })
     }
 }
 
@@ -4217,14 +4238,27 @@ impl RequestHandler for Vmm {
             ));
         }
 
-        let migration_worker = MigrationWorker::spawn(
+        // When spawning the thread fails, the VM keeps running normally.
+        let migration_worker = match MigrationWorker::spawn(
             vm,
             self.check_migration_evt.try_clone().unwrap(),
             send_data_migration,
             self.postponed_lifecycle_event.clone(),
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             self.hypervisor.clone(),
-        );
+        ) {
+            Ok(worker) => worker,
+            Err((vm, e)) => {
+                self.vm = MaybeVmOwnership::Vmm(vm);
+
+                let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
+                lock.as_mut()
+                    .expect("live migration should be ongoing")
+                    .mark_as_failed(&e);
+
+                return Err(e);
+            }
+        };
         let old = self.migration_thread_handle.replace(migration_worker);
         // If this fails, we messed up the thread lifecycle management.
         debug_assert!(old.is_none());


### PR DESCRIPTION
- essential small fixes for going into prod


We can't test this as the time from releasing the disk locks to 
completing the migration is <1ms. It is highly timing dependent. We
have more than enough "should we cancel?" synchronization points in
the earlier code paths so we are not losing anything.