### PR TITLE
Populate `fw_cfg` legacy items with meaningful defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -655,6 +655,7 @@ dependencies = [
  "serde",
  "thiserror",
  "tpm",
+ "uuid",
  "vm-allocator",
  "vm-device",
  "vm-memory",

--- a/devices/Cargo.toml
+++ b/devices/Cargo.toml
@@ -26,6 +26,7 @@ pci = { path = "../pci" }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
 tpm = { path = "../tpm" }
+uuid = { workspace = true }
 vm-allocator = { path = "../vm-allocator" }
 vm-device = { path = "../vm-device" }
 vm-memory = { workspace = true, features = [

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -117,7 +117,9 @@ pub enum FwCfgContent {
     Bytes(Vec<u8>),
     Slice(&'static [u8]),
     File(u64, File),
+    U64(u64),
     U32(u32),
+    U16(u16),
 }
 
 struct FwCfgContentAccess<'a> {
@@ -140,7 +142,15 @@ impl Read for FwCfgContentAccess<'_> {
                 Some(mut s) => s.read(buf),
                 None => Err(ErrorKind::UnexpectedEof)?,
             },
+            FwCfgContent::U64(n) => match n.to_le_bytes().get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
             FwCfgContent::U32(n) => match n.to_le_bytes().get(self.offset as usize..) {
+                Some(mut s) => s.read(buf),
+                None => Err(ErrorKind::UnexpectedEof)?,
+            },
+            FwCfgContent::U16(n) => match n.to_le_bytes().get(self.offset as usize..) {
                 Some(mut s) => s.read(buf),
                 None => Err(ErrorKind::UnexpectedEof)?,
             },
@@ -162,7 +172,9 @@ impl FwCfgContent {
                 .ok_or::<IoError>(ErrorKind::UnexpectedEof.into())?
                 as usize,
             FwCfgContent::Slice(s) => s.len(),
+            FwCfgContent::U64(n) => size_of_val(n),
             FwCfgContent::U32(n) => size_of_val(n),
+            FwCfgContent::U16(n) => size_of_val(n),
         };
         u32::try_from(ret).map_err(|_| ErrorKind::InvalidInput.into())
     }

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -31,7 +31,7 @@ use arch::layout::{
 };
 use bitfield_struct::bitfield;
 #[cfg(target_arch = "x86_64")]
-use linux_loader::bootparam::boot_params;
+use linux_loader::bootparam::{LOADED_HIGH, boot_params};
 #[cfg(target_arch = "aarch64")]
 use linux_loader::loader::pe::arm64_image_header as boot_params;
 use log::{debug, error};
@@ -84,6 +84,7 @@ const FW_CFG_UUID: u16 = 0x02;
 const FW_CFG_RAM_SIZE: u16 = 0x03;
 const FW_CFG_NOGRAPHIC: u16 = 0x04;
 const FW_CFG_NB_CPUS: u16 = 0x05;
+const FW_CFG_KERNEL_ADDR: u16 = 0x07;
 const FW_CFG_KERNEL_SIZE: u16 = 0x08;
 const FW_CFG_INITRD_SIZE: u16 = 0x0b;
 const FW_CFG_KERNEL_DATA: u16 = 0x11;
@@ -94,6 +95,10 @@ const FW_CFG_SETUP_SIZE: u16 = 0x17;
 const FW_CFG_SETUP_DATA: u16 = 0x18;
 const FW_CFG_FILE_DIR: u16 = 0x19;
 const FW_CFG_KNOWN_ITEMS: usize = 0x20;
+/// Linux PE/COFF Magic signature (see
+/// https://www.kernel.org/doc/html/latest/arch/x86/boot.html#the-real-mode-kernel-header)
+const HDRS_MAGIC: u32 = 0x5372_6448;
+const MIN_VERSION_WITH_BZIMAGE_SUPPORT: u16 = 0x200;
 
 pub const FW_CFG_FILE_FIRST: u16 = 0x20;
 pub const FW_CFG_DMA_SIGNATURE_CONTENT: [u8; 8] = *b"QEMU CFG";
@@ -208,7 +213,7 @@ pub struct FwCfgInitParams {
     /// Memory size to use for building the e820 memory map stored at etc/e820.
     pub e820_size: Option<usize>,
     /// File containing the bzImage of the kernel. Used to populate FW_CFG_KERNEL_DATA,
-    /// FW_CFG_KERNEL_SIZE, FW_CFG_SETUP_DATA and FW_CFG_SETUP_SIZE.
+    /// FW_CFG_KERNEL_SIZE, FW_CFG_SETUP_DATA, FW_CFG_SETUP_SIZE and FW_CFG_KERNEL_ADDR.
     pub kernel: Option<File>,
     /// File containing the init RAM disk. Used for populating FW_CFG_INITRD_DATA and
     /// FW_CFG_INITRD_SIZE.
@@ -775,6 +780,17 @@ impl FwCfg {
         file.read_exact_at(&mut buffer, 0)?;
         let bp = boot_params::from_mut_slice(&mut buffer).unwrap();
 
+        // We currently only support high-loaded bzImage images with Linux boot protocol version
+        // 2.00 or later.
+        if bp.hdr.header != HDRS_MAGIC
+            || bp.hdr.version < MIN_VERSION_WITH_BZIMAGE_SUPPORT
+            || bp.hdr.loadflags & LOADED_HIGH as u8 == 0
+        {
+            return Err(IoError::new(
+                ErrorKind::InvalidInput,
+                "CHV's fw_cfg currently only supports high-loaded, bzImage formatted kernels",
+            ));
+        }
         // For SEV-SNP guests on KVM, don't modify the kernel header so the
         // bytes sent via fw_cfg match what the VMM hashes for the launch digest.
         // The guest firmware handles these fields itself.
@@ -784,7 +800,6 @@ impl FwCfg {
             }
             bp.hdr.type_of_loader = 0xff;
         }
-
         let kernel_start = {
             let sects = if bp.hdr.setup_sects == 0 {
                 4
@@ -814,6 +829,9 @@ impl FwCfg {
 
         self.known_items[FW_CFG_SETUP_SIZE as usize] = FwCfgContent::U32(buffer.len() as u32);
         self.known_items[FW_CFG_SETUP_DATA as usize] = FwCfgContent::Bytes(buffer);
+        // High-loaded bzImage images with Linux boot protocol version 2.00 or later use 0x10_0000
+        // as kernel address. See the Linux boot protocol documentation.
+        self.known_items[FW_CFG_KERNEL_ADDR as usize] = FwCfgContent::U32(0x10_0000);
         let kernel_size = u32::try_from(
             file.metadata()?
                 .len()
@@ -1156,6 +1174,9 @@ mod unit_tests {
 
         // We create a buffer that follows the same rules as expected by load_kernel + canary bytes.
         let mut bp = boot_params::default();
+        bp.hdr.header = HDRS_MAGIC;
+        bp.hdr.version = MIN_VERSION_WITH_BZIMAGE_SUPPORT;
+        bp.hdr.loadflags |= u8::try_from(LOADED_HIGH).unwrap();
         let mut kernel_image = [INIT_VALUE; BUFFER_SIZE];
         kernel_image[0..size_of::<boot_params>()].copy_from_slice(bp.as_slice());
 
@@ -1202,6 +1223,45 @@ mod unit_tests {
             FW_CFG_KERNEL_DATA,
             &kernel_image[BUFFER_SIZE - EXPECTED_KERNEL_SIZE..],
         );
+
+        // Check that FW_CFG_KERNEL_ADDR is set correctly.
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_KERNEL_ADDR,
+            &0x10_0000_u32.to_le_bytes(),
+        );
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_x86_add_kernel_data_rejects_invalid_header() {
+        let mut fw_cfg = FwCfg::new(GuestMemoryAtomic::new(GuestMemoryMmap::new()));
+        // Create a compatible header for the non-SNP path.
+        let mut bp = boot_params::default();
+        bp.hdr.header = HDRS_MAGIC;
+        bp.hdr.version = MIN_VERSION_WITH_BZIMAGE_SUPPORT;
+        bp.hdr.loadflags |= u8::try_from(LOADED_HIGH).unwrap();
+
+        let mut illegal_header = bp;
+        illegal_header.hdr.header = 0;
+        let temp = TempFile::new().unwrap();
+        let mut temp_file = temp.as_file();
+        temp_file.write_all(illegal_header.as_slice()).unwrap();
+        let _ = fw_cfg.add_kernel_data(temp_file, false).unwrap_err();
+
+        let mut illegal_header = bp;
+        illegal_header.hdr.version = 0;
+        let temp = TempFile::new().unwrap();
+        let mut temp_file = temp.as_file();
+        temp_file.write_all(illegal_header.as_slice()).unwrap();
+        let _ = fw_cfg.add_kernel_data(temp_file, false).unwrap_err();
+
+        let mut illegal_header = bp;
+        illegal_header.hdr.loadflags = 0;
+        let temp = TempFile::new().unwrap();
+        let mut temp_file = temp.as_file();
+        temp_file.write_all(illegal_header.as_slice()).unwrap();
+        let _ = fw_cfg.add_kernel_data(temp_file, false).unwrap_err();
     }
 
     #[test]

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -118,6 +118,10 @@ const FW_CFG_FILENAME_TABLE_LOADER: &str = "etc/table-loader";
 const FW_CFG_FILENAME_RSDP: &str = "acpi/rsdp";
 const FW_CFG_FILENAME_ACPI_TABLES: &str = "acpi/tables";
 
+#[cfg(target_arch = "x86_64")]
+/// https://www.kernel.org/doc/html/latest/arch/x86/boot.html#the-real-mode-kernel-header
+const PE_COFF_SECTOR_SIZE: u32 = 512;
+
 #[derive(Debug)]
 pub enum FwCfgContent {
     Bytes(Vec<u8>),
@@ -740,38 +744,68 @@ impl FwCfg {
         file: &File,
         #[cfg(target_arch = "x86_64")] kvm_sev_snp_enabled: bool,
     ) -> Result<()> {
+        #[cfg(target_arch = "aarch64")]
+        self.add_aarch_kernel_data(file)?;
+        #[cfg(target_arch = "x86_64")]
+        self.add_x86_kernel_data(file, kvm_sev_snp_enabled)?;
+        Ok(())
+    }
+
+    #[cfg(target_arch = "aarch64")]
+    fn add_aarch_kernel_data(&mut self, file: &File) -> Result<()> {
         let mut buffer = vec![0u8; size_of::<boot_params>()];
         file.read_exact_at(&mut buffer, 0)?;
         let bp = boot_params::from_mut_slice(&mut buffer).unwrap();
-        #[cfg(target_arch = "x86_64")]
-        {
-            // For SEV-SNP guests on KVM, don't modify the kernel header so the
-            // bytes sent via fw_cfg match what the VMM hashes for the launch digest.
-            // The guest firmware handles these fields itself.
-            if !kvm_sev_snp_enabled {
-                if bp.hdr.setup_sects == 0 {
-                    bp.hdr.setup_sects = 4;
-                }
-                bp.hdr.type_of_loader = 0xff;
-            }
-        }
-        #[cfg(target_arch = "aarch64")]
+
         let kernel_start = bp.text_offset;
-        #[cfg(target_arch = "x86_64")]
+
+        self.known_items[FW_CFG_KERNEL_SIZE as usize] =
+            FwCfgContent::U32(file.metadata()?.len() as u32 - kernel_start as u32);
+        self.known_items[FW_CFG_KERNEL_DATA as usize] =
+            FwCfgContent::File(kernel_start as u64, file.try_clone()?);
+        compile_error!(
+            "`boot_params` is not implemented for AArch64, so this will never compile. This function needs an entire rewrite."
+        );
+        Ok(())
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    fn add_x86_kernel_data(&mut self, file: &File, kvm_sev_snp_enabled: bool) -> Result<()> {
+        let mut buffer = vec![0u8; size_of::<boot_params>()];
+        file.read_exact_at(&mut buffer, 0)?;
+        let bp = boot_params::from_mut_slice(&mut buffer).unwrap();
+
+        // For SEV-SNP guests on KVM, don't modify the kernel header so the
+        // bytes sent via fw_cfg match what the VMM hashes for the launch digest.
+        // The guest firmware handles these fields itself.
+        if !kvm_sev_snp_enabled {
+            if bp.hdr.setup_sects == 0 {
+                bp.hdr.setup_sects = 4;
+            }
+            bp.hdr.type_of_loader = 0xff;
+        }
+
         let kernel_start = {
             let sects = if bp.hdr.setup_sects == 0 {
                 4
             } else {
                 bp.hdr.setup_sects
             };
-            (sects as usize + 1) * 512
+            (sects as u32 + 1) * PE_COFF_SECTOR_SIZE
         };
 
-        #[cfg(target_arch = "x86_64")]
-        if kernel_start <= buffer.len() {
-            buffer.truncate(kernel_start);
+        // The chance that the conversion to u32 fails is quite low, because this would mean that
+        // the boot params header is larger than 4 GiB. Better be on the safe side.
+        let buffer_len_u32 = u32::try_from(buffer.len()).map_err(|_| {
+            IoError::new(
+                ErrorKind::FileTooLarge,
+                "The Linux boot protocol header is larger than 4 GiB",
+            )
+        })?;
+        if kernel_start <= buffer_len_u32 {
+            buffer.truncate(kernel_start as usize);
         } else {
-            buffer.resize(kernel_start, 0);
+            buffer.resize(kernel_start as usize, 0);
             file.read_exact_at(
                 &mut buffer[size_of::<boot_params>()..],
                 size_of::<boot_params>() as u64,
@@ -780,8 +814,17 @@ impl FwCfg {
 
         self.known_items[FW_CFG_SETUP_SIZE as usize] = FwCfgContent::U32(buffer.len() as u32);
         self.known_items[FW_CFG_SETUP_DATA as usize] = FwCfgContent::Bytes(buffer);
-        self.known_items[FW_CFG_KERNEL_SIZE as usize] =
-            FwCfgContent::U32(file.metadata()?.len() as u32 - kernel_start as u32);
+        let kernel_size = u32::try_from(
+            file.metadata()?
+                .len()
+                .checked_sub(kernel_start as u64)
+                .ok_or(IoError::new(
+                    ErrorKind::InvalidInput,
+                    "Kernel start is located beyond EOF",
+                ))?,
+        )
+        .map_err(|_| IoError::new(ErrorKind::FileTooLarge, "Kernel size exceeds 4 GiB"))?;
+        self.known_items[FW_CFG_KERNEL_SIZE as usize] = FwCfgContent::U32(kernel_size);
         self.known_items[FW_CFG_KERNEL_DATA as usize] =
             FwCfgContent::File(kernel_start as u64, file.try_clone()?);
         Ok(())
@@ -1100,6 +1143,64 @@ mod unit_tests {
             &mut fw_cfg,
             FW_CFG_NB_CPUS,
             &expected_num_boot_cpus.to_le_bytes(),
+        );
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_x86_cfg_kernel_data() {
+        const BUFFER_SIZE: usize = 2 * 4096;
+        const INIT_VALUE: u8 = 0xFE;
+        const EXPECTED_KERNEL_START: usize = 5 * PE_COFF_SECTOR_SIZE as usize;
+        const EXPECTED_KERNEL_SIZE: usize = BUFFER_SIZE - EXPECTED_KERNEL_START;
+
+        // We create a buffer that follows the same rules as expected by load_kernel + canary bytes.
+        let mut bp = boot_params::default();
+        let mut kernel_image = [INIT_VALUE; BUFFER_SIZE];
+        kernel_image[0..size_of::<boot_params>()].copy_from_slice(bp.as_slice());
+
+        // Write test data to the file.
+        let temp = TempFile::new().unwrap();
+        let mut temp_file = temp.as_file();
+        temp_file.write_all(&kernel_image).unwrap();
+        // When adding the file to fw_cfg the header will be patched. Do the same for the expected
+        // data.
+        bp.hdr.setup_sects = 4;
+        bp.hdr.type_of_loader = 0xff;
+        kernel_image[0..size_of::<boot_params>()].copy_from_slice(bp.as_slice());
+
+        // Create fw_cfg and register the kernel data.
+        let mut fw_cfg = fw_cfg_from_init_params(FwCfgInitParams {
+            ..Default::default()
+        });
+        fw_cfg.add_kernel_data(temp_file, false).unwrap();
+
+        // Check that FW_CFG_SETUP_SIZE is set correctly. x86 only
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_SETUP_SIZE,
+            &u32::try_from(EXPECTED_KERNEL_START).unwrap().to_le_bytes(),
+        );
+
+        // Check that FW_CFG_SETUP_DATA is set correctly. x86 only.
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_SETUP_DATA,
+            &kernel_image[0..EXPECTED_KERNEL_START],
+        );
+
+        // Check that FW_CFG_KERNEL_SIZE is set correctly.
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_KERNEL_SIZE,
+            &u32::try_from(EXPECTED_KERNEL_SIZE).unwrap().to_le_bytes(),
+        );
+
+        // Check that FW_CFG_KERNEL_DATA is set correctly.
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_KERNEL_DATA,
+            &kernel_image[BUFFER_SIZE - EXPECTED_KERNEL_SIZE..],
         );
     }
 

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -11,6 +11,7 @@
 //! https://cateee.net/lkddb/web-lkddb/FW_CFG_SYSFS.html
 //! No kernel requirement if above functionality is not required,
 //! only firmware must implement mechanism to interact with this fw_cfg device
+use std::ffi::CString;
 use std::fs::File;
 use std::io::{Error as IoError, ErrorKind, Read, Result};
 use std::mem::offset_of;
@@ -190,6 +191,23 @@ impl FwCfgContent {
 pub struct FwCfgItem {
     pub name: String,
     pub content: FwCfgContent,
+}
+
+/// Helper struct for initialization of FwCfg.
+#[derive(Debug, Default)]
+pub struct FwCfgInitParams {
+    /// Memory size to use for building the e820 memory map stored at etc/e820.
+    pub e820_size: Option<usize>,
+    /// File containing the bzImage of the kernel. Used to populate FW_CFG_KERNEL_DATA,
+    /// FW_CFG_KERNEL_SIZE, FW_CFG_SETUP_DATA and FW_CFG_SETUP_SIZE.
+    pub kernel: Option<File>,
+    /// File containing the init RAM disk. Used for populating FW_CFG_INITRD_DATA and
+    /// FW_CFG_INITRD_SIZE.
+    pub initramfs: Option<File>,
+    /// Command line for the kernel. Used to populate FW_CFG_CMDLINE_SIZE and FW_CFG_CMDLINE_DATA.
+    pub cmdline: Option<CString>,
+    /// List of additional items used to populate the fw_cfg file directory.
+    pub item_list: Option<Vec<FwCfgItem>>,
 }
 
 // ARM MMIO transport needs a rework.
@@ -480,30 +498,26 @@ impl FwCfg {
 
     pub fn populate_fw_cfg(
         &mut self,
-        mem_size: Option<usize>,
-        kernel: Option<File>,
-        initramfs: Option<File>,
-        cmdline: Option<std::ffi::CString>,
-        fw_cfg_item_list: Option<Vec<FwCfgItem>>,
+        fw_cfg_init: FwCfgInitParams,
         #[cfg(target_arch = "x86_64")] kvm_sev_snp_enabled: bool,
     ) -> Result<()> {
-        if let Some(mem_size) = mem_size {
-            self.add_e820(mem_size)?;
+        if let Some(e820_size) = fw_cfg_init.e820_size {
+            self.add_e820(e820_size)?;
         }
-        if let Some(kernel) = kernel {
+        if let Some(kernel) = &fw_cfg_init.kernel {
             self.add_kernel_data(
-                &kernel,
+                kernel,
                 #[cfg(target_arch = "x86_64")]
                 kvm_sev_snp_enabled,
             )?;
         }
-        if let Some(cmdline) = cmdline {
+        if let Some(cmdline) = fw_cfg_init.cmdline {
             self.add_kernel_cmdline(cmdline);
         }
-        if let Some(initramfs) = initramfs {
-            self.add_initramfs_data(&initramfs)?;
+        if let Some(initramfs) = &fw_cfg_init.initramfs {
+            self.add_initramfs_data(initramfs)?;
         }
-        if let Some(fw_cfg_item_list) = fw_cfg_item_list {
+        if let Some(fw_cfg_item_list) = fw_cfg_init.item_list {
             for item in fw_cfg_item_list {
                 self.add_item(item)?;
             }

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -948,120 +948,90 @@ mod unit_tests {
 
     use super::*;
 
-    #[test]
-    fn test_signature() {
-        let gm = GuestMemoryAtomic::new(
-            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
+    /// Asserts that fw_cfg is in the correct state after a read and that the bytes read from fw_cfg
+    /// match the expected result.
+    #[track_caller]
+    fn assert_legacy_selector_read(fw_cfg: &mut FwCfg, selector: u16, expected_bytes: &[u8]) {
+        let bytes_to_read = expected_bytes.len() + 1;
+        let mut result_bytes = vec![0xCD_u8; bytes_to_read];
+        fw_cfg.write(0, PORT_FW_CFG_SELECTOR_OFFSET, &selector.to_le_bytes());
+        assert_eq!(
+            fw_cfg.selector, selector,
+            "fw_cfg internal selector mismatch!"
+        );
+        assert_eq!(
+            fw_cfg.data_offset, 0,
+            "fw_cfg internal offset should be zero after reset!"
         );
 
-        let mut fw_cfg = FwCfg::new(gm);
-
-        let mut data = vec![0u8];
-
-        let mut sig_iter = FW_CFG_SIGNATURE_CONTENT.into_iter();
-        fw_cfg.write(0, PORT_FW_CFG_SELECTOR_OFFSET, &[FW_CFG_SIGNATURE as u8, 0]);
-        loop {
-            if let Some(char) = sig_iter.next() {
-                fw_cfg.read(0, PORT_FW_CFG_DATA_OFFSET, &mut data);
-                assert_eq!(data[0], char);
-            } else {
-                return;
-            }
+        for byte in result_bytes.as_mut_slice() {
+            fw_cfg.read(0, PORT_FW_CFG_DATA_OFFSET, byte.as_mut_bytes());
         }
+        assert_eq!(
+            fw_cfg.data_offset,
+            (bytes_to_read - 1) as u32,
+            "fw_cfg internal offset mismatch!"
+        );
+        assert_eq!(
+            expected_bytes,
+            &result_bytes[0..expected_bytes.len()],
+            "Bytes read from fw_cfg didn't match the expected bytes."
+        );
+        assert_eq!(
+            0x0,
+            result_bytes[expected_bytes.len()],
+            "fw_cfg read beyond EOF didn't return 0x0"
+        );
+    }
+
+    #[test]
+    fn test_signature() {
+        let mut fw_cfg = FwCfg::new(GuestMemoryAtomic::new(GuestMemoryMmap::new()));
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_SIGNATURE,
+            FW_CFG_SIGNATURE_CONTENT.as_bytes(),
+        );
     }
 
     #[test]
     fn test_kernel_cmdline() {
-        let gm = GuestMemoryAtomic::new(
-            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
-        );
-
-        let mut fw_cfg = FwCfg::new(gm);
+        let mut fw_cfg = FwCfg::new(GuestMemoryAtomic::new(GuestMemoryMmap::new()));
 
         let cmdline = *b"cmdline\0";
 
         fw_cfg.add_kernel_cmdline(CString::from_vec_with_nul(cmdline.to_vec()).unwrap());
 
-        let mut data = vec![0u8];
-
-        let mut cmdline_iter = cmdline.into_iter();
-        fw_cfg.write(
-            0,
-            PORT_FW_CFG_SELECTOR_OFFSET,
-            &[FW_CFG_CMDLINE_DATA as u8, 0],
-        );
-        loop {
-            if let Some(char) = cmdline_iter.next() {
-                fw_cfg.read(0, PORT_FW_CFG_DATA_OFFSET, &mut data);
-                assert_eq!(data[0], char);
-            } else {
-                return;
-            }
-        }
+        assert_legacy_selector_read(&mut fw_cfg, FW_CFG_CMDLINE_DATA, cmdline.as_bytes());
     }
 
     #[test]
     fn test_initram_fs() {
-        let gm = GuestMemoryAtomic::new(
-            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
-        );
-
-        let mut fw_cfg = FwCfg::new(gm);
+        let mut fw_cfg = FwCfg::new(GuestMemoryAtomic::new(GuestMemoryMmap::new()));
 
         let temp = TempFile::new().unwrap();
         let mut temp_file = temp.as_file();
 
         let initram_content = b"this is the initramfs";
-        let written = temp_file.write(initram_content);
-        assert_eq!(written.unwrap(), 21);
+        temp_file.write_all(initram_content).unwrap();
         let _ = fw_cfg.add_initramfs_data(temp_file);
 
-        let mut data = vec![0u8];
-
-        let mut initram_iter = (*initram_content).into_iter();
-        fw_cfg.write(
-            0,
-            PORT_FW_CFG_SELECTOR_OFFSET,
-            &[FW_CFG_INITRD_DATA as u8, 0],
-        );
-        loop {
-            if let Some(char) = initram_iter.next() {
-                fw_cfg.read(0, PORT_FW_CFG_DATA_OFFSET, &mut data);
-                assert_eq!(data[0], char);
-            } else {
-                return;
-            }
-        }
+        assert_legacy_selector_read(&mut fw_cfg, FW_CFG_INITRD_DATA, initram_content.as_bytes());
     }
 
     #[test]
     fn test_string_item() {
-        let gm = GuestMemoryAtomic::new(
-            GuestMemoryMmap::from_ranges(&[(GuestAddress(0), RAM_64BIT_START.0 as usize)]).unwrap(),
-        );
+        let mut fw_cfg = FwCfg::new(GuestMemoryAtomic::new(GuestMemoryMmap::new()));
 
-        let mut fw_cfg = FwCfg::new(gm);
-
+        let expected_bytes = b"262144";
         // Simulate OVMF X-PciMmio64Mb string item for GPU CC passthrough
         let item = FwCfgItem {
             name: "opt/ovmf/X-PciMmio64Mb".to_owned(),
-            content: FwCfgContent::Bytes("262144".as_bytes().to_vec()),
+            content: FwCfgContent::Bytes(expected_bytes.to_vec()),
         };
         fw_cfg.add_item(item).unwrap();
 
-        let expected = b"262144";
-        let mut data = vec![0u8];
-
-        // Select the first file item (FW_CFG_FILE_FIRST = 0x20)
-        fw_cfg.write(
-            0,
-            PORT_FW_CFG_SELECTOR_OFFSET,
-            &[FW_CFG_FILE_FIRST as u8, 0],
-        );
-        for &byte in expected.iter() {
-            fw_cfg.read(0, PORT_FW_CFG_DATA_OFFSET, &mut data);
-            assert_eq!(data[0], byte);
-        }
+        assert_legacy_selector_read(&mut fw_cfg, FW_CFG_FILE_FIRST, expected_bytes.as_bytes());
     }
 
     #[test]
@@ -1250,21 +1220,7 @@ mod unit_tests {
 
         // Read the same bytes twice, demonstrating that we can reset the cursor by selecting a new item.
         for _ in 0..2 {
-            fw_cfg.write(
-                0,
-                PORT_FW_CFG_SELECTOR_OFFSET,
-                &FW_CFG_FILE_FIRST.to_le_bytes(),
-            );
-            assert_eq!(fw_cfg.data_offset, 0);
-            let mut buffer = [0xEF_u8; 6];
-            const MAX_INDEX: usize = 4;
-            for (index, byte) in buffer.iter_mut().enumerate().take(MAX_INDEX) {
-                fw_cfg.read(0, PORT_FW_CFG_DATA_OFFSET, byte.as_mut_bytes());
-                assert_eq!(fw_cfg.data_offset as usize, index + 1);
-            }
-            assert_eq!(buffer[..MAX_INDEX], payload_bytes[..MAX_INDEX]);
-            assert_eq!(buffer[MAX_INDEX..], [0xEF; 2]);
-            assert_eq!(fw_cfg.data_offset, MAX_INDEX as u32);
+            assert_legacy_selector_read(&mut fw_cfg, FW_CFG_FILE_FIRST, payload_bytes.as_bytes());
         }
     }
 }

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -87,6 +87,8 @@ const FW_CFG_NB_CPUS: u16 = 0x05;
 const FW_CFG_KERNEL_ADDR: u16 = 0x07;
 const FW_CFG_KERNEL_SIZE: u16 = 0x08;
 const FW_CFG_INITRD_SIZE: u16 = 0x0b;
+#[cfg(target_arch = "x86_64")]
+const FW_CFG_MAX_CPUS: u16 = 0x0f;
 const FW_CFG_KERNEL_DATA: u16 = 0x11;
 const FW_CFG_INITRD_DATA: u16 = 0x12;
 const FW_CFG_CMDLINE_SIZE: u16 = 0x14;
@@ -230,6 +232,9 @@ pub struct FwCfgInitParams {
     pub no_graphics: bool,
     /// Number of boot vCPUs. Used to populate FW_CFG_NB_CPUS.
     pub nb_cpus: u16,
+    #[cfg(target_arch = "x86_64")]
+    /// Used to populate the FW_CFG_MAX_CPUS selector of fw_cfg. x86 only.
+    pub max_cpus: u16,
 }
 
 // ARM MMIO transport needs a rework.
@@ -551,6 +556,10 @@ impl FwCfg {
         self.known_items[FW_CFG_NOGRAPHIC as usize] =
             FwCfgContent::U16(u16::from(fw_cfg_init.no_graphics));
         self.known_items[FW_CFG_NB_CPUS as usize] = FwCfgContent::U16(fw_cfg_init.nb_cpus);
+        #[cfg(target_arch = "x86_64")]
+        {
+            self.known_items[FW_CFG_MAX_CPUS as usize] = FwCfgContent::U16(fw_cfg_init.max_cpus);
+        }
 
         Ok(())
     }
@@ -1161,6 +1170,23 @@ mod unit_tests {
             &mut fw_cfg,
             FW_CFG_NB_CPUS,
             &expected_num_boot_cpus.to_le_bytes(),
+        );
+    }
+
+    #[cfg(target_arch = "x86_64")]
+    #[test]
+    fn test_cfg_max_cpus() {
+        let expected_num_max_cpus = 0xABCD_u16;
+
+        let mut fw_cfg = fw_cfg_from_init_params(FwCfgInitParams {
+            max_cpus: expected_num_max_cpus,
+            ..Default::default()
+        });
+
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_MAX_CPUS,
+            &expected_num_max_cpus.to_le_bytes(),
         );
     }
 

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -83,6 +83,7 @@ const FW_CFG_ID: u16 = 0x01;
 const FW_CFG_UUID: u16 = 0x02;
 const FW_CFG_RAM_SIZE: u16 = 0x03;
 const FW_CFG_NOGRAPHIC: u16 = 0x04;
+const FW_CFG_NB_CPUS: u16 = 0x05;
 const FW_CFG_KERNEL_SIZE: u16 = 0x08;
 const FW_CFG_INITRD_SIZE: u16 = 0x0b;
 const FW_CFG_KERNEL_DATA: u16 = 0x11;
@@ -218,6 +219,8 @@ pub struct FwCfgInitParams {
     pub ram_size: u64,
     /// True if the VMM doesn't emulate a VGA interface. Used to populate FW_CFG_NOGRAPHIC.
     pub no_graphics: bool,
+    /// Number of boot vCPUs. Used to populate FW_CFG_NB_CPUS.
+    pub nb_cpus: u16,
 }
 
 // ARM MMIO transport needs a rework.
@@ -538,6 +541,8 @@ impl FwCfg {
         self.known_items[FW_CFG_RAM_SIZE as usize] = FwCfgContent::U64(fw_cfg_init.ram_size);
         self.known_items[FW_CFG_NOGRAPHIC as usize] =
             FwCfgContent::U16(u16::from(fw_cfg_init.no_graphics));
+        self.known_items[FW_CFG_NB_CPUS as usize] = FwCfgContent::U16(fw_cfg_init.nb_cpus);
+
         Ok(())
     }
 
@@ -1079,6 +1084,22 @@ mod unit_tests {
             &mut fw_cfg,
             FW_CFG_NOGRAPHIC,
             &expected_nographic_value.to_le_bytes(),
+        );
+    }
+
+    #[test]
+    fn test_cfg_nb_cpus() {
+        let expected_num_boot_cpus = 0xABCD_u16;
+
+        let mut fw_cfg = fw_cfg_from_init_params(FwCfgInitParams {
+            nb_cpus: expected_num_boot_cpus,
+            ..Default::default()
+        });
+
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_NB_CPUS,
+            &expected_num_boot_cpus.to_le_bytes(),
         );
     }
 

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -81,6 +81,7 @@ pub const PORT_FW_CFG_WIDTH: u64 = 0x10;
 const FW_CFG_SIGNATURE: u16 = 0x00;
 const FW_CFG_ID: u16 = 0x01;
 const FW_CFG_UUID: u16 = 0x02;
+const FW_CFG_RAM_SIZE: u16 = 0x03;
 const FW_CFG_KERNEL_SIZE: u16 = 0x08;
 const FW_CFG_INITRD_SIZE: u16 = 0x0b;
 const FW_CFG_KERNEL_DATA: u16 = 0x11;
@@ -212,6 +213,8 @@ pub struct FwCfgInitParams {
     pub item_list: Option<Vec<FwCfgItem>>,
     /// UUID used for populating FW_CFG_UUID.
     pub uuid: Uuid,
+    /// RAM size used to populate FW_CFG_RAM_SIZE.
+    pub ram_size: u64,
 }
 
 // ARM MMIO transport needs a rework.
@@ -529,6 +532,7 @@ impl FwCfg {
 
         self.known_items[FW_CFG_UUID as usize] =
             FwCfgContent::Bytes(Vec::from(fw_cfg_init.uuid.as_bytes()));
+        self.known_items[FW_CFG_RAM_SIZE as usize] = FwCfgContent::U64(fw_cfg_init.ram_size);
         Ok(())
     }
 
@@ -1039,6 +1043,22 @@ mod unit_tests {
         });
 
         assert_legacy_selector_read(&mut fw_cfg, FW_CFG_UUID, expected_uuid.as_bytes());
+    }
+
+    #[test]
+    fn test_cfg_ram_size() {
+        let expected_ram_size = 0x1122_3344_5566_7788_u64;
+
+        let mut fw_cfg = fw_cfg_from_init_params(FwCfgInitParams {
+            ram_size: expected_ram_size,
+            ..Default::default()
+        });
+
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_RAM_SIZE,
+            &expected_ram_size.to_le_bytes(),
+        );
     }
 
     #[test]

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -82,6 +82,7 @@ const FW_CFG_SIGNATURE: u16 = 0x00;
 const FW_CFG_ID: u16 = 0x01;
 const FW_CFG_UUID: u16 = 0x02;
 const FW_CFG_RAM_SIZE: u16 = 0x03;
+const FW_CFG_NOGRAPHIC: u16 = 0x04;
 const FW_CFG_KERNEL_SIZE: u16 = 0x08;
 const FW_CFG_INITRD_SIZE: u16 = 0x0b;
 const FW_CFG_KERNEL_DATA: u16 = 0x11;
@@ -215,6 +216,8 @@ pub struct FwCfgInitParams {
     pub uuid: Uuid,
     /// RAM size used to populate FW_CFG_RAM_SIZE.
     pub ram_size: u64,
+    /// True if the VMM doesn't emulate a VGA interface. Used to populate FW_CFG_NOGRAPHIC.
+    pub no_graphics: bool,
 }
 
 // ARM MMIO transport needs a rework.
@@ -533,6 +536,8 @@ impl FwCfg {
         self.known_items[FW_CFG_UUID as usize] =
             FwCfgContent::Bytes(Vec::from(fw_cfg_init.uuid.as_bytes()));
         self.known_items[FW_CFG_RAM_SIZE as usize] = FwCfgContent::U64(fw_cfg_init.ram_size);
+        self.known_items[FW_CFG_NOGRAPHIC as usize] =
+            FwCfgContent::U16(u16::from(fw_cfg_init.no_graphics));
         Ok(())
     }
 
@@ -1058,6 +1063,22 @@ mod unit_tests {
             &mut fw_cfg,
             FW_CFG_RAM_SIZE,
             &expected_ram_size.to_le_bytes(),
+        );
+    }
+
+    #[test]
+    fn test_cfg_nographic() {
+        let expected_nographic_value = 0x1_u16;
+
+        let mut fw_cfg = fw_cfg_from_init_params(FwCfgInitParams {
+            no_graphics: expected_nographic_value != 0,
+            ..Default::default()
+        });
+
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_NOGRAPHIC,
+            &expected_nographic_value.to_le_bytes(),
         );
     }
 

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -87,6 +87,7 @@ const FW_CFG_NB_CPUS: u16 = 0x05;
 const FW_CFG_KERNEL_ADDR: u16 = 0x07;
 const FW_CFG_KERNEL_SIZE: u16 = 0x08;
 const FW_CFG_INITRD_SIZE: u16 = 0x0b;
+const FW_CFG_BOOT_MENU: u16 = 0x0e;
 #[cfg(target_arch = "x86_64")]
 const FW_CFG_MAX_CPUS: u16 = 0x0f;
 const FW_CFG_KERNEL_DATA: u16 = 0x11;
@@ -235,6 +236,9 @@ pub struct FwCfgInitParams {
     #[cfg(target_arch = "x86_64")]
     /// Used to populate the FW_CFG_MAX_CPUS selector of fw_cfg. x86 only.
     pub max_cpus: u16,
+    /// True if the VMM wants to hint the firmware to show its boot menu. Used to populate the
+    /// FW_CFG_BOOT_MENU selector of fw_cfg.
+    pub boot_menu: bool,
 }
 
 // ARM MMIO transport needs a rework.
@@ -560,6 +564,8 @@ impl FwCfg {
         {
             self.known_items[FW_CFG_MAX_CPUS as usize] = FwCfgContent::U16(fw_cfg_init.max_cpus);
         }
+        self.known_items[FW_CFG_BOOT_MENU as usize] =
+            FwCfgContent::U16(u16::from(fw_cfg_init.boot_menu));
 
         Ok(())
     }
@@ -1187,6 +1193,22 @@ mod unit_tests {
             &mut fw_cfg,
             FW_CFG_MAX_CPUS,
             &expected_num_max_cpus.to_le_bytes(),
+        );
+    }
+
+    #[test]
+    fn test_cfg_boot_menu() {
+        let expected_boot_menu_value = 0x1_u16;
+
+        let mut fw_cfg = fw_cfg_from_init_params(FwCfgInitParams {
+            boot_menu: expected_boot_menu_value != 0,
+            ..Default::default()
+        });
+
+        assert_legacy_selector_read(
+            &mut fw_cfg,
+            FW_CFG_BOOT_MENU,
+            &expected_boot_menu_value.to_le_bytes(),
         );
     }
 

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -84,16 +84,33 @@ const FW_CFG_UUID: u16 = 0x02;
 const FW_CFG_RAM_SIZE: u16 = 0x03;
 const FW_CFG_NOGRAPHIC: u16 = 0x04;
 const FW_CFG_NB_CPUS: u16 = 0x05;
+// FW_CFG_MACHINE_ID = 0x06 is intentionally left out as it's only used in QEMU for Sparc and
+// PowerPC architectures, both not supported by CHV.
 const FW_CFG_KERNEL_ADDR: u16 = 0x07;
 const FW_CFG_KERNEL_SIZE: u16 = 0x08;
+// FW_CFG_KERNEL_CMDLINE = 0x09 is intentionally left out as it's only used in QEMU for Sparc and
+// PowerPC architectures, both not supported by CHV.
+// FW_CFG_INITRD_ADDR = 0x0a is intentionally left out because CHV's EDK2 fw_cfg kernel loader
+// ignores it and allocates the initrd at its own address.
 const FW_CFG_INITRD_SIZE: u16 = 0x0b;
+// FW_CFG_BOOT_DEVICE = 0x0C is intentionally left out as it's not used on CHV-supported
+// architectures in QEMU.
 const FW_CFG_BOOT_MENU: u16 = 0x0e;
+// FW_CFG_NUMA = 0x0D is intentionally left out as it's for SeaBIOS’s built-in ACPI-generation
+// fallback. SeaBIOS prioritizes fw_cfg's etc/table-loader path, which we export. CHV exports ACPI
+// through etc/table-loader and does not support SeaBIOS.
 #[cfg(target_arch = "x86_64")]
 const FW_CFG_MAX_CPUS: u16 = 0x0f;
+// FW_CFG_KERNEL_ENTRY = 0x10 is intentionally left out as CHV doesn't support loading
+// ELF PVH/Multiboot images through fw_cfg.
 const FW_CFG_KERNEL_DATA: u16 = 0x11;
 const FW_CFG_INITRD_DATA: u16 = 0x12;
+// FW_CFG_CMDLINE_ADDR = 0x13 is intentionally left out because it's ignored by CHV’s EDK2
+// fw_cfg kernel-loader path and is meaningful only to QEMU’s legacy Linux option-ROM boot path.
 const FW_CFG_CMDLINE_SIZE: u16 = 0x14;
 const FW_CFG_CMDLINE_DATA: u16 = 0x15;
+// FW_CFG_SETUP_ADDR = 0x16 is intentionally left out as it's the real-mode setup-image
+// destination consumed by QEMU’s legacy Linux option ROM. We do not expose an option ROM.
 const FW_CFG_SETUP_SIZE: u16 = 0x17;
 const FW_CFG_SETUP_DATA: u16 = 0x18;
 const FW_CFG_FILE_DIR: u16 = 0x19;

--- a/devices/src/legacy/fw_cfg.rs
+++ b/devices/src/legacy/fw_cfg.rs
@@ -36,6 +36,7 @@ use linux_loader::bootparam::boot_params;
 use linux_loader::loader::pe::arm64_image_header as boot_params;
 use log::{debug, error};
 use thiserror::Error;
+use uuid::Uuid;
 use vm_device::BusDevice;
 use vm_memory::bitmap::AtomicBitmap;
 use vm_memory::{
@@ -79,6 +80,7 @@ pub const PORT_FW_CFG_WIDTH: u64 = 0x10;
 
 const FW_CFG_SIGNATURE: u16 = 0x00;
 const FW_CFG_ID: u16 = 0x01;
+const FW_CFG_UUID: u16 = 0x02;
 const FW_CFG_KERNEL_SIZE: u16 = 0x08;
 const FW_CFG_INITRD_SIZE: u16 = 0x0b;
 const FW_CFG_KERNEL_DATA: u16 = 0x11;
@@ -208,6 +210,8 @@ pub struct FwCfgInitParams {
     pub cmdline: Option<CString>,
     /// List of additional items used to populate the fw_cfg file directory.
     pub item_list: Option<Vec<FwCfgItem>>,
+    /// UUID used for populating FW_CFG_UUID.
+    pub uuid: Uuid,
 }
 
 // ARM MMIO transport needs a rework.
@@ -522,6 +526,9 @@ impl FwCfg {
                 self.add_item(item)?;
             }
         }
+
+        self.known_items[FW_CFG_UUID as usize] =
+            FwCfgContent::Bytes(Vec::from(fw_cfg_init.uuid.as_bytes()));
         Ok(())
     }
 
@@ -984,6 +991,20 @@ mod unit_tests {
         );
     }
 
+    /// Creates a new FwCfg from the given FwCfgInitParams with no guest memory access.
+    #[track_caller]
+    fn fw_cfg_from_init_params(init_params: FwCfgInitParams) -> FwCfg {
+        let mut fw_cfg = FwCfg::new(GuestMemoryAtomic::new(GuestMemoryMmap::new()));
+        fw_cfg
+            .populate_fw_cfg(
+                init_params,
+                #[cfg(target_arch = "x86_64")]
+                false,
+            )
+            .unwrap();
+        fw_cfg
+    }
+
     #[test]
     fn test_signature() {
         let mut fw_cfg = FwCfg::new(GuestMemoryAtomic::new(GuestMemoryMmap::new()));
@@ -1003,6 +1024,21 @@ mod unit_tests {
         fw_cfg.add_kernel_cmdline(CString::from_vec_with_nul(cmdline.to_vec()).unwrap());
 
         assert_legacy_selector_read(&mut fw_cfg, FW_CFG_CMDLINE_DATA, cmdline.as_bytes());
+    }
+
+    #[test]
+    fn test_cfg_uuid() {
+        let expected_uuid = Uuid::from_bytes([
+            0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xAA, 0xBB, 0xCC, 0xDD, 0xFF,
+            0xBC, 0xFE,
+        ]);
+
+        let mut fw_cfg = fw_cfg_from_init_params(FwCfgInitParams {
+            uuid: expected_uuid,
+            ..Default::default()
+        });
+
+        assert_legacy_selector_read(&mut fw_cfg, FW_CFG_UUID, expected_uuid.as_bytes());
     }
 
     #[test]

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1335,6 +1335,7 @@ impl Vm {
             #[cfg(target_arch = "x86_64")]
             max_cpus: u16::try_from(apic_limit)
                 .map_err(|_| Error::FwCfgCannotRepresentNumMaxVCpus(apic_limit))?,
+            boot_menu: false,
         };
 
         fw_cfg

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -409,6 +409,10 @@ pub enum Error {
         "Number of vCPUs cannot be represented with fw_cfg. {0} exceed the maximum count of 65535"
     )]
     FwCfgCannotRepresentNumVCpus(u32),
+
+    #[cfg(all(feature = "fw_cfg", target_arch = "x86_64"))]
+    #[error("APIC limit cannot be represented with fw_cfg. {0} exceed the maximum of 65535")]
+    FwCfgCannotRepresentNumMaxVCpus(u32),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -1297,6 +1301,20 @@ impl Vm {
             .try_into()
             .map_err(|_| Error::FwCfgCannotRepresentNumVCpus(config.cpus.boot_vcpus))?;
 
+        #[cfg(target_arch = "x86_64")]
+        // With an explicit topology, `max_apic_id()` is inclusive; otherwise `max_vcpus` is
+        // already exclusive. Add one for an explicit topology to obtain an exclusive limit.
+        let apic_limit = {
+            let max_apic_id = config.max_apic_id();
+            if config.cpus.topology.is_some() {
+                max_apic_id
+                    .checked_add(1)
+                    .ok_or(Error::FwCfgCannotRepresentNumMaxVCpus(max_apic_id))?
+            } else {
+                max_apic_id
+            }
+        };
+
         let init = FwCfgInitParams {
             e820_size: e820_option,
             cmdline: cmdline_option,
@@ -1314,6 +1332,9 @@ impl Vm {
             ram_size: config.memory.size,
             no_graphics: true,
             nb_cpus,
+            #[cfg(target_arch = "x86_64")]
+            max_cpus: u16::try_from(apic_limit)
+                .map_err(|_| Error::FwCfgCannotRepresentNumMaxVCpus(apic_limit))?,
         };
 
         fw_cfg

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1298,6 +1298,7 @@ impl Vm {
                 .transpose()
                 .map_err(Error::FwCfgInvalidUuid)?
                 .unwrap_or_else(Uuid::nil),
+            ram_size: config.memory.size,
         };
 
         fw_cfg

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -12,6 +12,8 @@
 //
 
 use std::collections::{BTreeMap, BTreeSet, HashMap};
+#[cfg(feature = "fw_cfg")]
+use std::ffi::CString;
 use std::fs::{File, OpenOptions};
 use std::io::{self, Seek, SeekFrom, Write};
 #[cfg(all(target_arch = "x86_64", feature = "guest_debug"))]
@@ -38,7 +40,7 @@ use devices::AcpiNotificationFlags;
 #[cfg(target_arch = "aarch64")]
 use devices::interrupt_controller;
 #[cfg(feature = "fw_cfg")]
-use devices::legacy::fw_cfg::FwCfgItem;
+use devices::legacy::fw_cfg::{FwCfgInitParams, FwCfgItem};
 use event_monitor::event;
 #[cfg(all(target_arch = "aarch64", feature = "guest_debug"))]
 use gdbstub_arch::aarch64::reg::AArch64CoreRegs as CoreRegs;
@@ -1222,7 +1224,7 @@ impl Vm {
                 .map_err(Error::MissingFwCfgKernelFile)?;
             kernel_option = kernel;
         }
-        let mut cmdline_option: Option<std::ffi::CString> = None;
+        let mut cmdline_option: Option<CString> = None;
         if fw_cfg_config.cmdline {
             let cmdline = Vm::generate_cmdline(
                 config.payload.as_ref().unwrap(),
@@ -1275,16 +1277,19 @@ impl Vm {
         let Some(fw_cfg) = device_manager_binding.fw_cfg() else {
             return Err(Error::FwCfgDisabled);
         };
+        let init = FwCfgInitParams {
+            e820_size: e820_option,
+            cmdline: cmdline_option,
+            kernel: kernel_option,
+            initramfs: initramfs_option,
+            item_list: fw_cfg_item_list_option,
+        };
 
         fw_cfg
             .lock()
             .unwrap()
             .populate_fw_cfg(
-                e820_option,
-                kernel_option,
-                initramfs_option,
-                cmdline_option,
-                fw_cfg_item_list_option,
+                init,
                 #[cfg(target_arch = "x86_64")]
                 kvm_sev_snp_enabled,
             )

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -403,6 +403,12 @@ pub enum Error {
     #[cfg(feature = "fw_cfg")]
     #[error("Error parsing the VM's UUID")]
     FwCfgInvalidUuid(#[source] UuidError),
+
+    #[cfg(feature = "fw_cfg")]
+    #[error(
+        "Number of vCPUs cannot be represented with fw_cfg. {0} exceed the maximum count of 65535"
+    )]
+    FwCfgCannotRepresentNumVCpus(u32),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -1284,6 +1290,13 @@ impl Vm {
             return Err(Error::FwCfgDisabled);
         };
 
+        // fw_cfg can only be used with u16::MAX vCPUs.
+        let nb_cpus = config
+            .cpus
+            .boot_vcpus
+            .try_into()
+            .map_err(|_| Error::FwCfgCannotRepresentNumVCpus(config.cpus.boot_vcpus))?;
+
         let init = FwCfgInitParams {
             e820_size: e820_option,
             cmdline: cmdline_option,
@@ -1300,6 +1313,7 @@ impl Vm {
                 .unwrap_or_else(Uuid::nil),
             ram_size: config.memory.size,
             no_graphics: true,
+            nb_cpus,
         };
 
         fw_cfg

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1299,6 +1299,7 @@ impl Vm {
                 .map_err(Error::FwCfgInvalidUuid)?
                 .unwrap_or_else(Uuid::nil),
             ram_size: config.memory.size,
+            no_graphics: true,
         };
 
         fw_cfg

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -1201,20 +1201,19 @@ impl Vm {
 
     #[cfg(feature = "fw_cfg")]
     fn populate_fw_cfg(
+        &self,
         fw_cfg_config: &FwCfgConfig,
-        device_manager: &Arc<Mutex<DeviceManager>>,
-        config: &Arc<Mutex<VmConfig>>,
         #[cfg(target_arch = "x86_64")] kvm_sev_snp_enabled: bool,
     ) -> Result<()> {
+        let config = self.config.lock().unwrap();
+
         let mut e820_option: Option<usize> = None;
         if fw_cfg_config.e820 {
-            e820_option = Some(config.lock().unwrap().memory.size as usize);
+            e820_option = Some(config.memory.size as usize);
         }
         let mut kernel_option: Option<File> = None;
         if fw_cfg_config.kernel {
             let kernel = config
-                .lock()
-                .unwrap()
                 .payload
                 .as_ref()
                 .map(|p| p.kernel.as_ref().map(File::open))
@@ -1226,9 +1225,9 @@ impl Vm {
         let mut cmdline_option: Option<std::ffi::CString> = None;
         if fw_cfg_config.cmdline {
             let cmdline = Vm::generate_cmdline(
-                config.lock().unwrap().payload.as_ref().unwrap(),
+                config.payload.as_ref().unwrap(),
                 #[cfg(target_arch = "aarch64")]
-                device_manager,
+                self.device_manager,
             )
             .map_err(|_| Error::MissingFwCfgCmdline)?
             .as_cstring()
@@ -1238,8 +1237,6 @@ impl Vm {
         let mut initramfs_option: Option<File> = None;
         if fw_cfg_config.initramfs {
             let initramfs = config
-                .lock()
-                .unwrap()
                 .payload
                 .as_ref()
                 .map(|p| p.initramfs.as_ref().map(File::open))
@@ -1274,7 +1271,7 @@ impl Vm {
             fw_cfg_item_list_option = Some(fw_cfg_item_list);
         }
 
-        let device_manager_binding = device_manager.lock().unwrap();
+        let device_manager_binding = self.device_manager.lock().unwrap();
         let Some(fw_cfg) = device_manager_binding.fw_cfg() else {
             return Err(Error::FwCfgDisabled);
         };
@@ -2899,10 +2896,8 @@ impl Vm {
                     }
                 };
 
-                Self::populate_fw_cfg(
+                self.populate_fw_cfg(
                     &fw_cfg_config,
-                    &self.device_manager,
-                    &self.config,
                     #[cfg(target_arch = "x86_64")]
                     kvm_sev_snp_enabled,
                 )?;

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -73,6 +73,8 @@ use seccompiler::SeccompAction;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use tracer::trace_scoped;
+#[cfg(feature = "fw_cfg")]
+use uuid::{Error as UuidError, Uuid};
 use vm_device::Bus;
 #[cfg(feature = "tdx")]
 use vm_memory::GuestMemory;
@@ -397,6 +399,10 @@ pub enum Error {
     #[cfg(feature = "fw_cfg")]
     #[error("Error using fw_cfg while disabled")]
     FwCfgDisabled,
+
+    #[cfg(feature = "fw_cfg")]
+    #[error("Error parsing the VM's UUID")]
+    FwCfgInvalidUuid(#[source] UuidError),
 }
 pub type Result<T> = result::Result<T, Error>;
 
@@ -1277,12 +1283,21 @@ impl Vm {
         let Some(fw_cfg) = device_manager_binding.fw_cfg() else {
             return Err(Error::FwCfgDisabled);
         };
+
         let init = FwCfgInitParams {
             e820_size: e820_option,
             cmdline: cmdline_option,
             kernel: kernel_option,
             initramfs: initramfs_option,
             item_list: fw_cfg_item_list_option,
+            uuid: config
+                .platform
+                .as_ref()
+                .and_then(|pc| pc.system_uuid.as_ref())
+                .map(|s| Uuid::parse_str(s))
+                .transpose()
+                .map_err(Error::FwCfgInvalidUuid)?
+                .unwrap_or_else(Uuid::nil),
         };
 
         fw_cfg

--- a/vmm/src/vm_config.rs
+++ b/vmm/src/vm_config.rs
@@ -1235,7 +1235,7 @@ impl VmConfig {
         Ok(())
     }
 
-    #[cfg(all(feature = "kvm", target_arch = "x86_64"))]
+    #[cfg(all(target_arch = "x86_64", any(feature = "kvm", feature = "fw_cfg")))]
     pub(crate) fn max_apic_id(&self) -> u32 {
         if let Some(topology) = &self.cpus.topology {
             arch::x86_64::get_max_x2apic_id((


### PR DESCRIPTION
This commit series initializes all relevant x86 `fw_cfg` items with meaningful defaults. For the highest possible compatibility to QEMU we use the same values to initialize the respective items. After merging this PR, `fw_cfg` is ready to be used in a production environment. This is then the basis to build the `boot order` feature on.

As with the other series fixing x86 PIO, AArch64 and RISC-V support is out of scope for this PR. Please find the QEMU code path this series is modeled after in the commits implementing the respective `fw_cfg` item.

The first commit titled "X: use fw_cfg" is used to execute a pipeline and CI with changes introduced in this PR. Please ignore this commit in your review. I'll remove it once we resolved all discussion before we merge this PR.

You can find a pipeline here: https://gitlab.cyberus-technology.de/cyberus/cloud/libvirt/-/pipelines/261482

This is part of https://github.com/cobaltcore-dev/cobaltcore/issues/641 and https://github.com/cobaltcore-dev/cobaltcore/issues/491
