### PR TITLE
vmm: migration: don't emit "migration-finished" event after failure

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -905,13 +905,13 @@ impl MigrationWorker {
             self.postponed_lifecycle_event.as_ref(),
             self.cancel.clone(),
         )
+        .inspect(|_| event!("vm", "migration-finished"))
         .inspect_err(|e| error!("migrate error: {e}"));
 
         // Notify VMM thread to get migration result by joining this thread.
         self.check_migration_evt.write(1).unwrap();
 
         debug!("migration thread is finished");
-        event!("vm", "migration-finished");
         MigrationThreadOut {
             vm: self.vm,
             migration_res: res,


### PR DESCRIPTION
The events are not yet consumed by libvirt, so we do not need a libvirt pipeline. This streamlines the behavior with upstream.