### PR TITLE
Migration statistics v52 fix

### DIFF
--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1610,7 +1610,7 @@ impl Vmm {
                     MigrationStateOngoingPhase::MemoryPrecopy,
                     Some(MemoryTransmissionInfo {
                         memory_iteration: s.iteration as u64,
-                        memory_transmission_bps: s.current_iteration_total_bytes,
+                        memory_transmission_bps: s.bandwidth_bytes_per_second as u64,
                         memory_bytes_total: total_memory_size_bytes,
                         memory_bytes_transmitted: s.total_sent_bytes,
                         memory_pages_4k_transmitted: s.total_sent_bytes.div_ceil(PAGE_SIZE as u64),

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1658,15 +1658,12 @@ impl Vmm {
             };
 
             ctx.update_metrics_before_transfer(iteration_begin, &iteration_table);
-            // Update before we might exit the loop.
+            // Update before we either exit the loop or transfer memory
             update_migration_progress(ctx, vm);
             if is_converged(ctx)? {
                 info!("Precopy converged: {ctx}");
                 break Ok(iteration_table);
             }
-
-            // Update with new metrics before transmission.
-            update_migration_progress(ctx, vm);
 
             // Send the current dirty pages
             let transfer_begin = Instant::now();

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -1596,6 +1596,12 @@ impl Vmm {
         postponed_lifecycle_event: &Mutex<Option<PostMigrationLifecycleEvent>>,
         return_if_cancelled_cb: &impl Fn(&mut SocketStream) -> result::Result<(), MigratableError>,
     ) -> result::Result<MemoryRangeTable /* remaining */, MigratableError> {
+        let total_memory_size_bytes = vm
+            .memory_range_table()?
+            .ranges()
+            .iter()
+            .map(|range| range.length)
+            .sum::<u64>();
         let update_migration_progress = |s: &mut MemoryMigrationContext, vm: &Vm| {
             let mut lock = MIGRATION_PROGRESS_SNAPSHOT.lock().unwrap();
             lock.as_mut()
@@ -1605,7 +1611,7 @@ impl Vmm {
                     Some(MemoryTransmissionInfo {
                         memory_iteration: s.iteration as u64,
                         memory_transmission_bps: s.current_iteration_total_bytes,
-                        memory_bytes_total: s.bandwidth_bytes_per_second as u64,
+                        memory_bytes_total: total_memory_size_bytes,
                         memory_bytes_transmitted: s.total_sent_bytes,
                         memory_pages_4k_transmitted: s.total_sent_bytes.div_ceil(PAGE_SIZE as u64),
                         memory_pages_4k_remaining_iteration: s


### PR DESCRIPTION
Fixes some errors related to migration statistics in do_memory_iterations that were introduced in the massive v52 upgrade.

See each commit for more information.

Closes: https://github.com/cobaltcore-dev/cobaltcore/issues/575