### PR TITLE
misc: add commit to version info

### DIFF
--- a/chv.nix
+++ b/chv.nix
@@ -13,6 +13,7 @@
   # other
   meta, # meta of pkgs.cloud-hypervisor
   src, # clean source
+  chExtraVersion, # Additional information to be appended to the version string.
 }:
 let
   commonArgs = {
@@ -33,6 +34,9 @@ let
       # - https://github.com/sfackler/rust-openssl/issues/1430
       # - https://docs.rs/openssl/latest/openssl/
       OPENSSL_NO_VENDOR = true;
+
+      # Sets additional information to be appended to the version string.
+      CH_EXTRA_VERSION = chExtraVersion;
     };
 
     nativeBuildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -65,6 +65,9 @@
               inherit (pkgs.cloud-hypervisor) meta;
               inherit src;
               craneLib = craneLib';
+
+              # Query the repo revision to pass the cloud-hypervisor to be printed in the version string.
+              chExtraVersion = self.dirtyRev or self.rev or "unknown-revision";
             };
           in
           {


### PR DESCRIPTION
Sets the `CH_EXTRA_VERSION` env var during compilation to add the git revision to the version output.

To verify, build with the flake, then check the version output.
```command
> nix build .#cloud-hypervisor
> ./result/bin/cloud-hypervisor --version
cloud-hypervisor v51.1.0-3c77ad4de37af625dc5a18c8e405a773e76f5b1b-dirty
```
