### PR TITLE
virtio: enable `VIRTIO_NET_F_GUEST_ANNOUNCE` feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2736,6 +2736,7 @@ dependencies = [
  "rate_limiter",
  "seccompiler",
  "serde",
+ "serde_json",
  "serde_with",
  "serial_buffer",
  "thiserror 2.0.18",

--- a/docs/live_migration.md
+++ b/docs/live_migration.md
@@ -130,6 +130,10 @@ src $ ch-remote --api-socket=/tmp/api send-migration unix:/tmp/sock
 
 When the above commands completed, the VM should be successfully
 migrated to the destination machine without interrupting the workload.
+Cloud Hypervisor sends out RARP packages after the migration, to
+announce the new location of the VM to the network. For `virtio-net`
+devices, Cloud Hypervisor asks guests that negotiated
+`VIRTIO_NET_F_GUEST_ANNOUNCE` to also re-announce themselves.
 
 ### TCP Socket Migration
 
@@ -186,6 +190,10 @@ After completing the above commands, the source VM will be migrated to
 the destination host and continue running there. The source VM instance
 will terminate normally. All ongoing processes and connections within
 the VM should remain intact after the migration.
+Cloud Hypervisor sends out RARP packages after the migration, to
+announce the new location of the VM to the network. For `virtio-net`
+devices, Cloud Hypervisor asks guests that negotiated
+`VIRTIO_NET_F_GUEST_ANNOUNCE` to also re-announce themselves.
 
 #### Migration Parameters
 

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -200,3 +200,67 @@ impl CtrlQueue {
         Ok(())
     }
 }
+
+#[cfg(test)]
+mod unit_tests {
+    use std::mem::size_of;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use virtio_bindings::virtio_net::{VIRTIO_NET_CTRL_ANNOUNCE, VIRTIO_NET_CTRL_ANNOUNCE_ACK};
+    use virtio_bindings::virtio_ring::{VRING_DESC_F_NEXT, VRING_DESC_F_WRITE};
+    use vm_memory::{Bytes, GuestAddress};
+    use vm_virtio::queue::testing::VirtQueue as GuestQ;
+
+    use super::*;
+
+    #[test]
+    fn test_process_announce_ack() {
+        // The guest acknowledges the post-migration request on the control
+        // queue, which clears the pending announce state in the device model.
+        // This test builds the minimal virtqueue request for that command:
+        // one readable descriptor for the control header, followed by one
+        // writable descriptor where the device stores the command status.
+        let mem = GuestMemoryMmap::from_ranges(&[(GuestAddress(0), 0x10000)]).unwrap();
+        let guest_q = GuestQ::new(GuestAddress(0), &mem, 16);
+        let mut queue = guest_q.create_queue();
+
+        let ctrl_hdr = ControlHeader {
+            class: VIRTIO_NET_CTRL_ANNOUNCE as u8,
+            cmd: VIRTIO_NET_CTRL_ANNOUNCE_ACK as u8,
+        };
+        let ctrl_addr = GuestAddress(0x1000);
+        let status_addr = GuestAddress(0x1100);
+        mem.write_obj(ctrl_hdr, ctrl_addr).unwrap();
+
+        // Descriptor 0 contains the control header and points to descriptor 1.
+        guest_q.dtable[0].set(
+            ctrl_addr.0,
+            size_of::<ControlHeader>() as u32,
+            VRING_DESC_F_NEXT.try_into().unwrap(),
+            1,
+        );
+        // Descriptor 1 is the writable status byte returned by the device.
+        guest_q.dtable[1].set(status_addr.0, 1, VRING_DESC_F_WRITE.try_into().unwrap(), 0);
+
+        // Publish the two-descriptor request to the available ring so
+        // CtrlQueue::process() can pop and handle it.
+        guest_q.avail.ring[0].set(0);
+        guest_q.avail.idx.set(1);
+
+        // Start from the state reached after post_migration(): the guest still
+        // owes us an ANNOUNCE_ACK on the control queue.
+        let announce_pending = Arc::new(AtomicBool::new(true));
+        let mut ctrl_q = CtrlQueue::new(Vec::new(), Arc::clone(&announce_pending));
+
+        ctrl_q.process(&mem, &mut queue, None).unwrap();
+
+        // A successful ANNOUNCE_ACK clears the pending flag and reports
+        // VIRTIO_NET_OK in the guest-provided status buffer.
+        assert!(!announce_pending.load(Ordering::Acquire));
+        assert_eq!(
+            mem.read_obj::<u8>(status_addr).unwrap(),
+            VIRTIO_NET_OK as u8
+        );
+    }
+}

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -79,21 +79,18 @@ impl CtrlQueue {
                         .translate_gva(access_platform, ctrl_desc.len() as usize),
                 )
                 .map_err(Error::GuestMemory)?;
-            let data_desc = desc_chain.next().ok_or(Error::NoDataDescriptor)?;
-
-            let data_desc_addr = data_desc
-                .addr()
-                .translate_gva(access_platform, data_desc.len() as usize);
-
-            let status_desc = desc_chain.next().ok_or(Error::NoStatusDescriptor)?;
-
-            let ok = match u32::from(ctrl_hdr.class) {
+            let (ok, used_len, status_desc) = match u32::from(ctrl_hdr.class) {
                 VIRTIO_NET_CTRL_MQ => {
+                    let data_desc = desc_chain.next().ok_or(Error::NoDataDescriptor)?;
+                    let data_desc_addr = data_desc
+                        .addr()
+                        .translate_gva(access_platform, data_desc.len() as usize);
+                    let status_desc = desc_chain.next().ok_or(Error::NoStatusDescriptor)?;
                     let queue_pairs = desc_chain
                         .memory()
                         .read_obj::<u16>(data_desc_addr)
                         .map_err(Error::GuestMemory)?;
-                    if u32::from(ctrl_hdr.cmd) != VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET {
+                    let ok = if u32::from(ctrl_hdr.cmd) != VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET {
                         warn!("Unsupported command: {}", ctrl_hdr.cmd);
                         false
                     } else if (queue_pairs < VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MIN as u16)
@@ -104,14 +101,25 @@ impl CtrlQueue {
                     } else {
                         info!("Number of MQ pairs requested: {queue_pairs}");
                         true
-                    }
+                    };
+
+                    (
+                        ok,
+                        ctrl_desc.len() + data_desc.len() + status_desc.len(),
+                        status_desc,
+                    )
                 }
                 VIRTIO_NET_CTRL_GUEST_OFFLOADS => {
+                    let data_desc = desc_chain.next().ok_or(Error::NoDataDescriptor)?;
+                    let data_desc_addr = data_desc
+                        .addr()
+                        .translate_gva(access_platform, data_desc.len() as usize);
+                    let status_desc = desc_chain.next().ok_or(Error::NoStatusDescriptor)?;
                     let features = desc_chain
                         .memory()
                         .read_obj::<u64>(data_desc_addr)
                         .map_err(Error::GuestMemory)?;
-                    if u32::from(ctrl_hdr.cmd) == VIRTIO_NET_CTRL_GUEST_OFFLOADS_SET {
+                    let ok = if u32::from(ctrl_hdr.cmd) == VIRTIO_NET_CTRL_GUEST_OFFLOADS_SET {
                         let mut ok = true;
                         for tap in self.taps.iter_mut() {
                             info!("Reprogramming tap offload with features: {features}");
@@ -126,11 +134,23 @@ impl CtrlQueue {
                     } else {
                         warn!("Unsupported command: {}", ctrl_hdr.cmd);
                         false
-                    }
+                    };
+
+                    (
+                        ok,
+                        ctrl_desc.len() + data_desc.len() + status_desc.len(),
+                        status_desc,
+                    )
                 }
                 _ => {
+                    let data_desc = desc_chain.next().ok_or(Error::NoDataDescriptor)?;
+                    let status_desc = desc_chain.next().ok_or(Error::NoStatusDescriptor)?;
                     warn!("Unsupported command {ctrl_hdr:?}");
-                    false
+                    (
+                        false,
+                        ctrl_desc.len() + data_desc.len() + status_desc.len(),
+                        status_desc,
+                    )
                 }
             };
 
@@ -143,10 +163,8 @@ impl CtrlQueue {
                         .translate_gva(access_platform, status_desc.len() as usize),
                 )
                 .map_err(Error::GuestMemory)?;
-            let len = ctrl_desc.len() + data_desc.len() + status_desc.len();
-
             queue
-                .add_used(desc_chain.memory(), desc_chain.head_index(), len)
+                .add_used(desc_chain.memory(), desc_chain.head_index(), used_len)
                 .map_err(Error::QueueAddUsed)?;
 
             if !queue

--- a/net_util/src/ctrl_queue.rs
+++ b/net_util/src/ctrl_queue.rs
@@ -2,12 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
 use log::{error, info, warn};
 use thiserror::Error;
 use virtio_bindings::virtio_net::{
-    VIRTIO_NET_CTRL_GUEST_OFFLOADS, VIRTIO_NET_CTRL_GUEST_OFFLOADS_SET, VIRTIO_NET_CTRL_MQ,
-    VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MAX, VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MIN,
-    VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET, VIRTIO_NET_ERR, VIRTIO_NET_OK,
+    VIRTIO_NET_CTRL_ANNOUNCE, VIRTIO_NET_CTRL_ANNOUNCE_ACK, VIRTIO_NET_CTRL_GUEST_OFFLOADS,
+    VIRTIO_NET_CTRL_GUEST_OFFLOADS_SET, VIRTIO_NET_CTRL_MQ, VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MAX,
+    VIRTIO_NET_CTRL_MQ_VQ_PAIRS_MIN, VIRTIO_NET_CTRL_MQ_VQ_PAIRS_SET, VIRTIO_NET_ERR,
+    VIRTIO_NET_OK,
 };
 use virtio_queue::{Queue, QueueT};
 use vm_memory::{ByteValued, Bytes, GuestMemoryError};
@@ -55,11 +59,17 @@ unsafe impl ByteValued for ControlHeader {}
 
 pub struct CtrlQueue {
     pub taps: Vec<Tap>,
+    /// Tracks whether the guest still needs to acknowledge a post-migration
+    /// announce request through the control queue.
+    pub announce_pending: Arc<AtomicBool>,
 }
 
 impl CtrlQueue {
-    pub fn new(taps: Vec<Tap>) -> Self {
-        CtrlQueue { taps }
+    pub fn new(taps: Vec<Tap>, announce_pending: Arc<AtomicBool>) -> Self {
+        CtrlQueue {
+            taps,
+            announce_pending,
+        }
     }
 
     pub fn process(
@@ -141,6 +151,18 @@ impl CtrlQueue {
                         ctrl_desc.len() + data_desc.len() + status_desc.len(),
                         status_desc,
                     )
+                }
+                VIRTIO_NET_CTRL_ANNOUNCE => {
+                    let status_desc = desc_chain.next().ok_or(Error::NoStatusDescriptor)?;
+                    let ok = if u32::from(ctrl_hdr.cmd) == VIRTIO_NET_CTRL_ANNOUNCE_ACK {
+                        self.announce_pending.store(false, Ordering::Release);
+                        true
+                    } else {
+                        warn!("Unsupported command: {}", ctrl_hdr.cmd);
+                        false
+                    };
+
+                    (ok, ctrl_desc.len() + status_desc.len(), status_desc)
                 }
                 _ => {
                     let data_desc = desc_chain.next().ok_or(Error::NoDataDescriptor)?;

--- a/virtio-devices/Cargo.toml
+++ b/virtio-devices/Cargo.toml
@@ -48,5 +48,8 @@ vm-migration = { path = "../vm-migration" }
 vm-virtio = { path = "../vm-virtio" }
 vmm-sys-util = { workspace = true }
 
+[dev-dependencies]
+serde_json = { workspace = true }
+
 [lints]
 workspace = true

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -424,10 +424,14 @@ pub struct Net {
 #[derive(Serialize, Deserialize)]
 /// Serialized snapshot of the device state. The fields are copied from the
 /// live device when snapshotting and restored back into a new device instance.
+///
+/// Fields not present in previous versions are tagged with `#[serde(default)]`
+/// to allow deserialization if the field is not present.
 pub struct NetState {
     pub avail_features: u64,
     pub acked_features: u64,
     pub config: VirtioNetConfig,
+    #[serde(default)]
     pub announce_pending: bool,
     pub queue_size: Vec<u16>,
 }
@@ -1225,5 +1229,25 @@ mod unit_tests {
 
         assert!(!net.announce_pending.load(Ordering::Acquire));
         assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+    }
+
+    #[test]
+    fn test_net_state_deserialize_without_announce_pending_defaults_to_false() {
+        // Older snapshots do not contain announce_pending. Restoring them on a
+        // newer binary must treat the missing field as "no announce pending".
+        let state = NetState {
+            avail_features: 1,
+            acked_features: 2,
+            config: VirtioNetConfig::default(),
+            announce_pending: true,
+            queue_size: vec![256, 256],
+        };
+        let mut value = serde_json::to_value(state).unwrap();
+
+        value.as_object_mut().unwrap().remove("announce_pending");
+
+        let restored: NetState = serde_json::from_value(value).unwrap();
+
+        assert!(!restored.announce_pending);
     }
 }

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -10,7 +10,7 @@ use std::net::IpAddr;
 use std::num::Wrapping;
 use std::ops::Deref;
 use std::os::unix::io::{AsRawFd, RawFd};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier};
 use std::{result, thread};
 
@@ -414,6 +414,9 @@ pub struct Net {
     /// Tracks whether the guest still needs to acknowledge a post-migration
     /// announce request through the control queue.
     announce_pending: Arc<AtomicBool>,
+    /// Generation counter used to invalidate active announcers created before a
+    /// reset or device teardown, so they stop sending notifications.
+    announce_generation: Arc<AtomicU64>,
     ctrl_queue_epoll_thread: Option<thread::JoinHandle<()>>,
     counters: NetCounters,
     seccomp_action: SeccompAction,
@@ -579,6 +582,7 @@ impl Net {
             taps,
             config: constructor_state.config,
             announce_pending: Arc::new(AtomicBool::new(constructor_state.announce_pending)),
+            announce_generation: Arc::new(AtomicU64::new(0)),
             ctrl_queue_epoll_thread: None,
             counters: NetCounters::default(),
             seccomp_action,
@@ -783,6 +787,8 @@ impl Net {
 
 impl Drop for Net {
     fn drop(&mut self) {
+        self.announce_generation.fetch_add(1, Ordering::AcqRel);
+
         // Get a comma-separated list of the interface names of the tap devices
         // associated with this network device.
         let ifnames_str = self
@@ -976,6 +982,7 @@ impl VirtioDevice for Net {
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.announce_pending.store(false, Ordering::Release);
+        self.announce_generation.fetch_add(1, Ordering::AcqRel);
         let result = self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
         result
@@ -1048,6 +1055,10 @@ pub struct VirtioNetPostMigrationAnnouncer {
     /// Remembers whether this device negotiated the guest-visible announce path.
     guest_announce_negotiated: bool,
     announce_pending: Arc<AtomicBool>,
+    announce_generation: Arc<AtomicU64>,
+    /// Captures the announce generation at creation time to invalidate stale
+    /// retry sessions after reset or teardown.
+    generation: u64,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
     /// Prebuilt host-side RARP payload used for immediate post-migration
     /// announcement retries.
@@ -1061,6 +1072,8 @@ impl VirtioNetPostMigrationAnnouncer {
             id: dev.id.clone(),
             guest_announce_negotiated: dev.common.feature_acked(VIRTIO_NET_F_GUEST_ANNOUNCE.into()),
             announce_pending: Arc::clone(&dev.announce_pending),
+            announce_generation: Arc::clone(&dev.announce_generation),
+            generation: dev.announce_generation.load(Ordering::Acquire),
             interrupt_cb: dev.common.interrupt_cb.clone(),
             rarp_announce: dev.build_rarp_announce(),
             taps: dev.taps.clone(),
@@ -1073,7 +1086,12 @@ impl PostMigrationAnnouncer for VirtioNetPostMigrationAnnouncer {
     // guest runs again, and then also ask the guest to re-announce itself when
     // GUEST_ANNOUNCE was negotiated.
     fn announce(&mut self) {
-        // We have to add a virtio-net header to the RARP announce.
+        // If the announce generations don't match, we don't send any announcements.
+        if self.announce_generation.load(Ordering::Acquire) != self.generation {
+            return;
+        }
+
+        // We have to add a virtio-net header to the announce.
         let mut buf = vec![0u8; vnet_hdr_len() + self.rarp_announce.len()];
         buf[vnet_hdr_len()..].copy_from_slice(&self.rarp_announce);
 
@@ -1158,6 +1176,7 @@ mod unit_tests {
             taps: Vec::new(),
             config: VirtioNetConfig::default(),
             announce_pending: Arc::new(AtomicBool::new(false)),
+            announce_generation: Arc::new(AtomicU64::new(0)),
             ctrl_queue_epoll_thread: None,
             counters: NetCounters::default(),
             seccomp_action: SeccompAction::Allow,
@@ -1267,6 +1286,47 @@ mod unit_tests {
 
         assert!(!net.announce_pending.load(Ordering::Acquire));
         assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+    }
+
+    #[test]
+    fn test_reset_invalidates_old_announcer() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let mut net = test_net(
+            1 << VIRTIO_NET_F_GUEST_ANNOUNCE,
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+        let mut announcer = net.post_migration_announcer().unwrap();
+
+        announcer.announce();
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
+
+        let _ = net.reset();
+        announcer.announce();
+
+        assert!(!net.announce_pending.load(Ordering::Acquire));
+        assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn test_drop_invalidates_old_announcer() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let mut announcer = {
+            let net = test_net(
+                1 << VIRTIO_NET_F_GUEST_ANNOUNCE,
+                Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+            );
+            let mut announcer = net.post_migration_announcer().unwrap();
+
+            announcer.announce();
+            assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
+
+            announcer
+        };
+
+        announcer.announce();
+
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
     }
 
     #[test]

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -1084,17 +1084,48 @@ impl PostMigrationAnnouncer for VirtioNetPostMigrationAnnouncer {
 #[cfg(test)]
 mod unit_tests {
     use std::mem::size_of;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
     use seccompiler::SeccompAction;
-    use virtio_bindings::virtio_net::{VIRTIO_NET_F_STATUS, VIRTIO_NET_S_LINK_UP};
+    use virtio_bindings::virtio_net::{
+        VIRTIO_NET_F_GUEST_ANNOUNCE, VIRTIO_NET_F_STATUS, VIRTIO_NET_S_ANNOUNCE,
+        VIRTIO_NET_S_LINK_UP,
+    };
     use vmm_sys_util::eventfd::EventFd;
 
     use super::*;
+    use crate::device::{VirtioInterrupt, VirtioInterruptType};
 
-    fn test_net(acked_features: u64) -> Net {
+    struct TestInterrupt {
+        config_count: AtomicUsize,
+    }
+
+    impl TestInterrupt {
+        fn new() -> Self {
+            Self {
+                config_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl VirtioInterrupt for TestInterrupt {
+        fn trigger(
+            &self,
+            int_type: VirtioInterruptType,
+        ) -> std::result::Result<(), std::io::Error> {
+            if matches!(int_type, VirtioInterruptType::Config) {
+                self.config_count.fetch_add(1, Ordering::AcqRel);
+            }
+            Ok(())
+        }
+    }
+
+    fn test_net(acked_features: u64, interrupt_cb: Option<Arc<dyn VirtioInterrupt>>) -> Net {
         Net {
             common: VirtioCommon {
                 acked_features,
+                interrupt_cb,
                 ..Default::default()
             },
             id: "test-net".to_string(),
@@ -1130,8 +1161,69 @@ mod unit_tests {
 
     #[test]
     fn test_status_feature_reports_link_up() {
-        let net = test_net(1 << VIRTIO_NET_F_STATUS);
+        let net = test_net(1 << VIRTIO_NET_F_STATUS, None);
 
         assert_eq!(read_status(&net), VIRTIO_NET_S_LINK_UP as u16);
+    }
+
+    #[test]
+    fn test_post_migration_sets_announce_and_triggers_config() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let net = test_net(
+            (1 << VIRTIO_NET_F_GUEST_ANNOUNCE) | (1 << VIRTIO_NET_F_STATUS),
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+
+        net.post_migration_announcer().unwrap().announce();
+
+        assert!(net.announce_pending.load(Ordering::Acquire));
+        assert_ne!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn test_post_migration_without_feature_is_noop() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let net = test_net(0, Some(interrupt.clone() as Arc<dyn VirtioInterrupt>));
+
+        net.post_migration_announcer().unwrap().announce();
+
+        assert!(!net.announce_pending.load(Ordering::Acquire));
+        assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_post_migration_retries_retrigger_config_interrupt() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let net = test_net(
+            (1 << VIRTIO_NET_F_GUEST_ANNOUNCE) | (1 << VIRTIO_NET_F_STATUS),
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+        let mut announcer = net.post_migration_announcer().unwrap();
+
+        announcer.announce();
+        announcer.announce();
+
+        assert!(net.announce_pending.load(Ordering::Acquire));
+        assert_ne!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 2);
+    }
+
+    #[test]
+    fn test_reset_clears_pending_announce() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let mut net = test_net(
+            (1 << VIRTIO_NET_F_GUEST_ANNOUNCE) | (1 << VIRTIO_NET_F_STATUS),
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+
+        net.post_migration_announcer().unwrap().announce();
+        assert!(net.announce_pending.load(Ordering::Acquire));
+
+        let _ = net.reset();
+
+        assert!(!net.announce_pending.load(Ordering::Acquire));
+        assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
     }
 }

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -758,6 +758,27 @@ impl Net {
 
         buf
     }
+
+    /// Re-notify the guest about a restored pending ANNOUNCE request once the
+    /// transport has installed an interrupt callback during activation.
+    fn notify_pending_guest_announce(&self) {
+        if self.announce_pending.load(Ordering::Acquire)
+            && self
+                .common
+                .feature_acked(VIRTIO_NET_F_GUEST_ANNOUNCE.into())
+            && let Some(interrupt_cb) = &self.common.interrupt_cb
+        {
+            interrupt_cb
+                .trigger(VirtioInterruptType::Config)
+                .inspect_err(|e| {
+                    warn!(
+                        "Unable to resend pending announce interrupt for virtio-net device {}: {e}",
+                        self.id
+                    );
+                })
+                .ok();
+        }
+    }
 }
 
 impl Drop for Net {
@@ -947,6 +968,7 @@ impl VirtioDevice for Net {
         }
 
         self.common.epoll_threads = Some(epoll_threads);
+        self.notify_pending_guest_announce();
 
         event!("virtio-device", "activated", "id", &self.id);
         Ok(())
@@ -1195,6 +1217,22 @@ mod unit_tests {
         assert!(!net.announce_pending.load(Ordering::Acquire));
         assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
         assert_eq!(interrupt.config_count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_restored_pending_announce_retriggers_config_interrupt() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let net = test_net(
+            (1 << VIRTIO_NET_F_GUEST_ANNOUNCE) | (1 << VIRTIO_NET_F_STATUS),
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+        net.announce_pending.store(true, Ordering::Release);
+
+        net.notify_pending_guest_announce();
+
+        assert!(net.announce_pending.load(Ordering::Acquire));
+        assert_ne!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
     }
 
     #[test]

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -495,6 +495,7 @@ impl Net {
         }
 
         avail_features |= 1 << VIRTIO_NET_F_CTRL_VQ;
+        avail_features |= 1 << VIRTIO_NET_F_STATUS;
         let queue_num = num_queues + 1;
 
         let mut config = VirtioNetConfig::default();
@@ -684,6 +685,22 @@ impl Net {
         }
     }
 
+    /// Return the guest-visible virtio-net config, recomputing `status` from the
+    /// current state of the device.
+    fn config_with_status(&self) -> VirtioNetConfig {
+        let mut config = self.config;
+
+        // We want to recompute the guest-visible status field from the current state of
+        // the device. We clear this field first to avoid showing stale data.
+        config.status = 0;
+
+        if self.common.feature_acked(VIRTIO_NET_F_STATUS.into()) {
+            config.status |= VIRTIO_NET_S_LINK_UP as u16;
+        }
+
+        config
+    }
+
     #[cfg(fuzzing)]
     pub fn wait_for_epoll_threads(&mut self) {
         self.common.wait_for_epoll_threads();
@@ -770,7 +787,8 @@ impl VirtioDevice for Net {
     }
 
     fn read_config(&self, offset: u64, data: &mut [u8]) {
-        self.read_config_from_slice(self.config.as_slice(), offset, data);
+        let config = self.config_with_status();
+        self.read_config_from_slice(config.as_slice(), offset, data);
     }
 
     fn activate(
@@ -1013,5 +1031,59 @@ impl PostMigrationAnnouncer for TapRarpAnnouncer {
                 )
             };
         }
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::mem::size_of;
+
+    use seccompiler::SeccompAction;
+    use virtio_bindings::virtio_net::{VIRTIO_NET_F_STATUS, VIRTIO_NET_S_LINK_UP};
+    use vmm_sys_util::eventfd::EventFd;
+
+    use super::*;
+
+    fn test_net(acked_features: u64) -> Net {
+        Net {
+            common: VirtioCommon {
+                acked_features,
+                ..Default::default()
+            },
+            id: "test-net".to_string(),
+            taps: Vec::new(),
+            config: VirtioNetConfig::default(),
+            ctrl_queue_epoll_thread: None,
+            counters: NetCounters::default(),
+            seccomp_action: SeccompAction::Allow,
+            rate_limiter_config: None,
+            exit_evt: EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+        }
+    }
+
+    const STATUS_OFFSET: usize = std::mem::offset_of!(VirtioNetConfig, status);
+    fn read_status(device: &Net) -> u16 {
+        let mut data = vec![0; size_of::<VirtioNetConfig>()];
+        device.read_config(0, &mut data);
+
+        u16::from_le_bytes(
+            data[STATUS_OFFSET..STATUS_OFFSET + size_of::<u16>()]
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_fresh_constructor_state_exposes_status() {
+        let state = Net::fresh_constructor_state(None, false, MIN_MTU, 2, 256, false, false, false);
+
+        assert_ne!(state.avail_features & (1 << VIRTIO_NET_F_STATUS), 0);
+    }
+
+    #[test]
+    fn test_status_feature_reports_link_up() {
+        let net = test_net(1 << VIRTIO_NET_F_STATUS);
+
+        assert_eq!(read_status(&net), VIRTIO_NET_S_LINK_UP as u16);
     }
 }

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -16,7 +16,7 @@ use std::{result, thread};
 
 use anyhow::anyhow;
 use event_monitor::event;
-use log::{debug, error, info, trace};
+use log::{debug, error, info, trace, warn};
 #[cfg(not(fuzzing))]
 use net_util::virtio_features_to_tap_offload;
 use net_util::{
@@ -411,6 +411,9 @@ pub struct Net {
     id: String,
     taps: Vec<Tap>,
     config: VirtioNetConfig,
+    /// Tracks whether the guest still needs to acknowledge a post-migration
+    /// announce request through the control queue.
+    announce_pending: Arc<AtomicBool>,
     ctrl_queue_epoll_thread: Option<thread::JoinHandle<()>>,
     counters: NetCounters,
     seccomp_action: SeccompAction,
@@ -419,10 +422,13 @@ pub struct Net {
 }
 
 #[derive(Serialize, Deserialize)]
+/// Serialized snapshot of the device state. The fields are copied from the
+/// live device when snapshotting and restored back into a new device instance.
 pub struct NetState {
     pub avail_features: u64,
     pub acked_features: u64,
     pub config: VirtioNetConfig,
+    pub announce_pending: bool,
     pub queue_size: Vec<u16>,
 }
 
@@ -437,6 +443,7 @@ struct NetConstructorState {
     avail_features: u64,
     acked_features: u64,
     config: VirtioNetConfig,
+    announce_pending: bool,
     queue_sizes: Vec<u16>,
     paused: bool,
 }
@@ -450,6 +457,7 @@ impl Net {
             avail_features: state.avail_features,
             acked_features: state.acked_features,
             config: state.config,
+            announce_pending: state.announce_pending,
             queue_sizes: state.queue_size,
             paused: true,
         }
@@ -496,6 +504,7 @@ impl Net {
 
         avail_features |= 1 << VIRTIO_NET_F_CTRL_VQ;
         avail_features |= 1 << VIRTIO_NET_F_STATUS;
+        avail_features |= 1 << VIRTIO_NET_F_GUEST_ANNOUNCE;
         let queue_num = num_queues + 1;
 
         let mut config = VirtioNetConfig::default();
@@ -509,6 +518,7 @@ impl Net {
             avail_features,
             acked_features: 0,
             config,
+            announce_pending: false,
             queue_sizes: vec![queue_size; queue_num],
             paused: false,
         }
@@ -564,6 +574,7 @@ impl Net {
             id,
             taps,
             config: constructor_state.config,
+            announce_pending: Arc::new(AtomicBool::new(constructor_state.announce_pending)),
             ctrl_queue_epoll_thread: None,
             counters: NetCounters::default(),
             seccomp_action,
@@ -681,6 +692,7 @@ impl Net {
             avail_features: self.common.avail_features,
             acked_features: self.common.acked_features,
             config: self.config,
+            announce_pending: self.announce_pending.load(Ordering::Acquire),
             queue_size: self.common.queue_sizes.clone(),
         }
     }
@@ -696,6 +708,10 @@ impl Net {
 
         if self.common.feature_acked(VIRTIO_NET_F_STATUS.into()) {
             config.status |= VIRTIO_NET_S_LINK_UP as u16;
+
+            if self.announce_pending.load(Ordering::Acquire) {
+                config.status |= VIRTIO_NET_S_ANNOUNCE as u16;
+            }
         }
 
         config
@@ -826,7 +842,7 @@ impl VirtioDevice for Net {
                 mem: mem.clone(),
                 kill_evt,
                 pause_evt,
-                ctrl_q: CtrlQueue::new(self.taps.clone()),
+                ctrl_q: CtrlQueue::new(self.taps.clone(), Arc::clone(&self.announce_pending)),
                 queue: ctrl_queue,
                 queue_evt: ctrl_queue_evt,
                 access_platform: self.common.access_platform.clone(),
@@ -933,6 +949,7 @@ impl VirtioDevice for Net {
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+        self.announce_pending.store(false, Ordering::Release);
         let result = self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
         result
@@ -966,10 +983,7 @@ impl VirtioDevice for Net {
     }
 
     fn post_migration_announcer(&self) -> Option<Box<dyn PostMigrationAnnouncer>> {
-        Some(Box::new(TapRarpAnnouncer::new(
-            self.build_rarp_announce(),
-            self.taps.clone(),
-        )))
+        Some(Box::new(VirtioNetPostMigrationAnnouncer::new(self)))
     }
 }
 
@@ -1000,25 +1014,42 @@ impl Snapshottable for Net {
 impl Transportable for Net {}
 impl Migratable for Net {}
 
-/// Sends RARP packets on a virtio-net device, to update the MAC to port
-/// mappings of switches in the network. This reduces the time until network
-/// packets reliably arrive at the network device.
-pub struct TapRarpAnnouncer {
-    announce: [u8; ETH_FRAME_LEN], // Buffer for the raw RARP packet.
-    taps: Vec<Tap>,                // The TAP devices to the the packets on.
+/// Announces this virtio-net device on the network.
+/// Most fields are cloned references to device state so retry rounds can run
+/// without borrowing the device itself.
+pub struct VirtioNetPostMigrationAnnouncer {
+    id: String,
+    /// Remembers whether this device negotiated the guest-visible announce path.
+    guest_announce_negotiated: bool,
+    announce_pending: Arc<AtomicBool>,
+    interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
+    /// Prebuilt host-side RARP payload used for immediate post-migration
+    /// announcement retries.
+    rarp_announce: [u8; ETH_FRAME_LEN],
+    taps: Vec<Tap>,
 }
 
-impl TapRarpAnnouncer {
-    pub fn new(announce: [u8; 60], taps: Vec<Tap>) -> Self {
-        Self { announce, taps }
+impl VirtioNetPostMigrationAnnouncer {
+    pub fn new(dev: &Net) -> Self {
+        Self {
+            id: dev.id.clone(),
+            guest_announce_negotiated: dev.common.feature_acked(VIRTIO_NET_F_GUEST_ANNOUNCE.into()),
+            announce_pending: Arc::clone(&dev.announce_pending),
+            interrupt_cb: dev.common.interrupt_cb.clone(),
+            rarp_announce: dev.build_rarp_announce(),
+            taps: dev.taps.clone(),
+        }
     }
 }
 
-impl PostMigrationAnnouncer for TapRarpAnnouncer {
+impl PostMigrationAnnouncer for VirtioNetPostMigrationAnnouncer {
+    // Send a host-side RARP immediately so the network can converge before the
+    // guest runs again, and then also ask the guest to re-announce itself when
+    // GUEST_ANNOUNCE was negotiated.
     fn announce(&mut self) {
-        // We have to add a virtio-net header to the announce.
-        let mut buf = vec![0u8; vnet_hdr_len() + self.announce.len()];
-        buf[vnet_hdr_len()..].copy_from_slice(&self.announce);
+        // We have to add a virtio-net header to the RARP announce.
+        let mut buf = vec![0u8; vnet_hdr_len() + self.rarp_announce.len()];
+        buf[vnet_hdr_len()..].copy_from_slice(&self.rarp_announce);
 
         for tap in &self.taps {
             // SAFETY: `buf.as_ptr()` is valid for `buf.len()` bytes and remains
@@ -1030,6 +1061,22 @@ impl PostMigrationAnnouncer for TapRarpAnnouncer {
                     buf.len(),
                 )
             };
+        }
+
+        if self.guest_announce_negotiated
+            && let Some(interrupt_cb) = &self.interrupt_cb
+        {
+            self.announce_pending.store(true, Ordering::Release);
+
+            interrupt_cb
+                .trigger(VirtioInterruptType::Config)
+                .inspect_err(|e| {
+                    warn!(
+                        "Unable to send interrupt for virtio-net device {}: {e}",
+                        self.id
+                    );
+                })
+                .ok();
         }
     }
 }
@@ -1053,6 +1100,7 @@ mod unit_tests {
             id: "test-net".to_string(),
             taps: Vec::new(),
             config: VirtioNetConfig::default(),
+            announce_pending: Arc::new(AtomicBool::new(false)),
             ctrl_queue_epoll_thread: None,
             counters: NetCounters::default(),
             seccomp_action: SeccompAction::Allow,

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -431,7 +431,88 @@ pub struct NetState {
 // in the Linux kernel's UAPI headers.
 const ETH_FRAME_LEN: usize = 60;
 
+/// Constructor-time copy of the fields needed to initialize the live device
+/// state, derived either from a restored NetState or from fresh defaults.
+struct NetConstructorState {
+    avail_features: u64,
+    acked_features: u64,
+    config: VirtioNetConfig,
+    queue_sizes: Vec<u16>,
+    paused: bool,
+}
+
 impl Net {
+    /// Restores a [`NetConstructorState`] from the provided [`NetState`].
+    fn restored_constructor_state(id: &str, state: NetState) -> NetConstructorState {
+        info!("Restoring virtio-net {id}");
+
+        NetConstructorState {
+            avail_features: state.avail_features,
+            acked_features: state.acked_features,
+            config: state.config,
+            queue_sizes: state.queue_size,
+            paused: true,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    /// Creates a new [`NetConstructorState`].
+    fn fresh_constructor_state(
+        guest_mac: Option<MacAddr>,
+        iommu: bool,
+        mtu: u16,
+        num_queues: usize,
+        queue_size: u16,
+        offload_tso: bool,
+        offload_ufo: bool,
+        offload_csum: bool,
+    ) -> NetConstructorState {
+        let mut avail_features =
+            (1 << VIRTIO_NET_F_MTU) | (1 << VIRTIO_RING_F_EVENT_IDX) | (1 << VIRTIO_F_VERSION_1);
+
+        if iommu {
+            avail_features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;
+        }
+
+        // Configure TSO/UFO features when hardware checksum offload is enabled.
+        if offload_csum {
+            avail_features |= (1 << VIRTIO_NET_F_CSUM)
+                | (1 << VIRTIO_NET_F_GUEST_CSUM)
+                | (1 << VIRTIO_NET_F_CTRL_GUEST_OFFLOADS);
+
+            if offload_tso {
+                avail_features |= (1 << VIRTIO_NET_F_HOST_ECN)
+                    | (1 << VIRTIO_NET_F_HOST_TSO4)
+                    | (1 << VIRTIO_NET_F_HOST_TSO6)
+                    | (1 << VIRTIO_NET_F_GUEST_ECN)
+                    | (1 << VIRTIO_NET_F_GUEST_TSO4)
+                    | (1 << VIRTIO_NET_F_GUEST_TSO6);
+            }
+
+            if offload_ufo {
+                avail_features |= (1 << VIRTIO_NET_F_HOST_UFO) | (1 << VIRTIO_NET_F_GUEST_UFO);
+            }
+        }
+
+        avail_features |= 1 << VIRTIO_NET_F_CTRL_VQ;
+        let queue_num = num_queues + 1;
+
+        let mut config = VirtioNetConfig::default();
+        if let Some(mac) = guest_mac {
+            build_net_config_space(&mut config, mac, num_queues, Some(mtu), &mut avail_features);
+        } else {
+            build_net_config_space_with_mq(&mut config, num_queues, Some(mtu), &mut avail_features);
+        }
+
+        NetConstructorState {
+            avail_features,
+            acked_features: 0,
+            config,
+            queue_sizes: vec![queue_size; queue_num],
+            paused: false,
+        }
+    }
+
     /// Create a new virtio network device with the given TAP interface.
     #[allow(clippy::too_many_arguments)]
     pub fn new_with_tap(
@@ -453,90 +534,35 @@ impl Net {
 
         let mtu = taps[0].mtu().map_err(Error::TapError)? as u16;
 
-        let (avail_features, acked_features, config, queue_sizes, paused) = if let Some(state) =
-            state
-        {
-            info!("Restoring virtio-net {id}");
-            (
-                state.avail_features,
-                state.acked_features,
-                state.config,
-                state.queue_size,
-                true,
-            )
+        let constructor_state = if let Some(state) = state {
+            Self::restored_constructor_state(&id, state)
         } else {
-            let mut avail_features = (1 << VIRTIO_NET_F_MTU)
-                | (1 << VIRTIO_RING_F_EVENT_IDX)
-                | (1 << VIRTIO_F_VERSION_1);
-
-            if iommu {
-                avail_features |= 1u64 << VIRTIO_F_IOMMU_PLATFORM;
-            }
-
-            // Configure TSO/UFO features when hardware checksum offload is enabled.
-            if offload_csum {
-                avail_features |= (1 << VIRTIO_NET_F_CSUM)
-                    | (1 << VIRTIO_NET_F_GUEST_CSUM)
-                    | (1 << VIRTIO_NET_F_CTRL_GUEST_OFFLOADS);
-
-                if offload_tso {
-                    avail_features |= (1 << VIRTIO_NET_F_HOST_ECN)
-                        | (1 << VIRTIO_NET_F_HOST_TSO4)
-                        | (1 << VIRTIO_NET_F_HOST_TSO6)
-                        | (1 << VIRTIO_NET_F_GUEST_ECN)
-                        | (1 << VIRTIO_NET_F_GUEST_TSO4)
-                        | (1 << VIRTIO_NET_F_GUEST_TSO6);
-                }
-
-                if offload_ufo {
-                    avail_features |= (1 << VIRTIO_NET_F_HOST_UFO) | (1 << VIRTIO_NET_F_GUEST_UFO);
-                }
-            }
-
-            avail_features |= 1 << VIRTIO_NET_F_CTRL_VQ;
-            let queue_num = num_queues + 1;
-
-            let mut config = VirtioNetConfig::default();
-            if let Some(mac) = guest_mac {
-                build_net_config_space(
-                    &mut config,
-                    mac,
-                    num_queues,
-                    Some(mtu),
-                    &mut avail_features,
-                );
-            } else {
-                build_net_config_space_with_mq(
-                    &mut config,
-                    num_queues,
-                    Some(mtu),
-                    &mut avail_features,
-                );
-            }
-
-            (
-                avail_features,
-                0,
-                config,
-                vec![queue_size; queue_num],
-                false,
+            Self::fresh_constructor_state(
+                guest_mac,
+                iommu,
+                mtu,
+                num_queues,
+                queue_size,
+                offload_tso,
+                offload_ufo,
+                offload_csum,
             )
         };
 
         Ok(Net {
             common: VirtioCommon {
                 device_type: VirtioDeviceType::Net as u32,
-                avail_features,
-                acked_features,
-                queue_sizes,
+                avail_features: constructor_state.avail_features,
+                acked_features: constructor_state.acked_features,
+                queue_sizes: constructor_state.queue_sizes,
                 paused_sync: Some(Arc::new(Barrier::new((num_queues / 2) + 1))),
                 min_queues: 2,
-                paused: Arc::new(AtomicBool::new(paused)),
+                paused: Arc::new(AtomicBool::new(constructor_state.paused)),
                 ..Default::default()
             },
             id,
             taps,
-            config,
+            config: constructor_state.config,
             ctrl_queue_epoll_thread: None,
             counters: NetCounters::default(),
             seccomp_action,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -16,7 +16,8 @@ use virtio_bindings::virtio_net::{
     VIRTIO_NET_F_CSUM, VIRTIO_NET_F_CTRL_VQ, VIRTIO_NET_F_GUEST_CSUM, VIRTIO_NET_F_GUEST_ECN,
     VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6, VIRTIO_NET_F_GUEST_UFO,
     VIRTIO_NET_F_HOST_ECN, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_TSO6, VIRTIO_NET_F_HOST_UFO,
-    VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF, VIRTIO_NET_F_MTU,
+    VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF, VIRTIO_NET_F_MTU, VIRTIO_NET_F_STATUS,
+    VIRTIO_NET_S_LINK_UP,
 };
 use virtio_bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::{Queue, QueueT};
@@ -93,10 +94,10 @@ impl Net {
         ) = if let Some(state) = state {
             info!("Restoring vhost-user-net {id}");
 
-            // The backend acknowledged features must not contain
-            // VIRTIO_NET_F_MAC since we don't expect the backend
-            // to handle it.
-            let backend_acked_features = state.acked_features & !(1 << VIRTIO_NET_F_MAC);
+            // The backend acknowledged features must not contain frontend-only
+            // bits since we don't expect the backend to handle them.
+            let backend_acked_features =
+                state.acked_features & !((1 << VIRTIO_NET_F_MAC) | (1 << VIRTIO_NET_F_STATUS));
 
             vu.set_protocol_features_vhost_user(
                 backend_acked_features,
@@ -180,9 +181,9 @@ impl Net {
                 num_queues += 1;
             }
 
-            // Make sure the virtio feature to set the MAC address is exposed to
-            // the guest, even if it hasn't been negotiated with the backend.
-            acked_features |= 1 << VIRTIO_NET_F_MAC;
+            // Make sure frontend-owned config-space features stay exposed to
+            // the guest, even if they are not negotiated with the backend.
+            acked_features |= (1 << VIRTIO_NET_F_MAC) | (1 << VIRTIO_NET_F_STATUS);
 
             (
                 acked_features,
@@ -237,6 +238,22 @@ impl Net {
             vu_num_queues: self.vu_common.vu_num_queues,
         }
     }
+
+    /// Return the guest-visible virtio-net config, recomputing `status` from the
+    /// current state of the device.
+    fn config_with_status(&self) -> VirtioNetConfig {
+        let mut config = self.config;
+
+        // We want to recompute the guest-visible status field from the current state of
+        // the device. We clear this field first to avoid showing stale data.
+        config.status = 0;
+
+        if self.common.feature_acked(VIRTIO_NET_F_STATUS.into()) {
+            config.status |= VIRTIO_NET_S_LINK_UP as u16;
+        }
+
+        config
+    }
 }
 
 impl Drop for Net {
@@ -285,7 +302,8 @@ impl VirtioDevice for Net {
     }
 
     fn read_config(&self, offset: u64, data: &mut [u8]) {
-        self.read_config_from_slice(self.config.as_slice(), offset, data);
+        let config = self.config_with_status();
+        self.read_config_from_slice(config.as_slice(), offset, data);
     }
 
     fn activate(
@@ -340,9 +358,10 @@ impl VirtioDevice for Net {
 
         let backend_req_handler: Option<FrontendReqHandler<BackendReqHandler>> = None;
 
-        // The backend acknowledged features must not contain VIRTIO_NET_F_MAC
-        // since we don't expect the backend to handle it.
-        let backend_acked_features = self.common.acked_features & !(1 << VIRTIO_NET_F_MAC);
+        // The backend acknowledged features must not contain frontend-only
+        // bits since we don't expect the backend to handle them.
+        let backend_acked_features =
+            self.common.acked_features & !((1 << VIRTIO_NET_F_MAC) | (1 << VIRTIO_NET_F_STATUS));
 
         // Run a dedicated thread for handling potential reconnections with
         // the backend.
@@ -463,5 +482,53 @@ impl Migratable for Net {
     fn complete_migration(&mut self) -> std::result::Result<(), MigratableError> {
         self.vu_common
             .complete_migration(self.common.kill_evt.take())
+    }
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use std::mem::size_of;
+
+    use seccompiler::SeccompAction;
+    use virtio_bindings::virtio_net::{VIRTIO_NET_F_STATUS, VIRTIO_NET_S_LINK_UP};
+    use vmm_sys_util::eventfd::EventFd;
+
+    use super::*;
+
+    fn test_net(acked_features: u64) -> Net {
+        Net {
+            common: VirtioCommon {
+                acked_features,
+                ..Default::default()
+            },
+            vu_common: VhostUserCommon::default(),
+            id: "test-vu-net".to_string(),
+            config: VirtioNetConfig::default(),
+            guest_memory: None,
+            ctrl_queue_epoll_thread: None,
+            epoll_thread: None,
+            seccomp_action: SeccompAction::Allow,
+            exit_evt: EventFd::new(libc::EFD_NONBLOCK).unwrap(),
+            iommu: false,
+        }
+    }
+
+    const STATUS_OFFSET: usize = std::mem::offset_of!(VirtioNetConfig, status);
+    fn read_status(device: &Net) -> u16 {
+        let mut data = vec![0; size_of::<VirtioNetConfig>()];
+        device.read_config(0, &mut data);
+
+        u16::from_le_bytes(
+            data[STATUS_OFFSET..STATUS_OFFSET + size_of::<u16>()]
+                .try_into()
+                .unwrap(),
+        )
+    }
+
+    #[test]
+    fn test_status_feature_reports_link_up() {
+        let net = test_net(1 << VIRTIO_NET_F_STATUS);
+
+        assert_eq!(read_status(&net), VIRTIO_NET_S_LINK_UP as u16);
     }
 }

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -571,21 +571,51 @@ impl PostMigrationAnnouncer for VhostUserNetPostMigrationAnnouncer {
         }
     }
 }
-
 #[cfg(test)]
 mod unit_tests {
     use std::mem::size_of;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     use seccompiler::SeccompAction;
-    use virtio_bindings::virtio_net::{VIRTIO_NET_F_STATUS, VIRTIO_NET_S_LINK_UP};
+    use virtio_bindings::virtio_net::{
+        VIRTIO_NET_F_GUEST_ANNOUNCE, VIRTIO_NET_F_STATUS, VIRTIO_NET_S_ANNOUNCE,
+        VIRTIO_NET_S_LINK_UP,
+    };
     use vmm_sys_util::eventfd::EventFd;
 
     use super::*;
+    use crate::device::{VirtioInterrupt, VirtioInterruptType};
 
-    fn test_net(acked_features: u64) -> Net {
+    struct TestInterrupt {
+        config_count: AtomicUsize,
+    }
+
+    impl TestInterrupt {
+        fn new() -> Self {
+            Self {
+                config_count: AtomicUsize::new(0),
+            }
+        }
+    }
+
+    impl VirtioInterrupt for TestInterrupt {
+        fn trigger(
+            &self,
+            int_type: VirtioInterruptType,
+        ) -> std::result::Result<(), std::io::Error> {
+            if matches!(int_type, VirtioInterruptType::Config) {
+                self.config_count.fetch_add(1, Ordering::AcqRel);
+            }
+            Ok(())
+        }
+    }
+
+    fn test_net(acked_features: u64, interrupt_cb: Option<Arc<dyn VirtioInterrupt>>) -> Net {
         Net {
             common: VirtioCommon {
                 acked_features,
+                interrupt_cb,
                 ..Default::default()
             },
             vu_common: VhostUserCommon::default(),
@@ -615,8 +645,76 @@ mod unit_tests {
 
     #[test]
     fn test_status_feature_reports_link_up() {
-        let net = test_net(1 << VIRTIO_NET_F_STATUS);
+        let net = test_net(1 << VIRTIO_NET_F_STATUS, None);
 
         assert_eq!(read_status(&net), VIRTIO_NET_S_LINK_UP as u16);
+    }
+
+    #[test]
+    fn test_post_migration_sets_announce_and_triggers_config() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let net = test_net(
+            (1 << VIRTIO_NET_F_GUEST_ANNOUNCE) | (1 << VIRTIO_NET_F_STATUS),
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+
+        net.post_migration_announcer().unwrap().announce();
+
+        assert!(net.announce_pending.load(Ordering::Acquire));
+        assert_ne!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn test_frontend_avail_features_expose_guest_announce_and_status() {
+        let avail_features = Net::frontend_avail_features(1 << VIRTIO_NET_F_CTRL_VQ);
+
+        assert_ne!(avail_features & (1 << VIRTIO_NET_F_MAC), 0);
+        assert_ne!(avail_features & (1 << VIRTIO_NET_F_STATUS), 0);
+        assert_ne!(avail_features & (1 << VIRTIO_NET_F_GUEST_ANNOUNCE), 0);
+    }
+
+    #[test]
+    fn test_post_migration_without_feature_is_noop() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let net = test_net(0, Some(interrupt.clone() as Arc<dyn VirtioInterrupt>));
+
+        net.post_migration_announcer().unwrap().announce();
+
+        assert!(!net.announce_pending.load(Ordering::Acquire));
+        assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_post_migration_with_ctrl_vq_but_without_guest_announce_is_noop() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let net = test_net(
+            1 << VIRTIO_NET_F_CTRL_VQ,
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+
+        net.post_migration_announcer().unwrap().announce();
+
+        assert!(!net.announce_pending.load(Ordering::Acquire));
+        assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_reset_clears_pending_announce() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let mut net = test_net(
+            (1 << VIRTIO_NET_F_GUEST_ANNOUNCE) | (1 << VIRTIO_NET_F_STATUS),
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+
+        net.post_migration_announcer().unwrap().announce();
+        assert!(net.announce_pending.load(Ordering::Acquire));
+
+        let _ = net.reset();
+
+        assert!(!net.announce_pending.load(Ordering::Acquire));
+        assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
     }
 }

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -1,23 +1,23 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{result, thread};
 
 use event_monitor::event;
-use log::{error, info};
+use log::{error, info, warn};
 use net_util::{CtrlQueue, MacAddr, VirtioNetConfig, build_net_config_space};
 use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use vhost::vhost_user::message::{VhostUserProtocolFeatures, VhostUserVirtioFeatures};
 use vhost::vhost_user::{FrontendReqHandler, VhostUserFrontend, VhostUserFrontendReqHandler};
 use virtio_bindings::virtio_net::{
-    VIRTIO_NET_F_CSUM, VIRTIO_NET_F_CTRL_VQ, VIRTIO_NET_F_GUEST_CSUM, VIRTIO_NET_F_GUEST_ECN,
-    VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6, VIRTIO_NET_F_GUEST_UFO,
-    VIRTIO_NET_F_HOST_ECN, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_TSO6, VIRTIO_NET_F_HOST_UFO,
-    VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF, VIRTIO_NET_F_MTU, VIRTIO_NET_F_STATUS,
-    VIRTIO_NET_S_LINK_UP,
+    VIRTIO_NET_F_CSUM, VIRTIO_NET_F_CTRL_VQ, VIRTIO_NET_F_GUEST_ANNOUNCE, VIRTIO_NET_F_GUEST_CSUM,
+    VIRTIO_NET_F_GUEST_ECN, VIRTIO_NET_F_GUEST_TSO4, VIRTIO_NET_F_GUEST_TSO6,
+    VIRTIO_NET_F_GUEST_UFO, VIRTIO_NET_F_HOST_ECN, VIRTIO_NET_F_HOST_TSO4, VIRTIO_NET_F_HOST_TSO6,
+    VIRTIO_NET_F_HOST_UFO, VIRTIO_NET_F_MAC, VIRTIO_NET_F_MRG_RXBUF, VIRTIO_NET_F_MTU,
+    VIRTIO_NET_F_STATUS, VIRTIO_NET_S_ANNOUNCE, VIRTIO_NET_S_LINK_UP,
 };
 use virtio_bindings::virtio_ring::VIRTIO_RING_F_EVENT_IDX;
 use virtio_queue::{Queue, QueueT};
@@ -31,17 +31,20 @@ use crate::thread_helper::spawn_virtio_thread;
 use crate::vhost_user::vu_common_ctrl::{VhostUserConfig, VhostUserHandle};
 use crate::vhost_user::{DEFAULT_VIRTIO_FEATURES, Error, Result, VhostUserCommon};
 use crate::{
-    ActivateResult, GuestMemoryMmap, GuestRegionMmap, NetCtrlEpollHandler, VIRTIO_F_IOMMU_PLATFORM,
-    VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioInterrupt,
+    ActivateResult, GuestMemoryMmap, GuestRegionMmap, NetCtrlEpollHandler, PostMigrationAnnouncer,
+    VIRTIO_F_IOMMU_PLATFORM, VirtioCommon, VirtioDevice, VirtioDeviceType, VirtioInterrupt,
 };
 
 const DEFAULT_QUEUE_NUMBER: usize = 2;
 
 #[derive(Serialize, Deserialize)]
+/// Serialized snapshot of the device state. The fields are copied from the
+/// live device when snapshotting and restored back into a new device instance.
 pub struct State {
     pub avail_features: u64,
     pub acked_features: u64,
     pub config: VirtioNetConfig,
+    pub announce_pending: bool,
     pub acked_protocol_features: u64,
     pub vu_num_queues: usize,
 }
@@ -54,6 +57,9 @@ pub struct Net {
     vu_common: VhostUserCommon,
     id: String,
     config: VirtioNetConfig,
+    /// Tracks whether the guest still needs to acknowledge a post-migration
+    /// announce request through the control queue.
+    announce_pending: Arc<AtomicBool>,
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     ctrl_queue_epoll_thread: Option<thread::JoinHandle<()>>,
     epoll_thread: Option<thread::JoinHandle<()>>,
@@ -63,6 +69,23 @@ pub struct Net {
 }
 
 impl Net {
+    /// Derive the guest-visible feature set from the backend-negotiated
+    /// features plus frontend-only bits that Cloud Hypervisor implements
+    /// locally, such as `VIRTIO_NET_F_MAC`, `VIRTIO_NET_F_STATUS`, and
+    /// `VIRTIO_NET_F_GUEST_ANNOUNCE`.
+    fn frontend_avail_features(backend_acked_features: u64) -> u64 {
+        let mut guest_avail_features = backend_acked_features | (1 << VIRTIO_NET_F_MAC);
+
+        // Guest announce is implemented by the frontend through config
+        // changes and the locally handled control queue.
+        if guest_avail_features & (1 << VIRTIO_NET_F_CTRL_VQ) != 0 {
+            guest_avail_features |= 1 << VIRTIO_NET_F_STATUS;
+            guest_avail_features |= 1 << VIRTIO_NET_F_GUEST_ANNOUNCE;
+        }
+
+        guest_avail_features
+    }
+
     /// Create a new vhost-user-net device
     #[allow(clippy::too_many_arguments)]
     pub fn new(
@@ -90,14 +113,17 @@ impl Net {
             acked_protocol_features,
             vu_num_queues,
             config,
+            announce_pending,
             paused,
         ) = if let Some(state) = state {
             info!("Restoring vhost-user-net {id}");
 
             // The backend acknowledged features must not contain frontend-only
             // bits since we don't expect the backend to handle them.
-            let backend_acked_features =
-                state.acked_features & !((1 << VIRTIO_NET_F_MAC) | (1 << VIRTIO_NET_F_STATUS));
+            let backend_acked_features = state.acked_features
+                & !((1 << VIRTIO_NET_F_MAC)
+                    | (1 << VIRTIO_NET_F_STATUS)
+                    | (1 << VIRTIO_NET_F_GUEST_ANNOUNCE));
 
             vu.set_protocol_features_vhost_user(
                 backend_acked_features,
@@ -116,12 +142,14 @@ impl Net {
                 state.acked_protocol_features,
                 state.vu_num_queues,
                 state.config,
+                state.announce_pending,
                 true,
             )
         } else {
             // Filling device and vring features VMM supports.
             let mut avail_features = (1 << VIRTIO_NET_F_MRG_RXBUF)
                 | (1 << VIRTIO_NET_F_CTRL_VQ)
+                | (1 << VIRTIO_NET_F_GUEST_ANNOUNCE)
                 | DEFAULT_VIRTIO_FEATURES;
 
             if mtu.is_some() {
@@ -155,7 +183,7 @@ impl Net {
                 | VhostUserProtocolFeatures::INFLIGHT_SHMFD
                 | VhostUserProtocolFeatures::LOG_SHMFD;
 
-            let (mut acked_features, acked_protocol_features) =
+            let (acked_features, acked_protocol_features) =
                 vu.negotiate_features_vhost_user(avail_features, avail_protocol_features)?;
 
             let backend_num_queues =
@@ -181,12 +209,12 @@ impl Net {
                 num_queues += 1;
             }
 
-            // Make sure frontend-owned config-space features stay exposed to
-            // the guest, even if they are not negotiated with the backend.
-            acked_features |= (1 << VIRTIO_NET_F_MAC) | (1 << VIRTIO_NET_F_STATUS);
+            // Build the feature set that gets exposed to the guest. Some frontend available
+            // features are dependent on the features the backend supports.
+            let guest_avail_features = Self::frontend_avail_features(acked_features);
 
             (
-                acked_features,
+                guest_avail_features,
                 // If part of the available features that have been acked,
                 // the PROTOCOL_FEATURES bit must be already set through
                 // the VIRTIO acked features as we know the guest would
@@ -195,6 +223,7 @@ impl Net {
                 acked_protocol_features,
                 vu_num_queues,
                 config,
+                false,
                 false,
             )
         };
@@ -220,6 +249,7 @@ impl Net {
                 ..Default::default()
             },
             config,
+            announce_pending: Arc::new(AtomicBool::new(announce_pending)),
             guest_memory: None,
             ctrl_queue_epoll_thread: None,
             epoll_thread: None,
@@ -234,6 +264,7 @@ impl Net {
             avail_features: self.common.avail_features,
             acked_features: self.common.acked_features,
             config: self.config,
+            announce_pending: self.announce_pending.load(Ordering::Acquire),
             acked_protocol_features: self.vu_common.acked_protocol_features,
             vu_num_queues: self.vu_common.vu_num_queues,
         }
@@ -250,6 +281,10 @@ impl Net {
 
         if self.common.feature_acked(VIRTIO_NET_F_STATUS.into()) {
             config.status |= VIRTIO_NET_S_LINK_UP as u16;
+
+            if self.announce_pending.load(Ordering::Acquire) {
+                config.status |= VIRTIO_NET_S_ANNOUNCE as u16;
+            }
         }
 
         config
@@ -329,7 +364,7 @@ impl VirtioDevice for Net {
                 mem: mem.clone(),
                 kill_evt,
                 pause_evt,
-                ctrl_q: CtrlQueue::new(Vec::new()),
+                ctrl_q: CtrlQueue::new(Vec::new(), Arc::clone(&self.announce_pending)),
                 queue: ctrl_queue,
                 queue_evt: ctrl_queue_evt,
                 access_platform: None,
@@ -359,9 +394,11 @@ impl VirtioDevice for Net {
         let backend_req_handler: Option<FrontendReqHandler<BackendReqHandler>> = None;
 
         // The backend acknowledged features must not contain frontend-only
-        // bits since we don't expect the backend to handle them.
-        let backend_acked_features =
-            self.common.acked_features & !((1 << VIRTIO_NET_F_MAC) | (1 << VIRTIO_NET_F_STATUS));
+        // features since we don't expect the backend to handle them.
+        let backend_acked_features = self.common.acked_features
+            & !((1 << VIRTIO_NET_F_MAC)
+                | (1 << VIRTIO_NET_F_STATUS)
+                | (1 << VIRTIO_NET_F_GUEST_ANNOUNCE));
 
         // Run a dedicated thread for handling potential reconnections with
         // the backend.
@@ -395,6 +432,7 @@ impl VirtioDevice for Net {
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+        self.announce_pending.store(false, Ordering::Release);
         // We first must resume the virtio thread if it was paused.
         if self.common.pause_evt.take().is_some() {
             self.common.resume().ok()?;
@@ -420,6 +458,10 @@ impl VirtioDevice for Net {
 
     fn shutdown(&mut self) {
         self.vu_common.shutdown();
+    }
+
+    fn post_migration_announcer(&self) -> Option<Box<dyn PostMigrationAnnouncer>> {
+        Some(Box::new(VhostUserNetPostMigrationAnnouncer::new(self)))
     }
 
     fn add_memory_region(
@@ -485,6 +527,51 @@ impl Migratable for Net {
     }
 }
 
+/// Announces this vhost-user-net device on the network.
+/// Most fields are cloned references to device state so retry rounds can run
+/// without borrowing the device itself.
+pub struct VhostUserNetPostMigrationAnnouncer {
+    id: String,
+    /// Remembers whether this device negotiated the guest-visible announce path.
+    guest_announce_negotiated: bool,
+    announce_pending: Arc<AtomicBool>,
+    interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
+}
+
+impl VhostUserNetPostMigrationAnnouncer {
+    pub fn new(dev: &Net) -> Self {
+        Self {
+            id: dev.id.clone(),
+            guest_announce_negotiated: dev.common.feature_acked(VIRTIO_NET_F_GUEST_ANNOUNCE.into()),
+            announce_pending: Arc::clone(&dev.announce_pending),
+            interrupt_cb: dev.common.interrupt_cb.clone(),
+        }
+    }
+}
+
+impl PostMigrationAnnouncer for VhostUserNetPostMigrationAnnouncer {
+    // Vhost-user-net relies on the guest-visible announce path: mark the
+    // request pending and re-trigger the config interrupt while this retry
+    // session remains valid.
+    fn announce(&mut self) {
+        if self.guest_announce_negotiated
+            && let Some(interrupt_cb) = &self.interrupt_cb
+        {
+            self.announce_pending.store(true, Ordering::Release);
+
+            interrupt_cb
+                .trigger(crate::VirtioInterruptType::Config)
+                .inspect_err(|e| {
+                    warn!(
+                        "Unable to send interrupt for virtio-net device {}: {e}",
+                        self.id
+                    );
+                })
+                .ok();
+        }
+    }
+}
+
 #[cfg(test)]
 mod unit_tests {
     use std::mem::size_of;
@@ -504,6 +591,7 @@ mod unit_tests {
             vu_common: VhostUserCommon::default(),
             id: "test-vu-net".to_string(),
             config: VirtioNetConfig::default(),
+            announce_pending: Arc::new(AtomicBool::new(false)),
             guest_memory: None,
             ctrl_queue_epoll_thread: None,
             epoll_thread: None,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -1,7 +1,7 @@
 // Copyright 2019 Intel Corporation. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier, Mutex};
 use std::{result, thread};
 
@@ -64,6 +64,9 @@ pub struct Net {
     /// Tracks whether the guest still needs to acknowledge a post-migration
     /// announce request through the control queue.
     announce_pending: Arc<AtomicBool>,
+    /// Generation counter used to invalidate active announcers created before a
+    /// reset or device teardown, so they stop sending notifications.
+    announce_generation: Arc<AtomicU64>,
     guest_memory: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     ctrl_queue_epoll_thread: Option<thread::JoinHandle<()>>,
     epoll_thread: Option<thread::JoinHandle<()>>,
@@ -254,6 +257,7 @@ impl Net {
             },
             config,
             announce_pending: Arc::new(AtomicBool::new(announce_pending)),
+            announce_generation: Arc::new(AtomicU64::new(0)),
             guest_memory: None,
             ctrl_queue_epoll_thread: None,
             epoll_thread: None,
@@ -318,6 +322,8 @@ impl Net {
 
 impl Drop for Net {
     fn drop(&mut self) {
+        self.announce_generation.fetch_add(1, Ordering::AcqRel);
+
         if let Some(kill_evt) = self.common.kill_evt.take()
             && let Err(e) = kill_evt.write(1)
         {
@@ -459,6 +465,7 @@ impl VirtioDevice for Net {
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
         self.announce_pending.store(false, Ordering::Release);
+        self.announce_generation.fetch_add(1, Ordering::AcqRel);
         // We first must resume the virtio thread if it was paused.
         if self.common.pause_evt.take().is_some() {
             self.common.resume().ok()?;
@@ -561,6 +568,10 @@ pub struct VhostUserNetPostMigrationAnnouncer {
     /// Remembers whether this device negotiated the guest-visible announce path.
     guest_announce_negotiated: bool,
     announce_pending: Arc<AtomicBool>,
+    announce_generation: Arc<AtomicU64>,
+    /// Captures the announce generation at creation time to invalidate stale
+    /// retry sessions after reset or teardown.
+    generation: u64,
     interrupt_cb: Option<Arc<dyn VirtioInterrupt>>,
 }
 
@@ -570,6 +581,8 @@ impl VhostUserNetPostMigrationAnnouncer {
             id: dev.id.clone(),
             guest_announce_negotiated: dev.common.feature_acked(VIRTIO_NET_F_GUEST_ANNOUNCE.into()),
             announce_pending: Arc::clone(&dev.announce_pending),
+            announce_generation: Arc::clone(&dev.announce_generation),
+            generation: dev.announce_generation.load(Ordering::Acquire),
             interrupt_cb: dev.common.interrupt_cb.clone(),
         }
     }
@@ -580,6 +593,11 @@ impl PostMigrationAnnouncer for VhostUserNetPostMigrationAnnouncer {
     // request pending and re-trigger the config interrupt while this retry
     // session remains valid.
     fn announce(&mut self) {
+        // If the announce generations don't match, we don't send any announcements.
+        if self.announce_generation.load(Ordering::Acquire) != self.generation {
+            return;
+        }
+
         if self.guest_announce_negotiated
             && let Some(interrupt_cb) = &self.interrupt_cb
         {
@@ -648,6 +666,7 @@ mod unit_tests {
             id: "test-vu-net".to_string(),
             config: VirtioNetConfig::default(),
             announce_pending: Arc::new(AtomicBool::new(false)),
+            announce_generation: Arc::new(AtomicU64::new(0)),
             guest_memory: None,
             ctrl_queue_epoll_thread: None,
             epoll_thread: None,
@@ -758,6 +777,47 @@ mod unit_tests {
 
         assert!(!net.announce_pending.load(Ordering::Acquire));
         assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+    }
+
+    #[test]
+    fn test_reset_invalidates_old_announcer() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let mut net = test_net(
+            1 << VIRTIO_NET_F_GUEST_ANNOUNCE,
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+        let mut announcer = net.post_migration_announcer().unwrap();
+
+        announcer.announce();
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
+
+        let _ = net.reset();
+        announcer.announce();
+
+        assert!(!net.announce_pending.load(Ordering::Acquire));
+        assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
+    }
+
+    #[test]
+    fn test_drop_invalidates_old_announcer() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let mut announcer = {
+            let net = test_net(
+                1 << VIRTIO_NET_F_GUEST_ANNOUNCE,
+                Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+            );
+            let mut announcer = net.post_migration_announcer().unwrap();
+
+            announcer.announce();
+            assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
+
+            announcer
+        };
+
+        announcer.announce();
+
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
     }
 
     #[test]

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -293,6 +293,27 @@ impl Net {
 
         config
     }
+
+    /// Re-notify the guest about a restored pending ANNOUNCE request once the
+    /// transport has installed an interrupt callback during activation.
+    fn notify_pending_guest_announce(&self) {
+        if self.announce_pending.load(Ordering::Acquire)
+            && self
+                .common
+                .feature_acked(VIRTIO_NET_F_GUEST_ANNOUNCE.into())
+            && let Some(interrupt_cb) = &self.common.interrupt_cb
+        {
+            interrupt_cb
+                .trigger(crate::VirtioInterruptType::Config)
+                .inspect_err(|e| {
+                    warn!(
+                        "Unable to resend pending announce interrupt for virtio-net device {}: {e}",
+                        self.id
+                    );
+                })
+                .ok();
+        }
+    }
 }
 
 impl Drop for Net {
@@ -432,6 +453,7 @@ impl VirtioDevice for Net {
         )?;
         self.epoll_thread = Some(epoll_threads.remove(0));
 
+        self.notify_pending_guest_announce();
         Ok(())
     }
 
@@ -688,6 +710,22 @@ mod unit_tests {
         assert!(!net.announce_pending.load(Ordering::Acquire));
         assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
         assert_eq!(interrupt.config_count.load(Ordering::Acquire), 0);
+    }
+
+    #[test]
+    fn test_restored_pending_announce_retriggers_config_interrupt() {
+        let interrupt = Arc::new(TestInterrupt::new());
+        let net = test_net(
+            (1 << VIRTIO_NET_F_GUEST_ANNOUNCE) | (1 << VIRTIO_NET_F_STATUS),
+            Some(interrupt.clone() as Arc<dyn VirtioInterrupt>),
+        );
+        net.announce_pending.store(true, Ordering::Release);
+
+        net.notify_pending_guest_announce();
+
+        assert!(net.announce_pending.load(Ordering::Acquire));
+        assert_ne!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+        assert_eq!(interrupt.config_count.load(Ordering::Acquire), 1);
     }
 
     #[test]

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -40,10 +40,14 @@ const DEFAULT_QUEUE_NUMBER: usize = 2;
 #[derive(Serialize, Deserialize)]
 /// Serialized snapshot of the device state. The fields are copied from the
 /// live device when snapshotting and restored back into a new device instance.
+///
+/// Fields not present in previous versions are tagged with `#[serde(default)]`
+/// to allow deserialization if the field is not present.
 pub struct State {
     pub avail_features: u64,
     pub acked_features: u64,
     pub config: VirtioNetConfig,
+    #[serde(default)]
     pub announce_pending: bool,
     pub acked_protocol_features: u64,
     pub vu_num_queues: usize,
@@ -716,5 +720,26 @@ mod unit_tests {
 
         assert!(!net.announce_pending.load(Ordering::Acquire));
         assert_eq!(read_status(&net) & VIRTIO_NET_S_ANNOUNCE as u16, 0);
+    }
+
+    #[test]
+    fn test_state_deserialize_without_announce_pending_defaults_to_false() {
+        // Older snapshots do not contain announce_pending. Restoring them on a
+        // newer binary must treat the missing field as "no announce pending".
+        let state = State {
+            avail_features: 1,
+            acked_features: 2,
+            config: VirtioNetConfig::default(),
+            announce_pending: true,
+            acked_protocol_features: 3,
+            vu_num_queues: 4,
+        };
+        let mut value = serde_json::to_value(state).unwrap();
+
+        value.as_object_mut().unwrap().remove("announce_pending");
+
+        let restored: State = serde_json::from_value(value).unwrap();
+
+        assert!(!restored.announce_pending);
     }
 }


### PR DESCRIPTION
## Overview

This PR enables the `VIRTIO_NET_F_GUEST_ANNOUNCE` feature, where the guest announces itself after a live migration. The old RARP announcements are only a fallback, in case the guest driver does not negotiate `VIRTIO_NET_F_GUEST_ANNOUNCE`.

## New Behavior

- after each live migration, a virtio-net device now sends RARP announcements, and instructs the guest to announce itself (if this feature was negotiated)
- if we migrate from a CHV that does not support this to one that supports it, the feature stays disabled until the device and driver negotiate features again (e.g. when the VM is restarted)
- after a restore, the guest will receive a config interrupt if there was a announce pending
- added `announce_generation`:
  - if the driver resets the device while the announcer thread is running, we want to stop those announcements
  - otherwise, this could confuse the driver
  - thus, we increase this timer on every reset, and when the device is dropped (otherwise we would send announcements for a device that has been dropped)

## Tests

The tests are currently being built. 