### PR TITLE
main: log absolute timestamp instead of time since startup

### DIFF
--- a/cloud-hypervisor/src/main.rs
+++ b/cloud-hypervisor/src/main.rs
@@ -118,7 +118,6 @@ enum FdTableError {
 
 struct Logger {
     output: Mutex<Box<dyn std::io::Write + Send>>,
-    start: std::time::Instant,
 }
 
 impl log::Log for Logger {
@@ -131,10 +130,6 @@ impl log::Log for Logger {
             return;
         }
 
-        let now = std::time::Instant::now();
-        let duration = now.duration_since(self.start);
-        let duration_s = duration.as_secs_f32();
-
         let location = if let (Some(file), Some(line)) = (record.file(), record.line()) {
             format!("{file}:{line}")
         } else {
@@ -144,9 +139,8 @@ impl log::Log for Logger {
         let mut out = self.output.lock().unwrap();
         write!(
             &mut *out,
-            // 10: 6 decimal places + sep => whole seconds in range `0..=999` properly aligned
-            "cloud-hypervisor: {:>10.6?}s: <{}> {}:{} -- {}\r\n",
-            duration_s,
+            "cloud-hypervisor: {}: <{}> {}:{} -- {}\r\n",
+            jiff::Zoned::now().strftime("%Y-%m-%dT%H:%M:%S%.f%:z"),
             std::thread::current().name().unwrap_or("anonymous"),
             record.level(),
             location,
@@ -511,7 +505,6 @@ fn start_vmm(cmd_arguments: &ArgMatches) -> Result<Option<String>, Error> {
 
     log::set_boxed_logger(Box::new(Logger {
         output: Mutex::new(log_file),
-        start: std::time::Instant::now(),
     }))
     .map(|()| log::set_max_level(log_level))
     .map_err(Error::LoggerSetup)?;


### PR DESCRIPTION
Uses the system's timezone and the same time formatting as https://github.com/cyberus-technology/cloud-hypervisor/pull/132/changes/3d88fb6cacb530c8cb25093a5a382ca55d43ca8c.

Logs:
```
cloud-hypervisor: 2026-04-17T09:34:35.883798863+02:00: <main> INFO:cloud-hypervisor/src/main.rs:692 -- Cloud Hypervisor starting: build version: v51.1-239-ga8a5657eb, date: 2026-04-17T09:34:35.883766977+02:00
cloud-hypervisor: 2026-04-17T09:34:35.883814556+02:00: <main> INFO:event_monitor/src/lib.rs:113 -- Event: source = vmm event = starting 
cloud-hypervisor: 2026-04-17T09:34:35.884550993+02:00: <vmm> INFO:vmm/src/api/mod.rs:915 -- API request event: VmCreate VmConfig ...
cloud-hypervisor: 2026-04-17T09:34:35.884810615+02:00: <vmm> INFO:vmm/src/api/mod.rs:806 -- API request event: VmBoot
cloud-hypervisor: 2026-04-17T09:34:35.884819344+02:00: <vmm> INFO:vmm/src/lib.rs:3460 -- Booting VM
cloud-hypervisor: 2026-04-17T09:34:35.884827139+02:00: <vmm> INFO:event_monitor/src/lib.rs:113 -- Event: source = vm event = booting 
```

# Steps to undraft

- [x] Receive input from SAP what timezone is required.
    - Timezone should be UTC, but all systems use UTC anyway.

Fixes: https://github.com/cobaltcore-dev/cobaltcore/issues/490