### PR TITLE
misc: Fix Clippy hints

### DIFF
--- a/block/src/qcow/header.rs
+++ b/block/src/qcow/header.rs
@@ -242,7 +242,7 @@ impl QcowHeader {
                     let mut data = vec![0u8; ext_length as usize];
                     f.read_exact(&mut data).map_err(Error::ReadingHeader)?;
                     let table = feature_table.as_mut().unwrap();
-                    for entry in data.chunks_exact(FEATURE_NAME_ENTRY_SIZE) {
+                    for entry in data.as_chunks::<FEATURE_NAME_ENTRY_SIZE>().0 {
                         if entry[0] == FEAT_TYPE_INCOMPATIBLE {
                             let bit_number = entry[1];
                             let name_bytes = &entry[2..];

--- a/devices/src/legacy/gpio_pl061.rs
+++ b/devices/src/legacy/gpio_pl061.rs
@@ -255,16 +255,15 @@ impl Gpio {
 
 impl BusDevice for Gpio {
     fn read(&mut self, _base: u64, offset: u64, data: &mut [u8]) {
-        let value;
         let mut read_ok = true;
 
-        if (GPIO_ID_LOW..GPIO_ID_HIGH).contains(&offset) {
+        let value = if (GPIO_ID_LOW..GPIO_ID_HIGH).contains(&offset) {
             let index = ((offset - GPIO_ID_LOW) >> 2) as usize;
-            value = u32::from(GPIO_ID[index]);
+            u32::from(GPIO_ID[index])
         } else if offset < OFS_DATA {
-            value = self.data & ((offset >> 2) as u32);
+            self.data & ((offset >> 2) as u32)
         } else {
-            value = match offset {
+            match offset {
                 GPIODIR => self.dir,
                 GPIOIS => self.isense,
                 GPIOIBE => self.ibe,
@@ -277,8 +276,8 @@ impl BusDevice for Gpio {
                     read_ok = false;
                     0
                 }
-            };
-        }
+            }
+        };
 
         if read_ok && data.len() <= 4 {
             write_le_u32(data, value);

--- a/pci/src/configuration.rs
+++ b/pci/src/configuration.rs
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 AND BSD-3-Clause
 
+use std::mem;
 use std::sync::{Arc, Mutex};
 
 use byteorder::{ByteOrder, LittleEndian};
@@ -953,7 +954,7 @@ impl PciConfiguration {
                     "BAR reprogramming parameter is returned: {:x?}",
                     self.pending_bar_reprogram
                 );
-                return self.pending_bar_reprogram.drain(..).collect();
+                return mem::take(&mut self.pending_bar_reprogram);
             }
             info!(
                 "MSE bit is disabled. No BAR reprogramming parameter is returned: {:x?}",


### PR DESCRIPTION
Somehow my other PR (https://github.com/cyberus-technology/cloud-hypervisor/pull/190) raised some Clippy hints on code it never touched.

Here is the backport of the corresponding [upstream PR](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8537). The backport contains only parts relevant to us. This means:
* I removed changes to `qcow_raw_file.rs` from the [first commit](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8537/changes/5cb03947d23bc19a4e0ba90c1f887ba82458a17e), as we deleted the file
* I removed the [second commit](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8537/changes/26758e5ceee2965450bddb600c1e3b76e8b8df75) of the series as it only affects code that is upstream
* I modified the [third commit ](https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8537/changes/a5bcd0b504ca59a37724ead4d0d7d3880b5a5c0e) of the series (which is the second commit in this PR) to remove an import not used in our code.