### PR TITLE
Update seccomp rules

### DIFF
--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -988,6 +988,7 @@ fn http_api_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendError>
         (libc::SYS_rt_sigprocmask, vec![]),
         (libc::SYS_getcwd, vec![]),
         (libc::SYS_clock_nanosleep, vec![]),
+        (libc::SYS_read, vec![]),
     ])
 }
 

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -1041,6 +1041,7 @@ fn event_monitor_thread_rules() -> Result<Vec<(i64, Vec<SeccompRule>)>, BackendE
         (libc::SYS_sched_yield, vec![]),
         (libc::SYS_write, vec![]),
         (libc::SYS_madvise, vec![]),
+        (libc::SYS_read, vec![]),
     ])
 }
 


### PR DESCRIPTION
Updates the seccomp rules for the http-server and the event-monitor. Pipelines that failed because of seccomp violations are linked in the commits.