### PR TITLE
[Backport] virtio-devices: signal activated queue eventfds on resume

### DIFF
--- a/virtio-devices/src/block.rs
+++ b/virtio-devices/src/block.rs
@@ -57,9 +57,6 @@ const QUEUE_AVAIL_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 1;
 const COMPLETION_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 2;
 // New 'wake up' event from the rate limiter
 const RATE_LIMITER_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 3;
-// One-shot queue handler event used after a VM restore to wake the
-// handler so it can drain restored requests once vCPUs resume.
-const RESUME_EVENT: u16 = EPOLL_HELPER_EVENT_LAST + 4;
 
 // latency scale, for reduce precision loss in calculate.
 const LATENCY_SCALE: u64 = 10000;
@@ -158,17 +155,12 @@ struct BlockEpollHandler {
     writeback: Arc<AtomicBool>,
     counters: BlockCounters,
     queue_evt: EventFd,
-    /// Event used after a VM restore to wake this queue handler so it can
-    /// drain restored requests once vCPUs resume.
-    resume_evt: EventFd,
     inflight_requests: VecDeque<(u16, Request)>,
     rate_limiter: Option<RateLimiterGroupHandle>,
     access_platform: Option<Arc<dyn AccessPlatform>>,
     host_cpus: Option<Vec<usize>>,
     acked_features: u64,
     disable_sector0_writes: bool,
-    /// Whether this queue handler still needs its one-shot drain of restored requests.
-    needs_restored_queue_drain: bool,
 }
 
 fn has_feature(features: u64, feature_flag: u64) -> bool {
@@ -566,44 +558,6 @@ impl BlockEpollHandler {
         }
     }
 
-    /// Drains pending requests once after a VM restore and vCPU resume if the queue is non-empty.
-    fn drain_restored_queue(&mut self) -> result::Result<(), EpollHelperError> {
-        if !self.needs_restored_queue_drain {
-            return Ok(());
-        }
-
-        // `Block::resume_after_vcpus()` triggers this one-shot drain once the
-        // guest is running again.
-
-        let mem = self.mem.memory();
-        let used_idx = self
-            .queue
-            .used_idx(mem.deref(), Ordering::Acquire)
-            .map_err(EpollHelperError::QueueRingIndex)?;
-        let avail_idx = self
-            .queue
-            .avail_idx(mem.deref(), Ordering::Acquire)
-            .map_err(EpollHelperError::QueueRingIndex)?;
-        // Queue indices are wrapping u16 counters.
-        let pending = (avail_idx - used_idx).0;
-
-        // After restore the queue can already contain pending work. Drain it
-        // once on resume, because no new kick may arrive.
-        if pending != 0 {
-            let rate_limit_reached = self.rate_limiter.as_ref().is_some_and(|r| r.is_blocked());
-
-            // If restore-time draining is rate-limited here, the RATE_LIMITER_EVENT path will
-            // call `process_queue_submit_and_signal()` once the limiter unblocks.
-            if !rate_limit_reached {
-                self.process_queue_submit_and_signal()?;
-            }
-        }
-
-        self.needs_restored_queue_drain = false;
-
-        Ok(())
-    }
-
     fn run(
         &mut self,
         paused: &AtomicBool,
@@ -615,7 +569,6 @@ impl BlockEpollHandler {
         if let Some(rate_limiter) = &self.rate_limiter {
             helper.add_event(rate_limiter.as_raw_fd(), RATE_LIMITER_EVENT)?;
         }
-        helper.add_event(self.resume_evt.as_raw_fd(), RESUME_EVENT)?;
         self.set_queue_thread_affinity();
         helper.run(paused, paused_sync, self)?;
 
@@ -683,13 +636,6 @@ impl EpollHelperHandler for BlockEpollHandler {
                     )));
                 }
             }
-            RESUME_EVENT => {
-                self.resume_evt.read().map_err(|e| {
-                    EpollHelperError::HandleEvent(anyhow!("Failed to get resume event: {e:?}"))
-                })?;
-
-                self.drain_restored_queue()?;
-            }
             _ => {
                 return Err(EpollHelperError::HandleEvent(anyhow!(
                     "Unexpected event: {ev_type}"
@@ -716,10 +662,6 @@ pub struct Block {
     serial: Vec<u8>,
     queue_affinity: BTreeMap<u16, Vec<usize>>,
     disable_sector0_writes: bool,
-    /// Whether this device still needs to wake queue handlers after vCPUs resume from VM restore.
-    needs_restore_wakeup: bool,
-    /// Per-queue events used after a VM restore to wake blk queue handlers once.
-    resume_evts: Vec<EventFd>,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -751,7 +693,7 @@ impl Block {
         sparse: bool,
         disable_sector0_writes: bool,
     ) -> io::Result<Self> {
-        let (disk_nsectors, avail_features, acked_features, config, paused, needs_restore_wakeup) =
+        let (disk_nsectors, avail_features, acked_features, config, paused) =
             if let Some(state) = state {
                 info!("Restoring virtio-block {id}");
                 (
@@ -759,7 +701,6 @@ impl Block {
                     state.avail_features,
                     state.acked_features,
                     state.config,
-                    true,
                     true,
                 )
             } else {
@@ -850,7 +791,7 @@ impl Block {
                     config.num_queues = num_queues as u16;
                 }
 
-                (disk_nsectors, avail_features, 0, config, false, false)
+                (disk_nsectors, avail_features, 0, config, false)
             };
 
         let serial = serial.map_or_else(|| build_serial(&disk_path), Vec::from);
@@ -879,8 +820,6 @@ impl Block {
             serial,
             queue_affinity,
             disable_sector0_writes,
-            needs_restore_wakeup,
-            resume_evts: Vec::new(),
         })
     }
 
@@ -1096,16 +1035,6 @@ impl VirtioDevice for Block {
         self.update_writeback();
 
         let mut epoll_threads = Vec::new();
-
-        if self.resume_evts.is_empty() {
-            warn!(
-                "Clearing {} stale blk resume event handles before activation",
-                self.resume_evts.len()
-            );
-        }
-        debug_assert!(self.resume_evts.is_empty());
-        self.resume_evts.clear();
-
         let event_idx = self.common.feature_acked(VIRTIO_RING_F_EVENT_IDX.into());
 
         for i in 0..queues.len() {
@@ -1114,10 +1043,6 @@ impl VirtioDevice for Block {
 
             let queue_size = queue.size();
             let (kill_evt, pause_evt) = self.common.dup_eventfds();
-            let resume_evt = EventFd::new(libc::EFD_NONBLOCK).map_err(|e| {
-                error!("failed creating resume EventFd: {e}");
-                ActivateError::BadActivate
-            })?;
             let queue_idx = i as u16;
 
             let mut handler = BlockEpollHandler {
@@ -1139,10 +1064,6 @@ impl VirtioDevice for Block {
                 writeback: self.writeback.clone(),
                 counters: self.counters.clone(),
                 queue_evt,
-                resume_evt: resume_evt.try_clone().map_err(|e| {
-                    error!("failed cloning resume EventFd: {e}");
-                    ActivateError::BadActivate
-                })?,
                 // Analysis during boot shows around ~40 maximum requests
                 // This gives head room for systems with slower I/O without
                 // compromising the cost of the reallocation or memory overhead
@@ -1157,9 +1078,7 @@ impl VirtioDevice for Block {
                 host_cpus: self.queue_affinity.get(&queue_idx).cloned(),
                 acked_features: self.common.acked_features,
                 disable_sector0_writes: self.disable_sector0_writes,
-                needs_restored_queue_drain: self.needs_restore_wakeup,
             };
-            self.resume_evts.push(resume_evt);
 
             let paused = self.common.paused.clone();
             let paused_sync = self.common.paused_sync.clone();
@@ -1181,7 +1100,6 @@ impl VirtioDevice for Block {
     }
 
     fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
-        self.resume_evts.clear();
         let result = self.common.reset();
         event!("virtio-device", "reset", "id", &self.id);
         result
@@ -1232,27 +1150,6 @@ impl VirtioDevice for Block {
         );
 
         Some(counters)
-    }
-
-    /// Signals restored blk queue handlers through `RESUME_EVENT` after
-    /// vCPUs resume so requests pending before the snapshot are not left
-    /// waiting for a new guest kick.
-    fn resume_after_vcpus(&mut self) -> std::result::Result<(), MigratableError> {
-        if !self.needs_restore_wakeup {
-            return Ok(());
-        }
-
-        for resume_evt in &self.resume_evts {
-            resume_evt.write(1).map_err(|e| {
-                MigratableError::Resume(anyhow!(
-                    "Could not notify restored blk worker after vCPU resume: {e}"
-                ))
-            })?;
-        }
-
-        self.needs_restore_wakeup = false;
-
-        Ok(())
     }
 
     fn set_access_platform(&mut self, access_platform: Arc<dyn AccessPlatform>) {

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -172,19 +172,6 @@ pub trait VirtioDevice: Send {
     fn post_migration_announcer(&self) -> Option<Box<dyn PostMigrationAnnouncer>> {
         None
     }
-
-    /// Runs device-specific follow-up work after vCPUs have resumed.
-    ///
-    /// This hook exists for resume flows where device workers may be resumed
-    /// before guest vCPUs. Implementers can use it for work that may notify
-    /// the guest and therefore must only happen once vCPUs are running again.
-    ///
-    /// Callers must invoke this only after vCPU resume has completed.
-    /// Devices that do not need any post-vCPU-resume handling use the default
-    /// no-op implementation.
-    fn resume_after_vcpus(&mut self) -> std::result::Result<(), MigratableError> {
-        Ok(())
-    }
 }
 
 /// Trait to define address translation for devices managed by virtio-iommu

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -13,6 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Barrier};
 use std::thread;
 
+use anyhow::anyhow;
 use libc::EFD_NONBLOCK;
 use log::{error, info, warn};
 use virtio_queue::Queue;
@@ -201,6 +202,7 @@ pub struct VirtioCommon {
     pub paused_sync: Option<Arc<Barrier>>,
     pub epoll_threads: Option<Vec<thread::JoinHandle<()>>>,
     pub queue_sizes: Vec<u16>,
+    pub queue_evts: Vec<EventFd>,
     pub device_type: u32,
     pub min_queues: u16,
     pub access_platform: Option<Arc<dyn AccessPlatform>>,
@@ -238,6 +240,21 @@ impl VirtioCommon {
             return Err(ActivateError::BadActivate);
         }
 
+        // Do not retain virtio-net queue eventfds here. Signaling them on
+        // resume would break its `driver_awake` workaround.
+        self.queue_evts = match VirtioDeviceType::from(self.device_type) {
+            VirtioDeviceType::Net => Vec::new(),
+            _ => queues
+                .iter()
+                .map(|(_, _, queue_evt)| {
+                    queue_evt.try_clone().map_err(|e| {
+                        error!("failed cloning queue EventFd: {e}");
+                        ActivateError::BadActivate
+                    })
+                })
+                .collect::<Result<Vec<_>, _>>()?,
+        };
+
         let kill_evt = EventFd::new(EFD_NONBLOCK).map_err(|e| {
             error!("failed creating kill EventFd: {e}");
             ActivateError::BadActivate
@@ -258,6 +275,8 @@ impl VirtioCommon {
     }
 
     pub fn reset(&mut self) -> Option<Arc<dyn VirtioInterrupt>> {
+        self.queue_evts.clear();
+
         // We first must resume the virtio thread if it was paused.
         if self.pause_evt.take().is_some() {
             self.resume().ok()?;
@@ -339,6 +358,16 @@ impl Pausable for VirtioCommon {
             for t in epoll_threads.iter() {
                 t.thread().unpark();
             }
+        }
+
+        // Signal each activated queue eventfd so workers process restored queues
+        // that may already contain pending requests.
+        for queue_evt in &self.queue_evts {
+            queue_evt.write(1).map_err(|e| {
+                MigratableError::Resume(anyhow!(
+                    "Could not notify restored virtio worker on resume: {e}"
+                ))
+            })?;
         }
 
         Ok(())

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -370,6 +370,15 @@ impl Pausable for VirtioCommon {
             })?;
         }
 
+        // Also trigger interrupts into the guest to wake up the driver to avoid a "livelock"
+        if let Some(interrupt_cb) = &self.interrupt_cb {
+            for i in 0..self.queue_evts.len() {
+                interrupt_cb
+                    .trigger(crate::VirtioInterruptType::Queue(i as u16))
+                    .ok();
+            }
+        }
+
         Ok(())
     }
 }

--- a/virtio-devices/src/device.rs
+++ b/virtio-devices/src/device.rs
@@ -240,20 +240,15 @@ impl VirtioCommon {
             return Err(ActivateError::BadActivate);
         }
 
-        // Do not retain virtio-net queue eventfds here. Signaling them on
-        // resume would break its `driver_awake` workaround.
-        self.queue_evts = match VirtioDeviceType::from(self.device_type) {
-            VirtioDeviceType::Net => Vec::new(),
-            _ => queues
-                .iter()
-                .map(|(_, _, queue_evt)| {
-                    queue_evt.try_clone().map_err(|e| {
-                        error!("failed cloning queue EventFd: {e}");
-                        ActivateError::BadActivate
-                    })
+        self.queue_evts = queues
+            .iter()
+            .map(|(_, _, queue_evt)| {
+                queue_evt.try_clone().map_err(|e| {
+                    error!("failed cloning queue EventFd: {e}");
+                    ActivateError::BadActivate
                 })
-                .collect::<Result<Vec<_>, _>>()?,
-        };
+            })
+            .collect::<Result<Vec<_>, _>>()?;
 
         let kill_evt = EventFd::new(EFD_NONBLOCK).map_err(|e| {
             error!("failed creating kill EventFd: {e}");

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -176,11 +176,6 @@ struct NetEpollHandler {
     queue_index_base: u16,
     queue_pair: (Queue, Queue),
     queue_evt_pair: (EventFd, EventFd),
-    // Always generate interrupts until the driver has signalled to the device.
-    // This mitigates a problem with interrupts from tap events being "lost" upon
-    // a restore as the vCPU thread isn't ready to handle the interrupt. This causes
-    // issues when combined with VIRTIO_RING_F_EVENT_IDX interrupt suppression.
-    driver_awake: bool,
 }
 
 impl NetEpollHandler {
@@ -227,7 +222,6 @@ impl NetEpollHandler {
             .net
             .process_tx(&self.mem.memory(), &mut self.queue_pair.1)
             .map_err(DeviceError::NetQueuePair)?
-            || !self.driver_awake
         {
             self.signal_used_queue(self.queue_index_base + 1)?;
             debug!("Signalling TX queue");
@@ -256,7 +250,6 @@ impl NetEpollHandler {
             .net
             .process_rx(&self.mem.memory(), &mut self.queue_pair.0)
             .map_err(DeviceError::NetQueuePair)?
-            || !self.driver_awake
         {
             self.signal_used_queue(self.queue_index_base)?;
             trace!("Signalling RX queue");
@@ -318,7 +311,6 @@ impl EpollHelperHandler for NetEpollHandler {
         let ev_type = event.data as u16;
         match ev_type {
             RX_QUEUE_EVENT => {
-                self.driver_awake = true;
                 self.handle_rx_event().map_err(|e| {
                     EpollHelperError::HandleEvent(anyhow!("Error processing RX queue: {e:?}"))
                 })?;
@@ -328,7 +320,6 @@ impl EpollHelperHandler for NetEpollHandler {
                 if let Err(e) = queue_evt.read() {
                     error!("Failed to get tx queue event: {e:?}");
                 }
-                self.driver_awake = true;
                 self.handle_tx_event().map_err(|e| {
                     EpollHelperError::HandleEvent(anyhow!("Error processing TX queue: {e:?}"))
                 })?;
@@ -385,8 +376,6 @@ impl EpollHelperHandler for NetEpollHandler {
                             "Error from 'rate_limiter.event_handler()': {e:?}"
                         ))
                     })?;
-
-                    self.driver_awake = true;
                     self.process_tx().map_err(|e| {
                         EpollHelperError::HandleEvent(anyhow!("Error processing TX queue: {e:?}"))
                     })?;
@@ -957,7 +946,6 @@ impl VirtioDevice for Net {
                 interrupt_cb: interrupt_cb.clone(),
                 kill_evt,
                 pause_evt,
-                driver_awake: false,
             };
 
             let paused = self.common.paused.clone();

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -5214,22 +5214,6 @@ impl DeviceManager {
             MAX_DELAY,
         );
     }
-
-    /// Runs the post-vCPU-resume callback for virtio devices.
-    ///
-    /// This is needed for resume flows where device workers are resumed before
-    /// vCPUs. Devices can use this hook for follow-up work that may notify the
-    /// guest and therefore must only happen once vCPUs are running again.
-    ///
-    /// This method must be called only after `CpuManager::resume()` has
-    /// completed. Devices that do not need post-vCPU-resume handling ignore it
-    /// through the default no-op implementation.
-    pub fn post_vcpu_resume_hooks(&mut self) -> result::Result<(), MigratableError> {
-        for handle in self.virtio_devices.iter() {
-            handle.virtio_device.lock().unwrap().resume_after_vcpus()?;
-        }
-        Ok(())
-    }
 }
 
 /// Starts a thread that periodically performs the post-migration announcements.

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3126,10 +3126,6 @@ impl Pausable for Vm {
 
         self.device_manager.lock().unwrap().resume()?;
         self.cpu_manager.lock().unwrap().resume()?;
-        self.device_manager
-            .lock()
-            .unwrap()
-            .post_vcpu_resume_hooks()?;
 
         // And we're back to the Running state.
         self.state = new_state;


### PR DESCRIPTION
We revert https://github.com/cyberus-technology/cloud-hypervisor/pull/138 and backport the rework landed upstream https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8004.