### PR TITLE
vmm: fix migration sender hang on worker failure

### DIFF
--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -885,7 +885,7 @@ impl SendAdditionalConnections {
             // All threads may have terminated, leading to a dropped receiver. Thus we ignore
             // errors here.
             self.message_tx
-                .try_send(SendMemoryThreadMessage::Disconnect)
+                .send(SendMemoryThreadMessage::Disconnect)
                 .ok();
         }
 

--- a/vmm/src/migration_transport.rs
+++ b/vmm/src/migration_transport.rs
@@ -727,7 +727,9 @@ impl SendAdditionalConnections {
                 })?;
             match message {
                 SendMemoryThreadMessage::Memory(table) => {
-                    if external_cancel.load(Ordering::Acquire) {
+                    if external_cancel.load(Ordering::Acquire)
+                        || worker_error.load(Ordering::Acquire)
+                    {
                         continue;
                     }
 


### PR DESCRIPTION
A single failing parallel migration connection can deadlock the migration sender.

When the bounded send-channel is full, `SendAdditionalConnections::cleanup()` silently drops the Disconnect messages via the non-blocking `try_send`. The surviving workers drain the channel and then block forever in `recv()`, while the main thread blocks forever in `join()`. The VM stays stuck in the "migrating" state.

We fix this by sending the `Disconnect` messages with a blocking send. In addition, once one of the workers sets `worker_error`, the other workers stop sending the queued memory chunks and drain the channel, so the Disconnects are queued and all workers exit.

[Pipeline](https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/pipelines/259183)

cc @tpressure @phip1611 