### PR TITLE
Use `KVM_PRE_FAULT_MEMORY` ioctl during boot and restore

### DIFF
--- a/hypervisor/src/cpu.rs
+++ b/hypervisor/src/cpu.rs
@@ -338,6 +338,9 @@ pub enum HypervisorCpuError {
     GetNestedState(#[source] anyhow::Error),
     #[error("Failed to set nested guest state")]
     SetNestedState(#[source] anyhow::Error),
+
+    #[error("Failed to prefault guest memory")]
+    PrefaultMemory(#[source] anyhow::Error),
 }
 
 #[derive(Debug)]
@@ -618,4 +621,8 @@ pub trait Vcpu: Send + Sync {
     /// signal handler and only use it from there.
     #[cfg(feature = "kvm")]
     unsafe fn get_kvm_vcpu_raw_fd(&self) -> RawFd;
+
+    fn prefault_memory(&self, _gpa: u64, _size: u64) -> Result<()> {
+        Ok(())
+    }
 }

--- a/hypervisor/src/kvm/mod.rs
+++ b/hypervisor/src/kvm/mod.rs
@@ -17,6 +17,7 @@ use std::mem::offset_of;
 #[cfg(feature = "sev_snp")]
 use std::os::fd::FromRawFd;
 use std::os::fd::OwnedFd;
+use std::os::raw::c_ulong;
 #[cfg(any(feature = "kvm", feature = "sev_snp"))]
 use std::os::unix::io::AsRawFd;
 #[cfg(any(feature = "kvm", feature = "tdx"))]
@@ -34,11 +35,12 @@ use kvm_bindings::kvm_create_guest_memfd;
 use kvm_ioctls::{NoDatamatch, VcpuFd, VmFd};
 #[cfg(feature = "sev_snp")]
 use log::debug;
-use log::trace;
 #[cfg(target_arch = "x86_64")]
 use log::warn;
-use vmm_sys_util::errno;
+use log::{info, trace};
 use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::ioctl::ioctl_with_mut_ref;
+use vmm_sys_util::{errno, ioctl_iowr_nr};
 
 #[cfg(target_arch = "aarch64")]
 use crate::aarch64::gic::KvmGicV3Its;
@@ -129,10 +131,10 @@ pub use kvm_ioctls::{self, Cap, Kvm, VcpuExit};
 use log::error;
 use thiserror::Error;
 use vfio_ioctls::VfioDeviceFd;
+#[cfg(feature = "tdx")]
+use vmm_sys_util::ioctl::ioctl_with_val;
 #[cfg(target_arch = "x86_64")]
 use vmm_sys_util::{fam::FamStruct, ioctl_io_nr};
-#[cfg(feature = "tdx")]
-use vmm_sys_util::{ioctl::ioctl_with_val, ioctl_iowr_nr};
 
 #[cfg(any(target_arch = "aarch64", target_arch = "riscv64"))]
 use crate::RegList;
@@ -313,6 +315,13 @@ pub struct KvmTdxExitVmcall {
     pub out_r9: u64,
     pub out_rdx: u64,
 }
+
+ioctl_iowr_nr!(
+    KVM_PRE_FAULT_MEMORY,
+    kvm_bindings::KVMIO,
+    0xd5,
+    kvm_bindings::kvm_pre_fault_memory
+);
 
 impl From<kvm_userspace_memory_region2> for UserMemoryRegion {
     fn from(region: kvm_userspace_memory_region2) -> Self {
@@ -1469,6 +1478,12 @@ impl vm::Vm for KvmVm {
     /// Downcast to the underlying KvmVm type
     fn as_any(&self) -> &dyn Any {
         self
+    }
+
+    fn supports_prefault_memory(&self) -> bool {
+        self.fd
+            .check_extension_raw(kvm_bindings::KVM_CAP_PRE_FAULT_MEMORY as c_ulong)
+            > 0
     }
 }
 
@@ -3566,6 +3581,37 @@ impl cpu::Vcpu for KvmVcpu {
         self.fd
             .set_regs(&regs)
             .map_err(|e: kvm_ioctls::Error| cpu::HypervisorCpuError::SetRegister(e.into()))?;
+
+        Ok(())
+    }
+
+    /// Prefault the given memory range into KVMs level 2 page tables.
+    fn prefault_memory(&self, gpa: u64, size: u64) -> cpu::Result<()> {
+        let mut req = kvm_bindings::kvm_pre_fault_memory {
+            gpa,
+            size,
+            flags: 0,
+            padding: [0; 5],
+        };
+        info!(
+            "KVM_PRE_FAULT_MEMORY: GPA: {:#x}, SIZE: {:#x}",
+            req.gpa, req.size
+        );
+
+        // When KVM_PRE_FAULT_MEMORY returns, the input values are updated to point to
+        // the remaining range. If size > 0 on return, the ioctl can be issued again
+        // with the same argument.
+        while req.size > 0 {
+            // SAFETY: valid vCPU fd, valid in/out request buffer, return value is checked.
+            let ret = unsafe { ioctl_with_mut_ref(&self.fd, KVM_PRE_FAULT_MEMORY(), &mut req) };
+            if ret != 0 {
+                let err = std::io::Error::last_os_error();
+                error!("KVM_PRE_FAULT_MEMORY failed: ret={ret}, err={err}");
+                return Err(cpu::HypervisorCpuError::PrefaultMemory(anyhow!(
+                    "KVM_PRE_FAULT_MEMORY failed: ret={ret}, err={err}"
+                )));
+            }
+        }
 
         Ok(())
     }

--- a/hypervisor/src/vm.rs
+++ b/hypervisor/src/vm.rs
@@ -505,6 +505,12 @@ pub trait Vm: Send + Sync + Any {
     fn enable_x2apic_api(&self) -> Result<()> {
         unimplemented!("x2Apic is only supported on KVM/Linux hosts")
     }
+
+    /// Returns true if prefaulting memory into the level 2 page tables is supported
+    /// for this VM.
+    fn supports_prefault_memory(&self) -> bool {
+        false
+    }
 }
 
 pub trait VmOps: Send + Sync {

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -245,6 +245,9 @@ pub enum Error {
 
     #[error("Error enabling core scheduling")]
     CoreScheduling(#[source] io::Error),
+
+    #[error("Error prefaulting guest memory")]
+    PrefaultGuestMemory(#[source] hypervisor::HypervisorCpuError),
 }
 pub type Result<T> = result::Result<T, Error>;
 

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -1146,6 +1146,33 @@ impl CpuManager {
         Ok(vcpu)
     }
 
+    /// Applies the given snapshot to all vCPUs. The vCPUs can already be created at
+    /// this point.
+    pub fn restore_vcpu_states(&mut self, snapshot: Option<&Snapshot>) -> Result<()> {
+        let Some(snapshot) = snapshot else {
+            return Ok(());
+        };
+
+        for (cpu_id, vcpu) in self.vcpus.iter().enumerate() {
+            let mut vcpu = vcpu.lock().unwrap();
+            let vcpu_snapshot = snapshot_from_id(Some(snapshot), cpu_id.to_string().as_str())
+                .ok_or_else(|| {
+                    Error::VcpuCreate(anyhow!("Could not find snapshot for vCPU {cpu_id}"))
+                })?;
+
+            let state: CpuState = vcpu_snapshot.to_state().map_err(|e| {
+                Error::VcpuCreate(anyhow!("Could not get vCPU state from snapshot {e:?}"))
+            })?;
+
+            vcpu.vcpu
+                .set_state(&state)
+                .map_err(|e| Error::VcpuCreate(anyhow!("Could not set the vCPU state {e:?}")))?;
+            vcpu.saved_state = Some(state);
+        }
+
+        Ok(())
+    }
+
     pub fn configure_vcpu(
         &self,
         vcpu: &mut Vcpu,

--- a/vmm/src/cpu.rs
+++ b/vmm/src/cpu.rs
@@ -74,6 +74,7 @@ use vm_memory::ByteValued;
 #[cfg(feature = "guest_debug")]
 use vm_memory::{Bytes, GuestAddressSpace};
 use vm_memory::{GuestAddress, GuestMemoryAtomic};
+use vm_migration::protocol::MemoryRangeTable;
 use vm_migration::{
     Migratable, MigratableError, Pausable, Snapshot, SnapshotData, Snapshottable, Transportable,
     snapshot_from_id,
@@ -1269,6 +1270,7 @@ impl CpuManager {
         vcpu_id: u32,
         vcpu_thread_barrier: Arc<Barrier>,
         inserting: bool,
+        prefault_ranges: Option<MemoryRangeTable>,
     ) -> Result<()> {
         let reset_evt = self.reset_evt.try_clone().unwrap();
         let exit_evt = self.exit_evt.try_clone().unwrap();
@@ -1437,6 +1439,16 @@ impl CpuManager {
                             error!("Error applying seccomp filter: {e:?}");
                             return;
                         }
+
+                    if let Some(ranges)= prefault_ranges.as_ref() {
+                        let vcpu = vcpu.lock().unwrap();
+                        for range in ranges.ranges() {
+                            if let Err(e) = vcpu.vcpu.prefault_memory(range.gpa, range.length) {
+                                error!("Error prefaulting guest memory (GPA: {:#x}, size: {:#x} for vCPU {vcpu_id}: {e}", range.gpa, range.length);
+                                return;
+                            }
+                        }
+                    }
 
                     #[cfg(not(feature = "kvm"))]
                     extern "C" fn handle_signal(_: i32, _: *mut siginfo_t, _: *mut c_void) {}
@@ -1640,6 +1652,7 @@ impl CpuManager {
         desired_vcpus: u32,
         inserting: bool,
         paused: Option<bool>,
+        mut prefault_ranges: Option<MemoryRangeTable>,
     ) -> Result<()> {
         if desired_vcpus > self.config.max_vcpus {
             return Err(Error::DesiredVCpuCountExceedsMax);
@@ -1664,7 +1677,13 @@ impl CpuManager {
         // This reuses any inactive vCPUs as well as any that were newly created
         for vcpu_id in self.present_vcpus()..desired_vcpus {
             let vcpu = Arc::clone(&self.vcpus[vcpu_id as usize]);
-            self.start_vcpu(vcpu, vcpu_id, vcpu_thread_barrier.clone(), inserting)?;
+            self.start_vcpu(
+                vcpu,
+                vcpu_id,
+                vcpu_thread_barrier.clone(),
+                inserting,
+                prefault_ranges.take(),
+            )?;
         }
 
         // Unblock all CPU threads.
@@ -1704,8 +1723,12 @@ impl CpuManager {
     }
 
     // Starts all the vCPUs that the VM is booting with. Blocks until all vCPUs are running.
-    pub fn start_boot_vcpus(&mut self, paused: bool) -> Result<()> {
-        self.activate_vcpus(self.boot_vcpus(), false, Some(paused))
+    pub fn start_boot_vcpus(
+        &mut self,
+        paused: bool,
+        prefault_ranges: Option<MemoryRangeTable>,
+    ) -> Result<()> {
+        self.activate_vcpus(self.boot_vcpus(), false, Some(paused), prefault_ranges)
     }
 
     #[cfg(feature = "mshv")]
@@ -1727,8 +1750,11 @@ impl CpuManager {
         Ok(())
     }
 
-    pub fn start_restored_vcpus(&mut self) -> Result<()> {
-        self.activate_vcpus(self.vcpus.len() as u32, false, Some(true))
+    pub fn start_restored_vcpus(
+        &mut self,
+        prefault_ranges: Option<MemoryRangeTable>,
+    ) -> Result<()> {
+        self.activate_vcpus(self.vcpus.len() as u32, false, Some(true), prefault_ranges)
             .map_err(|e| {
                 Error::StartRestoreVcpu(anyhow!("Failed to start restored vCPUs: {e:#?}"))
             })?;
@@ -1760,7 +1786,7 @@ impl CpuManager {
                     let mut vcpu = vcpu.lock().unwrap();
                     self.configure_vcpu(&mut vcpu, None)?;
                 }
-                self.activate_vcpus(desired_vcpus, true, None)?;
+                self.activate_vcpus(desired_vcpus, true, None, None)?;
                 Ok(true)
             }
             cmp::Ordering::Less => {

--- a/vmm/src/lib.rs
+++ b/vmm/src/lib.rs
@@ -79,7 +79,7 @@ use crate::migration_transport::{
     ReceiveAdditionalConnections, ReceiveListener, SendAdditionalConnections, SocketStream,
 };
 use crate::seccomp_filters::{Thread, get_seccomp_filter};
-use crate::vm::{Error as VmError, PostMigrationLifecycleEvent, Vm, VmState};
+use crate::vm::{Error as VmError, PostMigrationLifecycleEvent, Vm, VmRestoreShell, VmState};
 use crate::vm_config::{
     DeviceConfig, DiskConfig, FsConfig, GenericVhostUserConfig, MemoryZoneConfig, NetConfig,
     PmemConfig, UserDeviceConfig, VdpaConfig, VmConfig, VsockConfig,
@@ -882,7 +882,7 @@ pub struct Vmm {
 /// Just a wrapper for the data that goes into
 /// [`ReceiveMigrationState::Configured`]
 struct ReceiveMigrationConfiguredData {
-    memory_manager: Arc<Mutex<MemoryManager>>,
+    vm: VmRestoreShell,
     guest_memory: GuestMemoryAtomic<GuestMemoryMmap>,
     connections: ReceiveAdditionalConnections,
 }
@@ -901,9 +901,8 @@ enum ReceiveMigrationState {
     /// around to populate it without having to acquire a lock (which we would have to do
     /// when accessing the memory through the memory manager).
     ///
-    /// We keep the memory manager around to pass it into the next state. From this point
-    /// on, the sender can start sending memory updates.
-    Configured(ReceiveMigrationConfiguredData),
+    /// We keep the restore shell around to finish VM construction in the next state.
+    Configured(Box<ReceiveMigrationConfiguredData>),
 
     /// Memory is populated and we received the state. The VM is ready to go.
     StateReceived {
@@ -1166,46 +1165,52 @@ impl Vmm {
             )))
         };
 
-        let mut configure_vm =
-            |socket: &mut SocketStream,
-             memory_files: HashMap<u32, File>|
-             -> std::result::Result<ReceiveMigrationConfiguredData, MigratableError> {
-                let memory_manager = self.vm_receive_config(
-                    req,
-                    socket,
-                    memory_files,
-                    receive_data_migration.tcp_serial_url.clone(),
-                    receive_data_migration.zones.clone(),
-                )?;
+        let mut configure_vm = |socket: &mut SocketStream,
+                                memory_files: HashMap<u32, File>|
+         -> std::result::Result<
+            Box<ReceiveMigrationConfiguredData>,
+            MigratableError,
+        > {
+            let vm = self.vm_receive_config(
+                req,
+                socket,
+                memory_files,
+                receive_data_migration.tcp_serial_url.clone(),
+                receive_data_migration.zones.clone(),
+            )?;
 
-                if !receive_data_migration.net_fds.is_empty() {
-                    let mut vm_config = self.vm_config.as_mut().unwrap().lock().unwrap();
-                    for restored_net in &receive_data_migration.net_fds {
-                        for net_config in vm_config.net.iter_mut().flatten() {
-                            // Only update net devices that are backed directly by file descriptors.
-                            if net_config.pci_common.id.as_ref() == Some(&restored_net.id)
-                                && net_config.fds.is_some()
-                            {
-                                net_config.fds.clone_from(&restored_net.fds);
-                            }
+            if !receive_data_migration.net_fds.is_empty() {
+                let mut vm_config = self.vm_config.as_mut().unwrap().lock().unwrap();
+                for restored_net in &receive_data_migration.net_fds {
+                    for net_config in vm_config.net.iter_mut().flatten() {
+                        // Only update net devices that are backed directly by file descriptors.
+                        if net_config.pci_common.id.as_ref() == Some(&restored_net.id)
+                            && net_config.fds.is_some()
+                        {
+                            net_config.fds.clone_from(&restored_net.fds);
                         }
                     }
                 }
+            }
 
-                let guest_memory = memory_manager.lock().unwrap().guest_memory();
-                // Create the additional-connection receiver even in the single-connection case.
-                // At this point the receiver does not know whether the sender will use extra TCP
-                // connections. If it does not, no worker connections are accepted and memory
-                // requests continue to arrive on the main connection.
-                let connections = listener
-                    .try_clone()
-                    .and_then(|l| ReceiveAdditionalConnections::new(l, guest_memory.clone()))?;
-                Ok(ReceiveMigrationConfiguredData {
-                    memory_manager,
-                    guest_memory,
-                    connections,
-                })
-            };
+            vm.start_restored_vcpus().map_err(|e| {
+                MigratableError::MigrateReceive(anyhow!("Error starting restored vCPUs: {e:?}"))
+            })?;
+
+            let guest_memory = vm.guest_memory();
+            // Create the additional-connection receiver even in the single-connection case.
+            // At this point the receiver does not know whether the sender will use extra TCP
+            // connections. If it does not, no worker connections are accepted and memory
+            // requests continue to arrive on the main connection.
+            let connections = listener
+                .try_clone()
+                .and_then(|l| ReceiveAdditionalConnections::new(l, guest_memory.clone()))?;
+            Ok(Box::new(ReceiveMigrationConfiguredData {
+                vm,
+                guest_memory,
+                connections,
+            }))
+        };
 
         let recv_memory_fd = |socket: &mut SocketStream,
                               mut memory_files: Vec<(u32, File)>|
@@ -1266,7 +1271,7 @@ impl Vmm {
                     let state_receive_begin = Instant::now();
                     config_data.connections.cleanup()?;
                     let (recv_state_dur, restore_vm_dur) =
-                        self.vm_receive_state(req, socket, config_data.memory_manager)?;
+                        self.vm_receive_state(req, socket, config_data.vm)?;
                     debug!(
                         "Migration (incoming): recv_snapshot:{}ms restore:{}ms",
                         recv_state_dur.as_millis(),
@@ -1349,7 +1354,7 @@ impl Vmm {
         existing_memory_files: HashMap<u32, File>,
         tcp_serial_url: Option<String>,
         zones: Vec<MemoryZoneConfig>,
-    ) -> std::result::Result<Arc<Mutex<MemoryManager>>, MigratableError>
+    ) -> std::result::Result<VmRestoreShell, MigratableError>
     where
         T: Read,
     {
@@ -1455,7 +1460,7 @@ impl Vmm {
         );
 
         let memory_manager = MemoryManager::new(
-            vm,
+            vm.clone(),
             &config.lock().unwrap().memory.clone(),
             None,
             phys_bits,
@@ -1467,7 +1472,42 @@ impl Vmm {
         .context("Error creating MemoryManager from snapshot")
         .map_err(MigratableError::MigrateReceive)?;
 
-        Ok(memory_manager)
+        memory_manager
+            .lock()
+            .unwrap()
+            .allocate_address_space()
+            .context("Error allocating address spaces")
+            .map_err(MigratableError::MigrateReceive)?;
+
+        let vm = Vm::new_restore_shell(
+            config,
+            memory_manager,
+            vm,
+            self.exit_evt
+                .try_clone()
+                .context("Error cloning exit EventFd")
+                .map_err(MigratableError::MigrateReceive)?,
+            self.reset_evt
+                .try_clone()
+                .context("Error cloning reset EventFd")
+                .map_err(MigratableError::MigrateReceive)?,
+            #[cfg(feature = "guest_debug")]
+            self.vm_debug_evt
+                .try_clone()
+                .context("Error cloning debug EventFd")
+                .map_err(MigratableError::MigrateReceive)?,
+            &self.seccomp_action,
+            self.hypervisor.clone(),
+            self.activate_evt
+                .try_clone()
+                .context("Error cloning activate EventFd")
+                .map_err(MigratableError::MigrateReceive)?,
+        )
+        .map_err(|e| {
+            MigratableError::MigrateReceive(anyhow!("Error creating restore shell: {e:?}"))
+        })?;
+
+        Ok(vm)
     }
 
     /// Receives the final VM state (devices, vCPUs) and restores the VM.
@@ -1477,7 +1517,7 @@ impl Vmm {
         &mut self,
         req: &Request,
         socket: &mut T,
-        mm: Arc<Mutex<MemoryManager>>,
+        vm_shell: VmRestoreShell,
     ) -> std::result::Result<
         (
             Duration, /* state receive + deserialize */
@@ -1517,52 +1557,29 @@ impl Vmm {
         let guest_exit_evt = self.guest_exit_evt.try_clone().map_err(|e| {
             MigratableError::MigrateReceive(anyhow!("Error cloning guest exit EventFd: {e}"))
         })?;
-        #[cfg(feature = "guest_debug")]
-        let debug_evt = self
-            .vm_debug_evt
-            .try_clone()
-            .context("Error clonung debug EventFd")
-            .map_err(MigratableError::MigrateReceive)?;
-        let activate_evt = self
-            .activate_evt
-            .try_clone()
-            .context("Error cloning activate EventFd")
-            .map_err(MigratableError::MigrateReceive)?;
 
         let (vm, restore_duration) = measure_ok(|| {
             #[cfg(not(target_arch = "riscv64"))]
             let timestamp = Instant::now();
-            let hypervisor_vm = mm.lock().unwrap().vm.clone();
 
-            let mut vm = Vm::new_from_memory_manager(
-                self.vm_config.clone().unwrap(),
-                mm,
-                hypervisor_vm,
-                exit_evt,
-                reset_evt,
-                guest_exit_evt,
-                #[cfg(feature = "guest_debug")]
-                debug_evt,
-                &self.seccomp_action,
-                self.hypervisor.clone(),
-                activate_evt,
-                #[cfg(not(target_arch = "riscv64"))]
-                timestamp,
-                self.console_info.clone(),
-                self.console_resize_pipe.clone(),
-                Arc::clone(&self.original_termios_opt),
-                Some(&snapshot),
-                #[cfg(feature = "igvm")]
-                None,
-            )
-            .map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Error creating VM from snapshot: {e:?}"))
-            })?;
-
-            // Create VM
-            vm.restore().map_err(|e| {
-                MigratableError::MigrateReceive(anyhow!("Failed restoring the Vm: {e}"))
-            })?;
+            let vm = vm_shell
+                .finish(
+                    exit_evt,
+                    reset_evt,
+                    guest_exit_evt,
+                    &self.activate_evt,
+                    #[cfg(not(target_arch = "riscv64"))]
+                    timestamp,
+                    self.console_info.as_ref(),
+                    self.console_resize_pipe.as_ref(),
+                    &self.original_termios_opt,
+                    Some(&snapshot),
+                )
+                .map_err(|e| {
+                    MigratableError::MigrateReceive(anyhow!(
+                        "Error creating VM from snapshot: {e:?}"
+                    ))
+                })?;
 
             Ok(vm)
         })?;

--- a/vmm/src/memory_manager.rs
+++ b/vmm/src/memory_manager.rs
@@ -176,10 +176,17 @@ pub struct MemoryZone {
     hugepages: bool,
     backing_page_size: u64,
     mergeable: bool,
+    prefault: bool,
 }
 
 impl MemoryZone {
-    fn new(shared: bool, hugepages: bool, backing_page_size: u64, mergeable: bool) -> Self {
+    fn new(
+        shared: bool,
+        hugepages: bool,
+        backing_page_size: u64,
+        mergeable: bool,
+        prefault: bool,
+    ) -> Self {
         Self {
             regions: Vec::new(),
             virtio_mem_zone: None,
@@ -187,6 +194,7 @@ impl MemoryZone {
             hugepages,
             backing_page_size,
             mergeable,
+            prefault,
         }
     }
 
@@ -198,6 +206,10 @@ impl MemoryZone {
     }
     pub fn virtio_mem_zone_mut(&mut self) -> Option<&mut VirtioMemZone> {
         self.virtio_mem_zone.as_mut()
+    }
+
+    pub fn prefault(&self) -> bool {
+        self.prefault
     }
 
     fn backing_page_size_for_gpa(&self, gpa: u64) -> Option<u64> {
@@ -654,7 +666,13 @@ impl MemoryManager {
         // Add zone id to the list of memory zones.
         memory_zones.insert(
             zone.id.clone(),
-            MemoryZone::new(zone.shared, zone.hugepages, zone_align_size, zone.mergeable),
+            MemoryZone::new(
+                zone.shared,
+                zone.hugepages,
+                zone_align_size,
+                zone.mergeable,
+                prefault.unwrap_or(zone.prefault),
+            ),
         );
 
         for ram_region in ram_regions.iter() {
@@ -753,6 +771,7 @@ impl MemoryManager {
                             zone.hugepages,
                             zone_align_size,
                             zone.mergeable,
+                            prefault.unwrap_or(zone.prefault),
                         ),
                     );
                 }
@@ -790,6 +809,7 @@ impl MemoryManager {
                     zone_config.hugepages,
                     zone_page_size,
                     zone_config.mergeable,
+                    prefault.unwrap_or(zone_config.prefault),
                 ),
             );
         }
@@ -2602,6 +2622,36 @@ impl MemoryManager {
         }
 
         Ok(table)
+    }
+
+    /// Returns all memory ranges with prefault enabled.
+    pub fn prefault_memory_range_table(&self, snapshot: bool) -> MemoryRangeTable {
+        if self.prefault
+            && let Ok(table) = self.memory_range_table(snapshot)
+        {
+            return table;
+        }
+
+        let mut table = MemoryRangeTable::default();
+
+        for memory_zone in self.memory_zones.values() {
+            if !memory_zone.prefault() {
+                continue;
+            }
+
+            if let Some(virtio_mem_zone) = memory_zone.virtio_mem_zone() {
+                table.extend(virtio_mem_zone.plugged_ranges());
+            }
+
+            memory_zone.regions().iter().for_each(|region| {
+                table.push(MemoryRange {
+                    gpa: region.start_addr().raw_value(),
+                    length: region.len(),
+                });
+            });
+        }
+
+        table
     }
 
     pub fn snapshot_data(&self) -> MemoryManagerSnapshotData {

--- a/vmm/src/seccomp_filters.rs
+++ b/vmm/src/seccomp_filters.rs
@@ -117,6 +117,7 @@ mod kvm {
     pub const KVM_SEV_SNP_LAUNCH_START: u64 = 0x4018_aeb4;
     pub const KVM_SEV_SNP_LAUNCH_UPDATE: u64 = 0x8018_aeb5;
     pub const KVM_SEV_SNP_LAUNCH_FINISH: u64 = 0x4008_aeb7;
+    pub const KVM_PRE_FAULT_MEMORY: u64 = 0xc040_aed5;
 }
 
 mod iommufd {
@@ -277,6 +278,7 @@ fn create_vmm_ioctl_seccomp_rule_common_kvm() -> Result<Vec<SeccompRule>, Backen
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SEV_SNP_LAUNCH_START)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SEV_SNP_LAUNCH_UPDATE)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SEV_SNP_LAUNCH_FINISH)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_PRE_FAULT_MEMORY)?],
     ])
 }
 
@@ -488,6 +490,7 @@ fn create_vmm_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError>
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_XSAVE,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_XSAVE2,)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_KVMCLOCK_CTRL)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_PRE_FAULT_MEMORY)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_CLOCK)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_CPUID2)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_FPU)?],
@@ -791,6 +794,7 @@ fn create_vcpu_ioctl_seccomp_rule_kvm() -> Result<Vec<SeccompRule>, BackendError
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_NMI)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_GET_NESTED_STATE)?],
         and![Cond::new(1, ArgLen::Dword, Eq, KVM_SET_NESTED_STATE)?],
+        and![Cond::new(1, ArgLen::Dword, Eq, KVM_PRE_FAULT_MEMORY)?],
     ])
 }
 

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -548,6 +548,201 @@ pub struct Vm {
     post_migration_lifecycle_event: Option<PostMigrationLifecycleEvent>,
 }
 
+/// Early VM state used during incoming migration.
+pub(crate) struct VmRestoreShell {
+    config: Arc<Mutex<VmConfig>>,
+    vm: Arc<dyn hypervisor::Vm>,
+    memory_manager: Arc<Mutex<MemoryManager>>,
+    cpu_manager: Arc<Mutex<cpu::CpuManager>>,
+    io_bus: Arc<Bus>,
+    mmio_bus: Arc<Bus>,
+    seccomp_action: SeccompAction,
+    #[cfg(not(target_arch = "riscv64"))]
+    numa_nodes: NumaNodes,
+    #[cfg(not(target_arch = "riscv64"))]
+    hypervisor: Arc<dyn hypervisor::Hypervisor>,
+    stop_on_boot: bool,
+    force_access_platform: bool,
+    #[cfg(feature = "igvm")]
+    igvm_file: Option<IgvmFile>,
+}
+
+impl VmRestoreShell {
+    pub(crate) fn start_restored_vcpus(&self) -> Result<()> {
+        info!("receiver restore phase: start_restored_vcpus");
+
+        if self.cpu_manager.lock().unwrap().vcpus().is_empty() {
+            info!("creating vCPUs");
+            self.cpu_manager
+                .lock()
+                .unwrap()
+                .create_boot_vcpus(None)
+                .map_err(Error::CpuManager)?;
+        }
+
+        let prefault_ranges = {
+            let prefault_ranges = self
+                .memory_manager
+                .lock()
+                .unwrap()
+                .prefault_memory_range_table(false);
+            if !self.vm.supports_prefault_memory() || prefault_ranges.is_empty() {
+                None
+            } else {
+                Some(prefault_ranges)
+            }
+        };
+
+        self.cpu_manager
+            .lock()
+            .unwrap()
+            .start_restored_vcpus(prefault_ranges)
+            .map_err(Error::CpuManager)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn finish(
+        self,
+        exit_evt: EventFd,
+        reset_evt: EventFd,
+        guest_exit_evt: EventFd,
+        activate_evt: &EventFd,
+        #[cfg(not(target_arch = "riscv64"))] timestamp: Instant,
+        console_info: Option<&ConsoleInfo>,
+        console_resize_pipe: Option<&Arc<File>>,
+        original_termios: &Arc<Mutex<Option<termios>>>,
+        snapshot: Option<&Snapshot>,
+    ) -> Result<Vm> {
+        info!("restore finalization: applying final VM state");
+
+        let boot_id_list = self
+            .config
+            .lock()
+            .unwrap()
+            .validate()
+            .map_err(Error::ConfigValidation)?;
+
+        if let Some(snapshot) = snapshot {
+            self.cpu_manager
+                .lock()
+                .unwrap()
+                .restore_vcpu_states(snapshot_from_id(Some(snapshot), CPU_MANAGER_SNAPSHOT_ID))
+                .map_err(Error::CpuManager)?;
+        }
+
+        let device_manager = Vm::create_device_manager(
+            self.io_bus,
+            self.mmio_bus,
+            self.vm.clone(),
+            self.config.clone(),
+            self.memory_manager.clone(),
+            self.cpu_manager.clone(),
+            exit_evt,
+            reset_evt,
+            guest_exit_evt,
+            self.seccomp_action,
+            self.numa_nodes.clone(),
+            activate_evt,
+            self.force_access_platform,
+            boot_id_list,
+            #[cfg(not(target_arch = "riscv64"))]
+            timestamp,
+            snapshot,
+        )?;
+
+        let load_payload_handle = Vm::hypervisor_specific_init(
+            &self.vm,
+            &self.memory_manager,
+            &self.cpu_manager,
+            &device_manager,
+            &self.config,
+            &self.hypervisor,
+            console_info,
+            console_resize_pipe,
+            original_termios,
+            snapshot,
+            #[cfg(feature = "igvm")]
+            self.igvm_file,
+        )?;
+
+        #[cfg(feature = "tdx")]
+        let kernel = self
+            .config
+            .lock()
+            .unwrap()
+            .payload
+            .as_ref()
+            .map(|p| p.kernel.as_ref().map(File::open))
+            .unwrap_or_default()
+            .transpose()
+            .map_err(Error::KernelFile)?;
+
+        let initramfs = self
+            .config
+            .lock()
+            .unwrap()
+            .payload
+            .as_ref()
+            .map(|p| p.initramfs.as_ref().map(File::open))
+            .unwrap_or_default()
+            .transpose()
+            .map_err(Error::InitramfsFile)?;
+
+        #[cfg(target_arch = "x86_64")]
+        let saved_clock = if let Some(snapshot) = snapshot.as_ref() {
+            let vm_snapshot = get_vm_snapshot(snapshot).map_err(Error::Restore)?;
+            vm_snapshot.clock
+        } else {
+            None
+        };
+
+        let state = if snapshot.is_some() {
+            VmState::Paused
+        } else {
+            VmState::Created
+        };
+
+        let post_migration_lifecycle_event = snapshot
+            .as_ref()
+            .map(|snapshot| {
+                get_vm_snapshot(snapshot)
+                    .map(|vm_snapshot| vm_snapshot.post_migration_lifecycle_event)
+                    .map_err(Error::Restore)
+            })
+            .transpose()?
+            .flatten();
+
+        let vcpu_throttler = ThrottleThreadHandle::new_from_cpu_manager(&self.cpu_manager);
+
+        Ok(Vm {
+            #[cfg(feature = "tdx")]
+            kernel,
+            initramfs,
+            device_manager,
+            config: self.config,
+            threads: Vec::with_capacity(1),
+            state,
+            cpu_manager: self.cpu_manager,
+            memory_manager: self.memory_manager,
+            vm: self.vm,
+            #[cfg(target_arch = "x86_64")]
+            saved_clock,
+            #[cfg(not(target_arch = "riscv64"))]
+            numa_nodes: self.numa_nodes,
+            #[cfg(not(target_arch = "riscv64"))]
+            hypervisor: self.hypervisor,
+            stop_on_boot: self.stop_on_boot,
+            load_payload_handle,
+            vcpu_throttler,
+            post_migration_lifecycle_event,
+        })
+    }
+
+    pub(crate) fn guest_memory(&self) -> GuestMemoryAtomic<GuestMemoryMmap> {
+        self.memory_manager.lock().unwrap().guest_memory()
+    }
+}
+
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PostMigrationLifecycleEvent {
     VmReboot,
@@ -568,6 +763,87 @@ impl Vm {
             .with_smt(1)
             .with_reserved_must_be_one(1)
             .with_migrate_ma(0)
+    }
+
+    #[allow(clippy::needless_pass_by_value)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn new_restore_shell(
+        config: Arc<Mutex<VmConfig>>,
+        memory_manager: Arc<Mutex<MemoryManager>>,
+        vm: Arc<dyn hypervisor::Vm>,
+        exit_evt: EventFd,
+        reset_evt: EventFd,
+        #[cfg(feature = "guest_debug")] vm_debug_evt: EventFd,
+        seccomp_action: &SeccompAction,
+        hypervisor: Arc<dyn hypervisor::Hypervisor>,
+        _activate_evt: EventFd,
+    ) -> Result<VmRestoreShell> {
+        #[cfg(feature = "igvm")]
+        let igvm_file = {
+            let config = config.lock().unwrap();
+            config
+                .payload
+                .as_ref()
+                .and_then(|p| p.igvm.as_ref())
+                .map(|igvm_path| crate::igvm::parse_igvm(igvm_path))
+                .transpose()
+                .map_err(Error::IgvmLoad)?
+        };
+
+        #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+        if config.lock().unwrap().max_apic_id() > MAX_SUPPORTED_CPUS_LEGACY {
+            vm.enable_x2apic_api().unwrap();
+        }
+
+        let numa_nodes =
+            Self::create_numa_nodes(config.lock().unwrap().numa.as_deref(), &memory_manager)?;
+        let force_access_platform = Self::should_force_access_platform(&config);
+        let stop_on_boot = Self::should_stop_on_boot(&config);
+
+        let memory = memory_manager.lock().unwrap().guest_memory();
+        let io_bus = Arc::new(Bus::new());
+        let mmio_bus = Arc::new(Bus::new());
+
+        let vm_ops: Arc<dyn VmOps> = Arc::new(VmOpsHandler {
+            memory,
+            #[cfg(target_arch = "x86_64")]
+            io_bus: io_bus.clone(),
+            mmio_bus: mmio_bus.clone(),
+        });
+
+        let cpu_manager = Self::create_cpu_manager(
+            &config,
+            vm.clone(),
+            exit_evt.try_clone().map_err(Error::EventFdClone)?,
+            reset_evt,
+            #[cfg(feature = "guest_debug")]
+            vm_debug_evt,
+            &hypervisor,
+            seccomp_action.clone(),
+            vm_ops,
+            &numa_nodes,
+        )?;
+
+        #[cfg(feature = "tdx")]
+        Self::init_tdx_if_enabled(&config, &vm, &cpu_manager)?;
+
+        Ok(VmRestoreShell {
+            config,
+            vm,
+            memory_manager,
+            cpu_manager,
+            io_bus,
+            mmio_bus,
+            seccomp_action: seccomp_action.clone(),
+            #[cfg(not(target_arch = "riscv64"))]
+            numa_nodes,
+            #[cfg(not(target_arch = "riscv64"))]
+            hypervisor,
+            stop_on_boot,
+            force_access_platform,
+            #[cfg(feature = "igvm")]
+            igvm_file,
+        })
     }
 
     #[allow(clippy::needless_pass_by_value)]
@@ -979,12 +1255,14 @@ impl Vm {
             )?;
         }
 
-        // Allocate address space for non-SEV-SNP guests
-        memory_manager
-            .lock()
-            .unwrap()
-            .allocate_address_space()
-            .map_err(Error::MemoryManager)?;
+        if memory_manager.lock().unwrap().num_guest_ram_mappings() == 0 {
+            // Allocate address space for non-SEV-SNP guests
+            memory_manager
+                .lock()
+                .unwrap()
+                .allocate_address_space()
+                .map_err(Error::MemoryManager)?;
+        }
 
         // Load payload asynchronously
         let load_payload_handle = if snapshot.is_none() {

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3041,10 +3041,23 @@ impl Vm {
             self.vm.resume().map_err(Error::ResumeVm)?;
         }
 
+        let prefault_ranges = {
+            let prefault_ranges = self
+                .memory_manager
+                .lock()
+                .unwrap()
+                .prefault_memory_range_table(false);
+            if !self.vm.supports_prefault_memory() || prefault_ranges.is_empty() {
+                None
+            } else {
+                Some(prefault_ranges)
+            }
+        };
+
         self.cpu_manager
             .lock()
             .unwrap()
-            .start_boot_vcpus(new_state == VmState::BreakPoint, None)
+            .start_boot_vcpus(new_state == VmState::BreakPoint, prefault_ranges)
             .map_err(Error::CpuManager)?;
 
         self.state = new_state;
@@ -3066,10 +3079,23 @@ impl Vm {
         // self.post_migration_announce();
 
         // Now we can start all vCPUs from here.
+        let prefault_ranges = {
+            let prefault_ranges = self
+                .memory_manager
+                .lock()
+                .unwrap()
+                .prefault_memory_range_table(false);
+            if !self.vm.supports_prefault_memory() || prefault_ranges.is_empty() {
+                None
+            } else {
+                Some(prefault_ranges)
+            }
+        };
+
         self.cpu_manager
             .lock()
             .unwrap()
-            .start_restored_vcpus(None)
+            .start_restored_vcpus(prefault_ranges)
             .map_err(Error::CpuManager)?;
 
         event!("vm", "restored");

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -3044,7 +3044,7 @@ impl Vm {
         self.cpu_manager
             .lock()
             .unwrap()
-            .start_boot_vcpus(new_state == VmState::BreakPoint)
+            .start_boot_vcpus(new_state == VmState::BreakPoint, None)
             .map_err(Error::CpuManager)?;
 
         self.state = new_state;
@@ -3069,7 +3069,7 @@ impl Vm {
         self.cpu_manager
             .lock()
             .unwrap()
-            .start_restored_vcpus()
+            .start_restored_vcpus(None)
             .map_err(Error::CpuManager)?;
 
         event!("vm", "restored");


### PR DESCRIPTION
This PR adds support for `KVM_PRE_FAULT_MEMORY` to prefault guest memory during boot and live migration restore, reducing memory performance degradation after a live migration. The current implementation runs prefaulting single-threaded.

More information will follow when un-drafting this.