### PR TITLE
arch: Automate year in generated license files for CPU profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -118,6 +118,7 @@ dependencies = [
  "fdt",
  "flate2",
  "hypervisor",
+ "jiff",
  "libc",
  "linux-loader",
  "log",

--- a/arch/Cargo.toml
+++ b/arch/Cargo.toml
@@ -18,13 +18,14 @@ kvm = ["hypervisor/kvm"]
 sev_snp = []
 tdx = []
 # Currently cpu profiles can only be generated with KVM
-cpu_profile_generation = ["dep:clap", "kvm"]
+cpu_profile_generation = ["dep:clap", "dep:jiff", "kvm"]
 
 [dependencies]
 anyhow = { workspace = true }
 byteorder = { workspace = true }
 clap = { workspace = true, optional = true }
 hypervisor = { path = "../hypervisor" }
+jiff = { workspace = true, optional = true }
 libc = { workspace = true }
 linux-loader = { workspace = true, features = ["bzimage", "elf", "pe"] }
 log = { workspace = true }

--- a/arch/src/x86_64/cpu_profile_generation.rs
+++ b/arch/src/x86_64/cpu_profile_generation.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 use anyhow::{Context, anyhow};
 use hypervisor::arch::x86::{CpuIdEntry, MsrEntry};
 use hypervisor::{CpuVendor, Hypervisor, HypervisorError, HypervisorType};
+use jiff::Zoned;
 use log::warn;
 
 use crate::x86_64::CpuidReg;
@@ -444,11 +445,14 @@ fn generate_msr_profile_data_with<'a, const N: usize>(
 }
 
 fn write_license_file(mut license_file: impl Write, data_type: &str) -> anyhow::Result<()> {
+    let year = Zoned::now().year();
     let license_text = {
-        r#"SPDX-FileCopyrightText: 2025 Cyberus Technology GmbH
+        format!(
+            r#"SPDX-FileCopyrightText: {year} Cyberus Technology GmbH
 
 SPDX-License-Identifier: Apache-2.0
 "#
+        )
     };
     license_file
         .write_all(license_text.as_bytes())


### PR DESCRIPTION
The CPU profile generation tool hard coded the year 2025 in the license file which is now wrong.

Instead of replacing it with 2026 we use jiff to automatically find the current year (in the system's default time zone).

## How has this been tested

I've manually executed the CPU profile generation tool and verified that the output is as expected.