### PR TITLE
vmm: clear restore snapshot after device creation

### DIFF
--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -1524,6 +1524,11 @@ impl DeviceManager {
         Ok(())
     }
 
+    /// Drop restore-only state once all devices have consumed it.
+    pub(crate) fn clear_restore_snapshot(&mut self) {
+        self.snapshot = None;
+    }
+
     #[cfg(feature = "fw_cfg")]
     pub fn create_fw_cfg_device(&mut self) -> Result<(), DeviceManagerError> {
         let fw_cfg = Arc::new(Mutex::new(devices::legacy::FwCfg::new(

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -639,6 +639,9 @@ impl Vm {
             snapshot,
         )?;
 
+        // Remove any snapshot artifacts after the hypervisor-specific init.
+        device_manager.lock().unwrap().clear_restore_snapshot();
+
         // Load kernel and initramfs files
         #[cfg(feature = "tdx")]
         let kernel = config


### PR DESCRIPTION
Different solution to #156. Please see the commit message for more details.

Fixes: https://github.com/cobaltcore-dev/cobaltcore/issues/567