### PR TITLE
vmm: add resize permission to qemu-compatible locking

### DIFF
--- a/block/src/fcntl.rs
+++ b/block/src/fcntl.rs
@@ -114,6 +114,8 @@ const QEMU_UNSHARE_LOCK_OFFSET: u64 = 200;
 const QEMU_READ_BYTE: u64 = 0;
 /// Write permission lock index for QEMU.
 const QEMU_WRITE_BYTE: u64 = 1;
+/// Resize permission lock index for QEMU.
+const QEMU_RESIZE_BYTE: u64 = 3;
 
 /// The granularity of the advisory lock.
 ///
@@ -177,14 +179,22 @@ impl LockGranularity {
                 LockGranularity::QemuCompatible
                     .flock(libc::F_UNLCK, QEMU_LOCK_OFFSET + QEMU_WRITE_BYTE),
                 LockGranularity::QemuCompatible
+                    .flock(libc::F_UNLCK, QEMU_LOCK_OFFSET + QEMU_RESIZE_BYTE),
+                LockGranularity::QemuCompatible
                     .flock(libc::F_UNLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_READ_BYTE),
                 LockGranularity::QemuCompatible
                     .flock(libc::F_UNLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_WRITE_BYTE),
+                LockGranularity::QemuCompatible
+                    .flock(libc::F_UNLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_RESIZE_BYTE),
             ],
             LockType::Write => vec![],
             LockType::Read => vec![
                 LockGranularity::QemuCompatible
                     .flock(libc::F_UNLCK, QEMU_LOCK_OFFSET + QEMU_WRITE_BYTE),
+                LockGranularity::QemuCompatible
+                    .flock(libc::F_UNLCK, QEMU_LOCK_OFFSET + QEMU_RESIZE_BYTE),
+                LockGranularity::QemuCompatible
+                    .flock(libc::F_UNLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_RESIZE_BYTE),
             ],
         };
 
@@ -214,9 +224,13 @@ impl LockGranularity {
                 LockGranularity::QemuCompatible
                     .flock(libc::F_UNLCK, QEMU_LOCK_OFFSET + QEMU_WRITE_BYTE),
                 LockGranularity::QemuCompatible
+                    .flock(libc::F_UNLCK, QEMU_LOCK_OFFSET + QEMU_RESIZE_BYTE),
+                LockGranularity::QemuCompatible
                     .flock(libc::F_UNLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_READ_BYTE),
                 LockGranularity::QemuCompatible
                     .flock(libc::F_UNLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_WRITE_BYTE),
+                LockGranularity::QemuCompatible
+                    .flock(libc::F_UNLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_RESIZE_BYTE),
             ],
             LockType::Write => vec![
                 LockGranularity::QemuCompatible
@@ -224,7 +238,11 @@ impl LockGranularity {
                 LockGranularity::QemuCompatible
                     .flock(libc::F_RDLCK, QEMU_LOCK_OFFSET + QEMU_WRITE_BYTE),
                 LockGranularity::QemuCompatible
+                    .flock(libc::F_RDLCK, QEMU_LOCK_OFFSET + QEMU_RESIZE_BYTE),
+                LockGranularity::QemuCompatible
                     .flock(libc::F_RDLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_WRITE_BYTE),
+                LockGranularity::QemuCompatible
+                    .flock(libc::F_RDLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_RESIZE_BYTE),
             ],
             LockType::Read => vec![
                 LockGranularity::QemuCompatible
@@ -304,7 +322,11 @@ impl LockGranularity {
                 LockGranularity::QemuCompatible
                     .flock(libc::F_WRLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_WRITE_BYTE),
                 LockGranularity::QemuCompatible
+                    .flock(libc::F_WRLCK, QEMU_UNSHARE_LOCK_OFFSET + QEMU_RESIZE_BYTE),
+                LockGranularity::QemuCompatible
                     .flock(libc::F_WRLCK, QEMU_LOCK_OFFSET + QEMU_WRITE_BYTE),
+                LockGranularity::QemuCompatible
+                    .flock(libc::F_WRLCK, QEMU_LOCK_OFFSET + QEMU_RESIZE_BYTE),
             ],
             LockType::Read => vec![
                 LockGranularity::QemuCompatible

--- a/docs/disk_locking.md
+++ b/docs/disk_locking.md
@@ -37,7 +37,8 @@ QEMU's file locking semantics.
 For read-only disks, this translates to QEMU's `BLK_PERM_CONSISTENT_READ`
 with `BLK_PERM_WRITE` unshared.
 For read-write disks, this translates to QEMU's `BLK_PERM_CONSISTENT_READ`
-and `BLK_PERM_WRITE` with `BLK_PERM_WRITE` unshared.
+`BLK_PERM_WRITE` and `BLK_PERM_RESIZE` with `BLK_PERM_WRITE` and
+`BLK_PERM_RESIZE` unshared.
 
 ### `byte-range`
 


### PR DESCRIPTION
Also lock the resize permission lock for read-write opened disks. Cloud-hypervisor can resize disks, so we should lock the byte.

Fixes https://github.com/cobaltcore-dev/cobaltcore/issues/627

Libvirt: https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/merge_requests/263

Before merging, this should be tested on customer infra.