### PR TITLE
massively improve error messages for failed migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "epoll",
  "event_monitor",
  "hypervisor",
+ "jiff",
  "libc",
  "log",
  "net_util",
@@ -1248,22 +1249,23 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.20"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c867c356cc096b33f4981825ab281ecba3db0acefe60329f044c1789d94c6543"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.20"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7946b4325269738f270bb55b3c19ab5c5040525f83fd625259422a9d25d9be5"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,10 @@ env_logger = "0.11.8"
 epoll = "4.4.0"
 flume = "0.12.0"
 itertools = "0.14.0"
+jiff = { version = "0.2.23", default-features = false, features = [
+  "std",
+  "tz-system",
+] }
 libc = "0.2.182"
 log = "0.4.29"
 rustls = "0.23.34"

--- a/cloud-hypervisor/Cargo.toml
+++ b/cloud-hypervisor/Cargo.toml
@@ -26,6 +26,7 @@ env_logger = { workspace = true }
 epoll = { workspace = true }
 event_monitor = { path = "../event_monitor" }
 hypervisor = { path = "../hypervisor" }
+jiff = { workspace = true }
 libc = { workspace = true }
 log = { workspace = true, features = ["std"] }
 option_parser = { path = "../option_parser" }

--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -696,6 +696,11 @@ fn start_vmm(cmd_arguments: &ArgMatches) -> Result<Option<String>, Error> {
         .map_err(Error::EventMonitorThread)?;
     }
 
+    info!(
+        "Cloud Hypervisor starting: build version: {}, date: {}",
+        env!("BUILD_VERSION"),
+        jiff::Zoned::now().strftime("%Y-%m-%dT%H:%M:%S%.f%:z")
+    );
     event!("vmm", "starting");
 
     let vmm_thread_handle = vmm::start_vmm_thread(

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3086,6 +3086,37 @@ impl Vmm {
         self.vm.vm_mut().unwrap().restore()
     }
 
+    /// Prints the error chain to `error!()` level, akin to user-facing errors when Cloud Hypervisor
+    /// or ch-remote fail.
+    // TODO: For upstreaming, we should unify this with the code-paths used by ch-remote and
+    // Cloud Hypervisor on failure.
+    fn log_print_error_chain<'a>(top_error: &'a (dyn std::error::Error + 'static)) {
+        // Print chain of errors
+        if top_error.source().is_none() {
+            error!("Migration failed with the following error:");
+            error!("  {top_error}");
+        } else {
+            // In cli_print_error_chain(), we also print the
+            // <top_err as Debug>::fmt() as oneliner so that we can see all
+            // properties. As we use anyhow errors in the migration path,
+            // Debug::fmt() is not helpful for us as it doesn't print the
+            // underlying properties (like the default Debug::fmt() impl would
+            // do). Instead, it would print a trace itself, which is not what
+            // we want to do here.
+
+            error!("Migration failed with the following chain of errors:");
+            std::iter::successors(Some(top_error), |sub_error| {
+                // Dereference necessary to mitigate rustc compiler bug.
+                // See <https://github.com/rust-lang/rust/issues/141673>
+                (*sub_error).source()
+            })
+            .enumerate()
+            .for_each(|(level, error)| {
+                error!("  {level}: {error}");
+            });
+        }
+    }
+
     /// Checks the migration result.
     ///
     /// This should be called when the migration thread indicated a state
@@ -3187,7 +3218,7 @@ impl Vmm {
                 }
             }
             Err(e) => {
-                error!("Migration failed: {e}");
+                Self::log_print_error_chain(&e);
                 event!("vm", "migration-failed");
                 try_resume_vm(vm);
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2910,8 +2910,20 @@ impl Vmm {
 
         // We release the locks early to enable locking them on the destination host.
         // The VM is already stopped.
-        vm.release_disk_locks()
-            .map_err(|e| MigratableError::UnlockError(anyhow!("{e}")))?;
+        match vm.release_disk_locks() {
+            Ok(()) => {}
+            Err(vm::Error::LockingError(e)) => {
+                // Preserve the error chain
+                return Err(MigratableError::UnlockError(anyhow!(e)));
+            }
+            // Unlikely, as the function only returns the variant above
+            Err(e) => {
+                // Because the underlying error is not Sync, we can't preserve the
+                // chain of errors here. Therefore, we at least print the display
+                // and debug representations for max debug information.
+                return Err(MigratableError::UnlockError(anyhow!("{e}: {e:?}")));
+            }
+        }
 
         #[cfg(feature = "kvm")]
         // Prevent signal handler to access thread local storage when signals are received


### PR DESCRIPTION
This massively improves the error messages for failed migrations, both for sender and receiver. There were many low-hanging fruits. I do not think that anything here is critical and can be shipped as is.

Please review this commit by commit.

CI pipeline: https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/merge_requests/157/pipelines