### PR TITLE
Fix clippy failures for Rust 1.97

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -640,7 +640,7 @@ impl CpuidFeatureEntry {
             };
             if !entry_compatible {
                 error!(
-                    "Detected incompatible CPUID entry: leaf={:#02x} (subleaf={:#02x}), register='{:?}', \
+                    "Detected incompatible CPUID entry: leaf={:#04x} (subleaf={:#04x}), register='{:?}', \
                     compatible_check='{:?}', source VM feature='{:#04x}', destination VM feature'{:#04x}'.",
                     entry.function,
                     entry.index,

--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -608,7 +608,7 @@ impl CpuidFeatureEntry {
                     };
                     if !is_compatible {
                         info!(
-                            "CPUID incompatibility for value definition='{:?}' detected in leaf={:#02x}, sub-leaf={:#02x}, register={:?}, compatibility_check={:?}, source VM value='{:#04x}' destination VM value='{:#04x}'",
+                            "CPUID incompatibility for value definition='{:?}' detected in leaf={:#04x}, sub-leaf={:#04x}, register={:?}, compatibility_check={:?}, source VM value='{:#04x}' destination VM value='{:#04x}'",
                             def,
                             entry.function,
                             entry.index,

--- a/cloud-hypervisor/tests/common/utils.rs
+++ b/cloud-hypervisor/tests/common/utils.rs
@@ -80,7 +80,7 @@ impl TargetApi {
         if output.status.success() {
             true
         } else {
-            eprintln!("Error running ch-remote command: {:?}", &cmd);
+            eprintln!("Error running ch-remote command: {cmd:?}");
             let stderr = String::from_utf8_lossy(&output.stderr);
             eprintln!("stderr: {stderr}");
             false
@@ -1154,7 +1154,7 @@ pub(crate) fn start_live_migration(
 
     // Start to send migration from the source VM
     let args = [
-        format!("--api-socket={}", &src_api_socket),
+        format!("--api-socket={src_api_socket}"),
         "send-migration".to_string(),
         format!(
             "destination_url=unix:{migration_socket},local={}",

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -3467,7 +3467,7 @@ mod common_parallel {
                     guest.disk_config.disk(DiskType::CloudInit).unwrap()
                 )
                 .as_str(),
-                format!("path={},direct=on,image_type=raw", loop_dev).as_str(),
+                format!("path={loop_dev},direct=on,image_type=raw").as_str(),
             ])
             .default_net()
             .capture_output()
@@ -4108,7 +4108,7 @@ mod common_parallel {
                     guest.disk_config.disk(DiskType::CloudInit).unwrap()
                 )
                 .as_str(),
-                format!("path={},image_type=raw", loop_dev).as_str(),
+                format!("path={loop_dev},image_type=raw").as_str(),
             ])
             .default_net()
             .capture_output()
@@ -4284,7 +4284,7 @@ mod common_parallel {
                     guest.disk_config.disk(DiskType::CloudInit).unwrap()
                 )
                 .as_str(),
-                format!("path={},image_type=raw", dm_dev).as_str(),
+                format!("path={dm_dev},image_type=raw").as_str(),
             ])
             .default_net()
             .capture_output()

--- a/cloud-hypervisor/tests/integration.rs
+++ b/cloud-hypervisor/tests/integration.rs
@@ -1350,7 +1350,7 @@ mod common_parallel {
         assert!(
             exec_host_command_output(&format!(
                 "mount {} {}",
-                &loop_dev_path,
+                loop_dev_path,
                 mnt_dir.to_str().unwrap()
             ))
             .status
@@ -1363,7 +1363,7 @@ mod common_parallel {
         assert!(
             exec_host_command_output(&format!(
                 "cp {} {}",
-                &src_qcow2,
+                src_qcow2,
                 dest_qcow2.to_str().unwrap()
             ))
             .status
@@ -3467,7 +3467,7 @@ mod common_parallel {
                     guest.disk_config.disk(DiskType::CloudInit).unwrap()
                 )
                 .as_str(),
-                format!("path={},direct=on,image_type=raw", &loop_dev).as_str(),
+                format!("path={},direct=on,image_type=raw", loop_dev).as_str(),
             ])
             .default_net()
             .capture_output()
@@ -3543,7 +3543,7 @@ mod common_parallel {
         assert!(
             exec_host_command_output(&format!(
                 "mount {} {}",
-                &loop_dev_path,
+                loop_dev_path,
                 mnt_dir.to_str().unwrap()
             ))
             .status
@@ -4108,7 +4108,7 @@ mod common_parallel {
                     guest.disk_config.disk(DiskType::CloudInit).unwrap()
                 )
                 .as_str(),
-                format!("path={},image_type=raw", &loop_dev).as_str(),
+                format!("path={},image_type=raw", loop_dev).as_str(),
             ])
             .default_net()
             .capture_output()
@@ -4284,7 +4284,7 @@ mod common_parallel {
                     guest.disk_config.disk(DiskType::CloudInit).unwrap()
                 )
                 .as_str(),
-                format!("path={},image_type=raw", &dm_dev).as_str(),
+                format!("path={},image_type=raw", dm_dev).as_str(),
             ])
             .default_net()
             .capture_output()

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -1318,7 +1318,7 @@ impl vm::Vm for KvmVm {
     ///
     fn start_dirty_log(&self) -> vm::Result<()> {
         let dirty_log_slots = self.dirty_log_slots.read().unwrap();
-        for (_, s) in dirty_log_slots.iter() {
+        for s in dirty_log_slots.values() {
             let region = kvm_userspace_memory_region2 {
                 slot: s.slot,
                 guest_phys_addr: s.guest_phys_addr,
@@ -1344,7 +1344,7 @@ impl vm::Vm for KvmVm {
     ///
     fn stop_dirty_log(&self) -> vm::Result<()> {
         let dirty_log_slots = self.dirty_log_slots.read().unwrap();
-        for (_, s) in dirty_log_slots.iter() {
+        for s in dirty_log_slots.values() {
             let region = kvm_userspace_memory_region2 {
                 slot: s.slot,
                 guest_phys_addr: s.guest_phys_addr,

--- a/hypervisor/src/mshv/mod.rs
+++ b/hypervisor/src/mshv/mod.rs
@@ -2229,7 +2229,7 @@ impl vm::Vm for MshvVm {
         // Before disabling the dirty page tracking we need
         // to set the dirty bits in the Hypervisor
         // This is a requirement from Microsoft Hypervisor
-        for (_, s) in dirty_log_slots.iter() {
+        for s in dirty_log_slots.values() {
             self.fd
                 .get_dirty_log(
                     s.guest_pfn,

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2097,7 +2097,7 @@ pub fn remote_command(api_socket: &str, command: &str, arg: Option<&str>) -> boo
     if output.status.success() {
         true
     } else {
-        eprintln!("Error running ch-remote command: {:?}", &cmd);
+        eprintln!("Error running ch-remote command: {:?}", cmd);
         let stderr = String::from_utf8_lossy(&output.stderr);
         eprintln!("stderr: {stderr}");
         false

--- a/test_infra/src/lib.rs
+++ b/test_infra/src/lib.rs
@@ -2097,7 +2097,7 @@ pub fn remote_command(api_socket: &str, command: &str, arg: Option<&str>) -> boo
     if output.status.success() {
         true
     } else {
-        eprintln!("Error running ch-remote command: {:?}", cmd);
+        eprintln!("Error running ch-remote command: {cmd:?}");
         let stderr = String::from_utf8_lossy(&output.stderr);
         eprintln!("stderr: {stderr}");
         false

--- a/virtio-devices/src/mem.rs
+++ b/virtio-devices/src/mem.rs
@@ -514,7 +514,7 @@ impl MemEpollHandler {
         if plug {
             let mut gpa = addr;
             for _ in 0..nb_blocks {
-                for (_, handler) in handlers.iter() {
+                for handler in handlers.values() {
                     if let Err(e) = handler.map(gpa, gpa, config.block_size) {
                         error!(
                             "failed DMA mapping addr 0x{:x} size 0x{:x}: {}",
@@ -529,7 +529,7 @@ impl MemEpollHandler {
 
             config.plugged_size += size;
         } else {
-            for (_, handler) in handlers.iter() {
+            for handler in handlers.values() {
                 if let Err(e) = handler.unmap(addr, size) {
                     error!("failed DMA unmapping addr 0x{addr:x} size 0x{size:x}: {e}");
                     return VIRTIO_MEM_RESP_ERROR;
@@ -555,7 +555,7 @@ impl MemEpollHandler {
             for (idx, plugged) in self.blocks_state.lock().unwrap().inner().iter().enumerate() {
                 if *plugged {
                     let gpa = config.addr + (idx as u64 * config.block_size);
-                    for (_, handler) in handlers.iter() {
+                    for handler in handlers.values() {
                         if let Err(e) = handler.unmap(gpa, config.block_size) {
                             error!(
                                 "failed DMA unmapping addr 0x{:x} size 0x{:x}: {}",

--- a/virtio-devices/src/net.rs
+++ b/virtio-devices/src/net.rs
@@ -885,7 +885,7 @@ impl VirtioDevice for Net {
 
             let mut epoll_threads = Vec::new();
             spawn_virtio_thread(
-                &format!("{}_ctrl", &self.id),
+                &format!("{}_ctrl", self.id),
                 &self.seccomp_action,
                 Thread::VirtioNetCtl,
                 &mut epoll_threads,

--- a/virtio-devices/src/vhost_user/net.rs
+++ b/virtio-devices/src/vhost_user/net.rs
@@ -403,7 +403,7 @@ impl VirtioDevice for Net {
 
             let mut epoll_threads = Vec::new();
             spawn_virtio_thread(
-                &format!("{}_ctrl", &self.id),
+                &format!("{}_ctrl", self.id),
                 &self.seccomp_action,
                 Thread::VirtioVhostNetCtl,
                 &mut epoll_threads,

--- a/vmm/src/device_manager.rs
+++ b/vmm/src/device_manager.rs
@@ -3940,7 +3940,7 @@ impl DeviceManager {
             // Register DMA mapping in IOMMU.
             // Do not register virtio-mem regions, as they are handled directly by
             // virtio-mem device itself.
-            for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+            for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
                 for region in zone.regions() {
                     // vfio_dma_map is unsound and ought to be marked as unsafe
                     #[allow(unused_unsafe)]
@@ -4209,7 +4209,7 @@ impl DeviceManager {
                 .map_err(DeviceManagerError::AddDmaMappingHandlerVirtioMem)?;
         }
 
-        for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+        for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
             for region in zone.regions() {
                 vfio_user_pci_device
                     .dma_map(region)
@@ -4350,7 +4350,7 @@ impl DeviceManager {
 
                 // Do not register virtio-mem regions, as they are handled directly by
                 // virtio-mem devices.
-                for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
                     for region in zone.regions() {
                         let gpa = region.start_addr().0;
                         let size = region.len();
@@ -4935,7 +4935,7 @@ impl DeviceManager {
                 if let Some(dma_handler) = dev.dma_handler()
                     && !iommu_attached
                 {
-                    for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                    for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
                         for region in zone.regions() {
                             let iova = region.start_addr().0;
                             let size = region.len();
@@ -4955,7 +4955,7 @@ impl DeviceManager {
             }
             PciDeviceHandle::VfioUser(vfio_user_pci_device) => {
                 let mut dev = vfio_user_pci_device.lock().unwrap();
-                for (_, zone) in self.memory_manager.lock().unwrap().memory_zones().iter() {
+                for zone in self.memory_manager.lock().unwrap().memory_zones().values() {
                     for region in zone.regions() {
                         // On error, log, but continue so the loop below removing the mapping from
                         // the devices runs.

--- a/vmm/src/device_tree.rs
+++ b/vmm/src/device_tree.rs
@@ -114,7 +114,7 @@ impl<'a> BftIter<'a> {
         let mut nodes = Vec::with_capacity(hash_map.len());
         let mut i = 0;
 
-        for (_, node) in hash_map.iter() {
+        for node in hash_map.values() {
             if node.parent.is_none() {
                 nodes.push(node);
             }

--- a/vmm/src/interrupt.rs
+++ b/vmm/src/interrupt.rs
@@ -191,7 +191,7 @@ impl MsiInterruptGroup {
 
     fn set_gsi_routes(&self, routes: &HashMap<u32, RoutingEntry>) -> Result<()> {
         let mut entry_vec: Vec<IrqRoutingEntry> = Vec::new();
-        for (_, entry) in routes.iter() {
+        for entry in routes.values() {
             if entry.masked {
                 continue;
             }
@@ -207,7 +207,7 @@ impl MsiInterruptGroup {
 
 impl InterruptSourceGroup for MsiInterruptGroup {
     fn enable(&self) -> Result<()> {
-        for (_, route) in self.irq_routes.iter() {
+        for route in self.irq_routes.values() {
             route.lock().unwrap().enable(self.vm.as_ref())?;
         }
 
@@ -215,7 +215,7 @@ impl InterruptSourceGroup for MsiInterruptGroup {
     }
 
     fn disable(&self) -> Result<()> {
-        for (_, route) in self.irq_routes.iter() {
+        for route in self.irq_routes.values() {
             route.lock().unwrap().disable(self.vm.as_ref())?;
         }
 

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -3275,9 +3275,9 @@ impl RequestHandler for Vmm {
             "Receiving migration: receiver_url={},tls={},net_fds={:?}, tcp_url={:?}, zones={:?}",
             receive_data_migration.receiver_url,
             receive_data_migration.tls_dir.is_some(),
-            &receive_data_migration.net_fds,
-            &receive_data_migration.tcp_serial_url,
-            &receive_data_migration.zones,
+            receive_data_migration.net_fds,
+            receive_data_migration.tcp_serial_url,
+            receive_data_migration.zones,
         );
 
         let mut listener = migration_transport::receive_migration_listener(

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -598,7 +598,7 @@ impl Vm {
             .validate()
             .map_err(Error::ConfigValidation)?;
 
-        info!("Booting VM from config: {:?}", config);
+        info!("Booting VM from config: {config:?}");
 
         // Create NUMA nodes based on NumaConfig.
         let numa_nodes =

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -598,7 +598,7 @@ impl Vm {
             .validate()
             .map_err(Error::ConfigValidation)?;
 
-        info!("Booting VM from config: {:?}", &config);
+        info!("Booting VM from config: {:?}", config);
 
         // Create NUMA nodes based on NumaConfig.
         let numa_nodes =


### PR DESCRIPTION
Backport clippy fixes from https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8282 and fix remaining issues.

With the release of Rust 1.97 today, those lints are making CI fail (https://github.com/cyberus-technology/cloud-hypervisor/actions/runs/29020654414/job/86126582787?pr=180)

Libvirt pipeline: https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/merge_requests/255

Fixes: https://github.com/cobaltcore-dev/cobaltcore/issues/629