### PR TITLE
vmm: migration: gracefully measure + log VM downtime + misc improvements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2848,6 +2848,7 @@ dependencies = [
  "hypervisor",
  "igvm",
  "igvm_defs",
+ "jiff",
  "kvm-bindings",
  "landlock",
  "libc",

--- a/vmm/Cargo.toml
+++ b/vmm/Cargo.toml
@@ -54,6 +54,7 @@ hex = { version = "0.4.3", optional = true }
 hypervisor = { path = "../hypervisor" }
 igvm = { workspace = true, optional = true }
 igvm_defs = { workspace = true, optional = true }
+jiff = { workspace = true, features = ["serde"] }
 kvm-bindings = { workspace = true }
 landlock = "0.4.4"
 libc = { workspace = true }

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -2964,7 +2964,7 @@ impl Vmm {
         s.migration_duration = s.migration_start_time.elapsed();
 
         info!(
-            "Migration complete: downtime:{:}ms,total:{:1}s,iterations:{}",
+            "Migration complete: downtime(actual):{}ms,total:{:1}s,iterations:{}",
             s.downtime_duration.as_millis(),
             s.migration_duration.as_secs_f64(),
             s.iteration,

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -320,6 +320,14 @@ const _: () = {
     );
 };
 
+/// The timeout of the migration-receiver.
+///
+/// We set this to a relatively high number to ease local development with
+/// `ch-remote`. For production, this has no negative impacts as the management
+/// software has full control over the Cloud Hypervisor process and will kill
+/// the process on terminated migration.
+const MIGRATION_ACCEPT_TIMEOUT_DURATION: Duration = Duration::from_secs(5 * 60);
+
 enum SocketStream {
     Unix(UnixStream),
     Tcp(TcpStream),
@@ -1127,7 +1135,7 @@ impl ReceiveListener {
             ReceiveListener::Tcp(listener) => {
                 let socket = {
                     let socket =
-                        Self::accept_with_timeout(listener, MIGRATION_READ_TIMEOUT_DURATION)?;
+                        Self::accept_with_timeout(listener, MIGRATION_ACCEPT_TIMEOUT_DURATION)?;
 
                     socket.set_read_timeout(Some(MIGRATION_READ_TIMEOUT_DURATION))?;
                     socket.set_write_timeout(Some(MIGRATION_WRITE_TIMEOUT_DURATION))?;
@@ -1162,7 +1170,7 @@ impl ReceiveListener {
             ReceiveListener::Tls(listener, conn) => {
                 let socket = {
                     let socket =
-                        Self::accept_with_timeout(listener, MIGRATION_READ_TIMEOUT_DURATION)?;
+                        Self::accept_with_timeout(listener, MIGRATION_ACCEPT_TIMEOUT_DURATION)?;
                     socket.set_read_timeout(Some(MIGRATION_READ_TIMEOUT_DURATION))?;
                     socket.set_write_timeout(Some(MIGRATION_WRITE_TIMEOUT_DURATION))?;
                     conn.wrap(socket)

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -300,16 +300,25 @@ impl From<u64> for EpollDispatch {
 // TODO make this a member of Vmm?
 static MIGRATION_PROGRESS_SNAPSHOT: Mutex<Option<MigrationProgress>> = Mutex::new(None);
 
-// The time a writer may block on a socket until it throws an error.
-// Also the interval at which the [`KeepAliveStream`] sends keep alive messages.
-// This timeout has to be smaller than [`MIGRATION_READ_TIMEOUT_DURATION`],
-// otherwise spurious timeouts may happen.
+/// The time a writer may block on a socket until it throws an error.
+///
+/// Also the interval at which the [`KeepAliveStream`] sends keep alive messages.
+/// This timeout has to be smaller than [`MIGRATION_READ_TIMEOUT_DURATION`],
+/// otherwise spurious timeouts may happen.
 const MIGRATION_WRITE_TIMEOUT_DURATION: Duration = Duration::from_secs(5);
 
 /// The time a reader may block on a socket until it throws an error.
+///
 /// This timeout has to be larger than [`MIGRATION_WRITE_TIMEOUT_DURATION`],
 /// otherwise spurious timeouts may happen.
 const MIGRATION_READ_TIMEOUT_DURATION: Duration = Duration::from_secs(10);
+
+const _: () = {
+    assert!(
+        MIGRATION_WRITE_TIMEOUT_DURATION.as_millis() < MIGRATION_READ_TIMEOUT_DURATION.as_millis(),
+        "MIGRATION_WRITE_TIMEOUT_DURATION must be smaller than MIGRATION_READ_TIMEOUT_DURATION",
+    );
+};
 
 enum SocketStream {
     Unix(UnixStream),

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -20,6 +20,7 @@ use std::num::Wrapping;
 use std::ops::Deref;
 use std::os::unix::net::UnixStream;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 #[cfg(not(target_arch = "riscv64"))]
 use std::time::Instant;
 use std::{cmp, result, str, thread};
@@ -47,6 +48,7 @@ use gdbstub_arch::x86::reg::X86_64CoreRegs as CoreRegs;
 #[cfg(target_arch = "aarch64")]
 use hypervisor::arch::aarch64::regs::AARCH64_PMU_IRQ;
 use hypervisor::{HypervisorVmConfig, HypervisorVmError, VmOps};
+use jiff::Zoned;
 use libc::{SIGWINCH, termios};
 use linux_loader::cmdline::Cmdline;
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -525,6 +527,7 @@ pub struct Vm {
     load_payload_handle: Option<thread::JoinHandle<Result<EntryPoint>>>,
     vcpu_throttler: ThrottleThreadHandle,
     post_migration_lifecycle_event: Option<PostMigrationLifecycleEvent>,
+    pause_time: Option<Zoned>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -669,6 +672,13 @@ impl Vm {
             None
         };
 
+        let pause_time = if let Some(snapshot) = snapshot.as_ref() {
+            let vm_snapshot = get_vm_snapshot(snapshot).map_err(Error::Restore)?;
+            vm_snapshot.pause_time
+        } else {
+            None
+        };
+
         let state = if snapshot.is_some() {
             VmState::Paused
         } else {
@@ -709,7 +719,17 @@ impl Vm {
             load_payload_handle,
             vcpu_throttler,
             post_migration_lifecycle_event,
+            pause_time,
         })
+    }
+
+    /// Returns the duration since the last VM pause.
+    pub(crate) fn pause_downtime(&self) -> Option<Duration> {
+        let Some(ref pause_time) = self.pause_time else {
+            return None;
+        };
+
+        std::time::SystemTime::from(pause_time).elapsed().ok()
     }
 
     /// Determine if IOMMU should be forced based on confidential computing features.
@@ -3092,6 +3112,7 @@ impl Pausable for Vm {
             .pause()
             .map_err(|e| MigratableError::Pause(anyhow!("Could not pause the VM: {e}")))?;
 
+        self.pause_time = Some(Zoned::now());
         self.state = new_state;
 
         event!("vm", "paused");
@@ -3127,8 +3148,16 @@ impl Pausable for Vm {
         self.device_manager.lock().unwrap().resume()?;
         self.cpu_manager.lock().unwrap().resume()?;
 
+        info!(
+            "VM resumed after a downtime of {}ms",
+            self.pause_downtime()
+                .expect("VM should have been paused before")
+                .as_millis()
+        );
+
         // And we're back to the Running state.
         self.state = new_state;
+        self.pause_time = None;
         event!("vm", "resumed");
         Ok(())
     }
@@ -3142,6 +3171,7 @@ pub struct VmSnapshot {
     pub clock: Option<hypervisor::ClockData>,
     #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
     pub common_cpuid: Vec<hypervisor::arch::x86::CpuIdEntry>,
+    pub pause_time: Option<Zoned>,
 }
 
 pub const VM_SNAPSHOT_ID: &str = "vm";
@@ -3199,6 +3229,7 @@ impl Snapshottable for Vm {
             clock: self.saved_clock,
             #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
             common_cpuid,
+            pause_time: self.pause_time.clone(),
         };
 
         let mut vm_snapshot = Snapshot::new_from_state(&vm_snapshot_state)?;
@@ -3532,6 +3563,27 @@ mod unit_tests {
     #[test]
     fn test_vm_paused_transitions() {
         test_vm_state_transitions(VmState::Paused);
+    }
+
+    #[test]
+    fn test_vm_snapshot_pause_time_roundtrip() {
+        let snapshot = VmSnapshot {
+            #[cfg(target_arch = "x86_64")]
+            clock: None,
+            #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+            common_cpuid: Vec::new(),
+            post_migration_lifecycle_event: None,
+            pause_time: Some(
+                "2024-10-31T16:33:53.123456789+00:00[UTC]"
+                    .parse::<Zoned>()
+                    .unwrap(),
+            ),
+        };
+
+        let serialized = serde_json::to_vec(&snapshot).unwrap();
+        let restored: VmSnapshot = serde_json::from_slice(&serialized).unwrap();
+
+        assert_eq!(restored.pause_time, snapshot.pause_time);
     }
 
     #[cfg(feature = "tdx")]


### PR DESCRIPTION
- added a `pause_timestamp` field to `struct Vm` and `struct VmSnapshot`: this way, on a new host, we can nicely log the actual downtime (ignoring network) which is a great win for observability
- small misc improvements