### PR TITLE
vmm: clean up migration threads on failure

### DIFF
--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -543,6 +543,9 @@ impl ReceiveAdditionalConnections {
 
 impl Drop for ReceiveAdditionalConnections {
     fn drop(&mut self) {
+        if let Err(error) = self.terminate_fd.write(1) {
+            warn!("Failed to write to termination fd: {error}");
+        }
         if self.accept_thread.is_some() {
             warn!(
                 "ReceiveAdditionalConnections was not cleaned up! Either cleanup() was never called (programming error) or it failed before completing."


### PR DESCRIPTION
Migration threads may be left orphaned and keep the socket bound after a migration has failed. Prevent this by signaling termination via the `terminate_fd` in `ReceiveAdditionalConnections`'s `Drop` impl.

As far as I can tell, we cannot test this in libvirt because it doesn't expose a way to create the conditions that the migration fails.

Backport of https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8656

Fixes https://github.com/cobaltcore-dev/cobaltcore/issues/640