### PR TITLE
arch: Deserialize CPU profiles in kebab-case

### DIFF
--- a/arch/build.rs
+++ b/arch/build.rs
@@ -188,6 +188,7 @@ fn generate_cpu_profile_enum(profile_names: &[ProfileName]) -> String {
     // Use the quote crate to build the CpuProfile enum as a TokenStream.
     let tokens = quote! {
         #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, Default)]
+        #[serde(rename_all = "kebab-case")]
         pub enum CpuProfile {
             #[default]
             Host,


### PR DESCRIPTION
When we introduced our build script we forgot to tell `serde` to (de-) serialize the `CpuProfile` enum in kebab-case which is a breaking change.

This generated enum now looks like this:

```
#[derive(
    Debug,
    Clone,
    Copy,
    PartialEq,
    Eq,
    serde::Serialize,
    serde::Deserialize,
    Default
)]
#[serde(rename_all = "kebab-case")]
pub enum CpuProfile {
    #[default]
    Host,
    SapphireRapids,
    Skylake,
}
```
