### PR TITLE
vmm: fix CpuManager deadlock between pause handling and MMIO

### DIFF
--- a/vm-device/src/bus.rs
+++ b/vm-device/src/bus.rs
@@ -147,6 +147,9 @@ impl Bus {
         None
     }
 
+    /// Inserts a bus device into the bus.
+    ///
+    /// The bus will only hold a weak reference to the object.
     #[allow(clippy::needless_pass_by_value)]
     pub fn insert(&self, device: Arc<dyn BusDeviceSync>, base: u64, len: u64) -> Result<()> {
         if len == 0 {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -631,7 +631,7 @@ pub struct CpuManager {
     reset_evt: EventFd,
     #[cfg(feature = "guest_debug")]
     vm_debug_evt: EventFd,
-    vcpu_states: Vec<VcpuState>,
+    vcpu_states: Arc<Mutex<Vec<VcpuState>>>,
     selected_cpu: u32,
     vcpus: Vec<Arc<Mutex<Vcpu>>>,
     seccomp_action: SeccompAction,
@@ -658,6 +658,7 @@ impl BusDevice for CpuManager {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
         // The Linux kernel, quite reasonably, doesn't zero the memory it gives us.
         data.fill(0);
+        let vcpu_states = self.vcpu_states.lock().unwrap();
 
         match offset {
             CPU_SELECTION_OFFSET => {
@@ -667,7 +668,7 @@ impl BusDevice for CpuManager {
             }
             CPU_STATUS_OFFSET => {
                 if self.selected_cpu < self.max_vcpus() {
-                    let state = &self.vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+                    let state = &vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
                     if state.active() {
                         data[0] |= 1 << CPU_ENABLE_FLAG;
                     }
@@ -696,23 +697,28 @@ impl BusDevice for CpuManager {
             }
             CPU_STATUS_OFFSET => {
                 if self.selected_cpu < self.max_vcpus() {
-                    let state = &mut self.vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
-                    // The ACPI code writes back a 1 to acknowledge the insertion
-                    if (data[0] & (1 << CPU_INSERTING_FLAG) == 1 << CPU_INSERTING_FLAG)
-                        && state.inserting
-                    {
-                        state.inserting = false;
-                    }
-                    // Ditto for removal
-                    if (data[0] & (1 << CPU_REMOVING_FLAG) == 1 << CPU_REMOVING_FLAG)
-                        && state.removing
-                    {
-                        state.removing = false;
-                    }
-                    // Trigger removal of vCPU
-                    if data[0] & (1 << CPU_EJECT_FLAG) == 1 << CPU_EJECT_FLAG
-                        && let Err(e) = self.remove_vcpu(self.selected_cpu)
-                    {
+                    let eject = {
+                        // This structure is not shared with the vCPU thread, therefore, holding the
+                        // lock for the entire function doesn't cause any deadlock.
+                        let mut vcpu_states = self.vcpu_states.lock().unwrap();
+                        let state = &mut vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+
+                        if (data[0] & (1 << CPU_INSERTING_FLAG) == 1 << CPU_INSERTING_FLAG)
+                            && state.inserting
+                        {
+                            state.inserting = false;
+                        }
+
+                        if (data[0] & (1 << CPU_REMOVING_FLAG) == 1 << CPU_REMOVING_FLAG)
+                            && state.removing
+                        {
+                            state.removing = false;
+                        }
+
+                        data[0] & (1 << CPU_EJECT_FLAG) == 1 << CPU_EJECT_FLAG
+                    };
+
+                    if eject && let Err(e) = self.remove_vcpu(self.selected_cpu) {
                         error!("Error removing vCPU: {e:?}");
                     }
                 } else {
@@ -846,6 +852,7 @@ impl CpuManager {
         let max_vcpus = usize::try_from(config.max_vcpus).unwrap();
         let mut vcpu_states = Vec::with_capacity(max_vcpus);
         vcpu_states.resize_with(max_vcpus, VcpuState::default);
+        let vcpu_states = Arc::new(Mutex::new(vcpu_states));
         let hypervisor_type = hypervisor.hypervisor_type();
         #[cfg(target_arch = "x86_64")]
         let cpu_vendor = hypervisor.get_cpu_vendor();
@@ -1191,14 +1198,14 @@ impl CpuManager {
         let vcpus_pause_signalled = self.vcpus_pause_signalled.clone();
         let vcpus_kick_signalled = self.vcpus_kick_signalled.clone();
 
-        let vcpu_kill = self.vcpu_states[usize::try_from(vcpu_id).unwrap()]
-            .kill
-            .clone();
-        let vcpu_run_interrupted = self.vcpu_states[usize::try_from(vcpu_id).unwrap()]
+        let mut vcpu_states = self.vcpu_states.lock().unwrap();
+
+        let vcpu_kill = vcpu_states[usize::try_from(vcpu_id).unwrap()].kill.clone();
+        let vcpu_run_interrupted = vcpu_states[usize::try_from(vcpu_id).unwrap()]
             .vcpu_run_interrupted
             .clone();
         let panic_vcpu_run_interrupted = vcpu_run_interrupted.clone();
-        let vcpu_paused = self.vcpu_states[usize::try_from(vcpu_id).unwrap()]
+        let vcpu_paused = vcpu_states[usize::try_from(vcpu_id).unwrap()]
             .paused
             .clone();
 
@@ -1473,8 +1480,8 @@ impl CpuManager {
 
         // On hot plug calls into this function entry_point is None. It is for
         // those hotplug CPU additions that we need to set the inserting flag.
-        self.vcpu_states[usize::try_from(vcpu_id).unwrap()].handle = handle;
-        self.vcpu_states[usize::try_from(vcpu_id).unwrap()].inserting = inserting;
+        vcpu_states[usize::try_from(vcpu_id).unwrap()].handle = handle;
+        vcpu_states[usize::try_from(vcpu_id).unwrap()].inserting = inserting;
 
         Ok(())
     }
@@ -1518,17 +1525,19 @@ impl CpuManager {
     }
 
     fn mark_vcpus_for_removal(&mut self, desired_vcpus: u32) {
+        let mut vcpu_states = self.vcpu_states.lock().unwrap();
+
         // Mark vCPUs for removal, actual removal happens on ejection
         for cpu_id in desired_vcpus..self.present_vcpus() {
-            self.vcpu_states[usize::try_from(cpu_id).unwrap()].removing = true;
-            self.vcpu_states[usize::try_from(cpu_id).unwrap()]
+            vcpu_states[usize::try_from(cpu_id).unwrap()].removing = true;
+            vcpu_states[usize::try_from(cpu_id).unwrap()]
                 .pending_removal
                 .store(true, Ordering::SeqCst);
         }
     }
 
     pub fn check_pending_removed_vcpu(&mut self) -> bool {
-        for state in self.vcpu_states.iter() {
+        for state in self.vcpu_states.lock().unwrap().iter() {
             if state.active() && state.pending_removal.load(Ordering::SeqCst) {
                 return true;
             }
@@ -1538,7 +1547,8 @@ impl CpuManager {
 
     fn remove_vcpu(&mut self, cpu_id: u32) -> Result<()> {
         info!("Removing vCPU: cpu_id = {cpu_id}");
-        let state = &mut self.vcpu_states[usize::try_from(cpu_id).unwrap()];
+        let mut vcpu_states = self.vcpu_states.lock().unwrap();
+        let state = &mut vcpu_states[usize::try_from(cpu_id).unwrap()];
         state.kill.store(true, Ordering::SeqCst);
         state.signal_thread();
         state.wait_until_signal_acknowledged()?;
@@ -1634,12 +1644,15 @@ impl CpuManager {
     /// For the vCPU threads this will interrupt the KVM_RUN ioctl() allowing
     /// the loop to check the shared state booleans.
     fn signal_vcpus(&mut self) -> Result<()> {
+        // Holding the lock for the whole operation is correct:
+        let vcpu_states = self.vcpu_states.lock().unwrap();
+
         // Splitting this into two loops reduced the time to pause many vCPUs
         // massively. Example: 254 vCPUs. >254ms -> ~4ms.
-        for state in self.vcpu_states.iter() {
+        for state in vcpu_states.iter() {
             state.signal_thread();
         }
-        for state in self.vcpu_states.iter() {
+        for state in vcpu_states.iter() {
             state.wait_until_signal_acknowledged()?;
         }
 
@@ -1654,14 +1667,14 @@ impl CpuManager {
         self.vcpus_pause_signalled.store(false, Ordering::SeqCst);
 
         // Unpark all the VCPU threads.
-        for state in self.vcpu_states.iter() {
+        for state in self.vcpu_states.lock().unwrap().iter() {
             state.unpark_thread();
         }
 
         self.signal_vcpus()?;
 
         // Wait for all the threads to finish. This removes the state from the vector.
-        for mut state in self.vcpu_states.drain(..) {
+        for mut state in self.vcpu_states.lock().unwrap().drain(..) {
             state.join_thread()?;
         }
 
@@ -1696,6 +1709,8 @@ impl CpuManager {
 
     fn present_vcpus(&self) -> u32 {
         self.vcpu_states
+            .lock()
+            .unwrap()
             .iter()
             .fold(0, |acc, state| acc + state.active() as u32)
     }
@@ -2658,7 +2673,7 @@ impl Pausable for CpuManager {
 
         // The vCPU thread will change its paused state before parking, wait here for each
         // activated vCPU change their state to ensure they have parked.
-        for state in self.vcpu_states.iter() {
+        for state in self.vcpu_states.lock().unwrap().iter() {
             if state.active() {
                 // wait for vCPU to update state
                 while !state.paused.load(Ordering::SeqCst) {
@@ -2676,16 +2691,18 @@ impl Pausable for CpuManager {
         // their run vCPU loop.
         self.vcpus_pause_signalled.store(false, Ordering::SeqCst);
 
+        let vcpu_states = self.vcpu_states.lock().unwrap();
+
         // Unpark all the vCPU threads.
         // Step 1/2: signal each thread
         {
-            for state in self.vcpu_states.iter() {
+            for state in vcpu_states.iter() {
                 state.unpark_thread();
             }
         }
         // Step 2/2: wait for state ACK
         {
-            for state in self.vcpu_states.iter() {
+            for state in vcpu_states.iter() {
                 // wait for vCPU to update state
                 while state.paused.load(Ordering::SeqCst) {
                     // To avoid a priority inversion with the vCPU thread

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -631,8 +631,8 @@ pub struct CpuManager {
     reset_evt: EventFd,
     #[cfg(feature = "guest_debug")]
     vm_debug_evt: EventFd,
+    // Shared with AcpiCpuHotplugController
     vcpu_states: Arc<Mutex<Vec<VcpuState>>>,
-    selected_cpu: u32,
     vcpus: Vec<Arc<Mutex<Vcpu>>>,
     seccomp_action: SeccompAction,
     vm_ops: Arc<dyn VmOps>,
@@ -644,93 +644,6 @@ pub struct CpuManager {
     hypervisor: Arc<dyn hypervisor::Hypervisor>,
     #[cfg(feature = "sev_snp")]
     sev_snp_enabled: bool,
-}
-
-const CPU_ENABLE_FLAG: usize = 0;
-const CPU_INSERTING_FLAG: usize = 1;
-const CPU_REMOVING_FLAG: usize = 2;
-const CPU_EJECT_FLAG: usize = 3;
-
-const CPU_STATUS_OFFSET: u64 = 4;
-const CPU_SELECTION_OFFSET: u64 = 0;
-
-impl BusDevice for CpuManager {
-    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
-        // The Linux kernel, quite reasonably, doesn't zero the memory it gives us.
-        data.fill(0);
-        let vcpu_states = self.vcpu_states.lock().unwrap();
-
-        match offset {
-            CPU_SELECTION_OFFSET => {
-                assert!(data.len() >= core::mem::size_of::<u32>());
-                data[0..core::mem::size_of::<u32>()]
-                    .copy_from_slice(&self.selected_cpu.to_le_bytes());
-            }
-            CPU_STATUS_OFFSET => {
-                if self.selected_cpu < self.max_vcpus() {
-                    let state = &vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
-                    if state.active() {
-                        data[0] |= 1 << CPU_ENABLE_FLAG;
-                    }
-                    if state.inserting {
-                        data[0] |= 1 << CPU_INSERTING_FLAG;
-                    }
-                    if state.removing {
-                        data[0] |= 1 << CPU_REMOVING_FLAG;
-                    }
-                } else {
-                    warn!("Out of range vCPU id: {}", self.selected_cpu);
-                }
-            }
-            _ => {
-                warn!("Unexpected offset for accessing CPU manager device: {offset:#}");
-            }
-        }
-    }
-
-    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
-        match offset {
-            CPU_SELECTION_OFFSET => {
-                assert!(data.len() >= core::mem::size_of::<u32>());
-                self.selected_cpu =
-                    u32::from_le_bytes(data[0..core::mem::size_of::<u32>()].try_into().unwrap());
-            }
-            CPU_STATUS_OFFSET => {
-                if self.selected_cpu < self.max_vcpus() {
-                    let eject = {
-                        // This structure is not shared with the vCPU thread, therefore, holding the
-                        // lock for the entire function doesn't cause any deadlock.
-                        let mut vcpu_states = self.vcpu_states.lock().unwrap();
-                        let state = &mut vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
-
-                        if (data[0] & (1 << CPU_INSERTING_FLAG) == 1 << CPU_INSERTING_FLAG)
-                            && state.inserting
-                        {
-                            state.inserting = false;
-                        }
-
-                        if (data[0] & (1 << CPU_REMOVING_FLAG) == 1 << CPU_REMOVING_FLAG)
-                            && state.removing
-                        {
-                            state.removing = false;
-                        }
-
-                        data[0] & (1 << CPU_EJECT_FLAG) == 1 << CPU_EJECT_FLAG
-                    };
-
-                    if eject && let Err(e) = self.remove_vcpu(self.selected_cpu) {
-                        error!("Error removing vCPU: {e:?}");
-                    }
-                } else {
-                    warn!("Out of range vCPU id: {}", self.selected_cpu);
-                }
-            }
-            _ => {
-                warn!("Unexpected offset for accessing CPU manager device: {offset:#}");
-            }
-        }
-        None
-    }
 }
 
 #[derive(Default)]
@@ -908,7 +821,6 @@ impl CpuManager {
             reset_evt,
             #[cfg(feature = "guest_debug")]
             vm_debug_evt,
-            selected_cpu: 0,
             vcpus: Vec::with_capacity(max_vcpus),
             seccomp_action,
             vm_ops,
@@ -1543,23 +1455,6 @@ impl CpuManager {
             }
         }
         false
-    }
-
-    fn remove_vcpu(&mut self, cpu_id: u32) -> Result<()> {
-        info!("Removing vCPU: cpu_id = {cpu_id}");
-        let mut vcpu_states = self.vcpu_states.lock().unwrap();
-        let state = &mut vcpu_states[usize::try_from(cpu_id).unwrap()];
-        state.kill.store(true, Ordering::SeqCst);
-        state.signal_thread();
-        state.wait_until_signal_acknowledged()?;
-        state.join_thread()?;
-        state.handle = None;
-
-        // Once the thread has exited, clear the "kill" so that it can reused
-        state.kill.store(false, Ordering::SeqCst);
-        state.pending_removal.store(false, Ordering::SeqCst);
-
-        Ok(())
     }
 
     pub fn create_boot_vcpus(
@@ -3201,6 +3096,132 @@ impl CpuElf64Writable for CpuManager {
         }
 
         Ok(())
+    }
+}
+
+/// MMIO-accessible controller for handling ACPI hotplug and unplug events.
+///
+/// Shares state about the vCPUs with the [`CpuManager`].
+pub struct AcpiCpuHotplugController {
+    /// The currently selected CPU by the guest.
+    selected_cpu: u32,
+    /// Shared vCPU state with [`CpuManager`].
+    vcpu_states: Arc<Mutex<Vec<VcpuState>>>,
+    /// Maximum number of vCPUS of the VM.
+    max_vcpus: u32,
+}
+
+impl AcpiCpuHotplugController {
+    const CPU_ENABLE_FLAG: usize = 0;
+    const CPU_INSERTING_FLAG: usize = 1;
+    const CPU_REMOVING_FLAG: usize = 2;
+    const CPU_EJECT_FLAG: usize = 3;
+
+    const CPU_SELECTION_OFFSET: u64 = 0;
+    const CPU_STATUS_OFFSET: u64 = 4;
+
+    /// Creates a new [`AcpiCpuHotplugController`].
+    pub fn new(cpu_manager: &CpuManager) -> AcpiCpuHotplugController {
+        Self {
+            max_vcpus: cpu_manager.config.max_vcpus,
+            selected_cpu: 0,
+            vcpu_states: cpu_manager.vcpu_states.clone(),
+        }
+    }
+
+    /// Removes a vCPU from the guest.
+    ///
+    /// The corresponding vCPU thread will be gracefully stopped and joined.
+    fn remove_vcpu(cpu_id: u32, state: &mut VcpuState) -> Result<()> {
+        info!("Removing vCPU: cpu_id = {cpu_id}");
+        state.kill.store(true, Ordering::SeqCst);
+        state.signal_thread();
+        state.wait_until_signal_acknowledged()?;
+        state.join_thread()?;
+        state.handle = None;
+
+        // Once the thread has exited, clear the "kill" so that it can reused
+        state.kill.store(false, Ordering::SeqCst);
+        state.pending_removal.store(false, Ordering::SeqCst);
+
+        Ok(())
+    }
+}
+
+impl BusDevice for AcpiCpuHotplugController {
+    fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
+        // The Linux kernel, quite reasonably, doesn't zero the memory it gives us.
+        data.fill(0);
+        let vcpu_states = self.vcpu_states.lock().unwrap();
+
+        match offset {
+            Self::CPU_SELECTION_OFFSET => {
+                assert!(data.len() >= core::mem::size_of::<u32>());
+                data[0..core::mem::size_of::<u32>()]
+                    .copy_from_slice(&self.selected_cpu.to_le_bytes());
+            }
+            Self::CPU_STATUS_OFFSET => {
+                if self.selected_cpu < self.max_vcpus {
+                    let state = &vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+                    if state.active() {
+                        data[0] |= 1 << Self::CPU_ENABLE_FLAG;
+                    }
+                    if state.inserting {
+                        data[0] |= 1 << Self::CPU_INSERTING_FLAG;
+                    }
+                    if state.removing {
+                        data[0] |= 1 << Self::CPU_REMOVING_FLAG;
+                    }
+                } else {
+                    warn!("Out of range vCPU id: {}", self.selected_cpu);
+                }
+            }
+            _ => {
+                warn!("Unexpected offset for accessing CPU manager device: {offset:#}");
+            }
+        }
+    }
+
+    fn write(&mut self, _base: u64, offset: u64, data: &[u8]) -> Option<Arc<Barrier>> {
+        match offset {
+            Self::CPU_SELECTION_OFFSET => {
+                assert!(data.len() >= core::mem::size_of::<u32>());
+                self.selected_cpu =
+                    u32::from_le_bytes(data[0..core::mem::size_of::<u32>()].try_into().unwrap());
+            }
+            Self::CPU_STATUS_OFFSET => {
+                if self.selected_cpu < self.max_vcpus {
+                    // This structure is not shared with the vCPU thread, therefore, holding the
+                    // lock for the entire function doesn't cause any deadlock.
+                    let mut vcpu_states = self.vcpu_states.lock().unwrap();
+                    let state = &mut vcpu_states[usize::try_from(self.selected_cpu).unwrap()];
+                    // The ACPI code writes back a 1 to acknowledge the insertion
+                    if (data[0] & (1 << Self::CPU_INSERTING_FLAG) == 1 << Self::CPU_INSERTING_FLAG)
+                        && state.inserting
+                    {
+                        state.inserting = false;
+                    }
+                    // Ditto for removal
+                    if (data[0] & (1 << Self::CPU_REMOVING_FLAG) == 1 << Self::CPU_REMOVING_FLAG)
+                        && state.removing
+                    {
+                        state.removing = false;
+                    }
+                    // Trigger removal of vCPU:
+                    if data[0] & (1 << Self::CPU_EJECT_FLAG) == 1 << Self::CPU_EJECT_FLAG
+                        && let Err(e) = Self::remove_vcpu(self.selected_cpu, state)
+                    {
+                        error!("Error removing vCPU: {e:?}");
+                    }
+                } else {
+                    warn!("Out of range vCPU id: {}", self.selected_cpu);
+                }
+            }
+            _ => {
+                warn!("Unexpected offset for accessing CPU manager device: {offset:#}");
+            }
+        }
+        None
     }
 }
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -646,13 +646,18 @@ pub struct CpuManager {
     sev_snp_enabled: bool,
 }
 
+/// Management structure for a vCPU (thread).
 #[derive(Default)]
 struct VcpuState {
     inserting: bool,
     removing: bool,
     pending_removal: Arc<AtomicBool>,
+    /// Handle to the vCPU thread.
     handle: Option<thread::JoinHandle<()>>,
+    /// Instructs the thread to exit the run-vCPU loop.
     kill: Arc<AtomicBool>,
+    /// Marks that the vCPU thread ACKed its interruption from executing guest
+    /// code.
     vcpu_run_interrupted: Arc<AtomicBool>,
     /// Used to ACK state changes from the run vCPU loop to the CPU Manager.
     paused: Arc<AtomicBool>,
@@ -667,6 +672,13 @@ impl VcpuState {
     ///
     /// Please call [`Self::wait_until_signal_acknowledged`] afterward to block
     /// until the vCPU thread has acknowledged the signal.
+    ///
+    /// If the thread is in KVM_RUN (or MSHV_RUN_VP or equivalent), this kicks
+    /// the thread out of kernel space. If the thread is in user-space, the
+    /// thread will handle the event. If the thread is in user-space but about to
+    /// enter kernel-space, the user-space signal handler will make sure that
+    /// the next kernel entry of the given vCPU thread immediately exits to
+    /// handle the event in user-space.
     fn signal_thread(&self) {
         if let Some(handle) = self.handle.as_ref() {
             // SAFETY: FFI call with correct arguments
@@ -1534,10 +1546,10 @@ impl CpuManager {
         }
     }
 
-    /// Signal to the spawned threads (vCPUs and console signal handler).
+    /// Signals all vCPU threads and waits for them to ACK the interruption.
     ///
-    /// For the vCPU threads this will interrupt the KVM_RUN ioctl() allowing
-    /// the loop to check the shared state booleans.
+    /// Calls [`VcpuState::signal_thread`] and
+    /// [`VcpuState::wait_until_signal_acknowledged`] for each vCPU.
     fn signal_vcpus(&mut self) -> Result<()> {
         // Holding the lock for the whole operation is correct:
         let vcpu_states = self.vcpu_states.lock().unwrap();

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -118,7 +118,7 @@ use vm_virtio::{AccessPlatform, VirtioDeviceType};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::console_devices::{ConsoleDeviceError, ConsoleInfo, ConsoleOutput};
-use crate::cpu::{CPU_MANAGER_ACPI_SIZE, CpuManager};
+use crate::cpu::{AcpiCpuHotplugController, CPU_MANAGER_ACPI_SIZE, CpuManager};
 use crate::device_tree::{DeviceNode, DeviceTree};
 use crate::interrupt::{LegacyUserspaceInterruptManager, MsiInterruptManager};
 use crate::memory_manager::{Error as MemoryManagerError, MEMORY_MANAGER_ACPI_SIZE, MemoryManager};
@@ -994,6 +994,10 @@ pub struct DeviceManager {
     // CPU Manager
     cpu_manager: Arc<Mutex<CpuManager>>,
 
+    /// Owned version needed to keep the bus device alive (the bus only holds
+    /// a weak reference).
+    _acpi_cpu_hotplug_controller: Arc<Mutex<AcpiCpuHotplugController>>,
+
     // The virtio devices on the system
     virtio_devices: VecDeque<MetaVirtioDevice>,
 
@@ -1283,6 +1287,10 @@ impl DeviceManager {
             )?);
         }
 
+        let acpi_cpu_hotplug_controller =
+            AcpiCpuHotplugController::new(&cpu_manager.lock().unwrap());
+        let acpi_cpu_hotplug_controller = Arc::new(Mutex::new(acpi_cpu_hotplug_controller));
+
         if dynamic {
             let acpi_address = address_manager
                 .allocator
@@ -1294,7 +1302,7 @@ impl DeviceManager {
             address_manager
                 .mmio_bus
                 .insert(
-                    cpu_manager.clone(),
+                    acpi_cpu_hotplug_controller.clone(),
                     acpi_address.0,
                     CPU_MANAGER_ACPI_SIZE as u64,
                 )
@@ -1389,6 +1397,7 @@ impl DeviceManager {
             fw_cfg: None,
             #[cfg(feature = "ivshmem")]
             ivshmem_device: None,
+            _acpi_cpu_hotplug_controller: acpi_cpu_hotplug_controller,
         };
 
         let device_manager = Arc::new(Mutex::new(device_manager));


### PR DESCRIPTION
Extract AcpiCpuHotplugController from CpuManager and move the BusDevice implementation to the new type. This separates VMM-internal vCPU management from the guest-visible ACPI CPU hotplug MMIO interface.

Besides clarifying responsibilities and reducing technical debt, this fixes a rare deadlock involving pause handling and MMIO access.

New responsibilities:
- CpuManager manages VMM-internal vCPU lifecycle and coordination
- AcpiCpuHotplugController implements the guest-visible ACPI CPU hotplug MMIO interface

# Deadlock scenario

A vCPU thread may exit KVM_RUN to perform an MMIO access previously handled by CpuManager. If the VMM thread begins processing a `pause` event before that MMIO operation acquires access to CpuManager, CpuManager::pause() will block waiting for the vCPU thread to ACK the pause, while the vCPU thread is blocked waiting to complete the MMIO operation through the same CpuManager - which it can never lock - the VMM is deadlocked.

This can occur during early boot or CPU hotplug when pause events race with MMIO accesses. The issue is rare and timing-dependent, but real. For reproducing: run `ch-remote pause|resume` in a loop while booting a Linux VM (via direct kernel boot).

With the new design, these MMIO operations no longer depend on CpuManager, which removes the deadlock path entirely.

PS: We have the same problem with `DeviceManager`. This is more complex, however, to fix.

# Hints for Reviewers

**CI Pipeline**: https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/merge_requests/165/pipelines