### PR TITLE
Backport unregistered mmio pio read fixes

### DIFF
--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -487,7 +487,8 @@ impl VmOps for VmOpsHandler {
 
     fn mmio_read(&self, gpa: u64, data: &mut [u8]) -> result::Result<(), HypervisorVmError> {
         if let Err(vm_device::BusError::MissingAddressRange) = self.mmio_bus.read(gpa, data) {
-            info!("Guest MMIO read to unregistered address 0x{gpa:x}");
+            info!("Guest MMIO read from unregistered address 0x{gpa:x}");
+            data.fill(0xff); // 0xff is sentinel value for invalid reads
         }
         Ok(())
     }

--- a/vmm/src/vm.rs
+++ b/vmm/src/vm.rs
@@ -512,7 +512,8 @@ impl VmOps for VmOpsHandler {
     fn pio_read(&self, port: u64, data: &mut [u8]) -> result::Result<(), HypervisorVmError> {
         if let Err(vm_device::BusError::MissingAddressRange) = self.io_bus.read(port, data) {
             // TODO: Make this `info!` again (see https://github.com/cobaltcore-dev/cobaltcore/issues/603)
-            debug!("Guest PIO read to unregistered address 0x{port:x}");
+            debug!("Guest PIO read from unregistered address 0x{port:x}");
+            data.fill(0xff); // 0xff is sentinel value for invalid reads
         }
         Ok(())
     }


### PR DESCRIPTION
Back port of the changes from the following usptream PR: https://github.com/cloud-hypervisor/cloud-hypervisor/pull/8237

Note: `pio_read` still uses `debug!` instead of `info!` related to: https://github.com/cobaltcore-dev/cobaltcore/issues/603

I stumble accros this issue when working on fw_cfg. In detail, that's the behavior OVMF also expects. E.g. when reading the number of boot CPUs, OVMF will also query IO ports 0xcf8/0xcfc to discover QEMU's CPUHP CPU hotplug interface. It will afterwards compare if the values are all-ones, which indicates that the port access is not valid. If so, it will use the number of boot CPUs provided by fw_cfg. If not, OVMF will try to use QEMU's modern CPU hotplug interface to find the number of boot CPUs. We obviously do not implement QEMU's hotplug interface.

Currently, the buffer is not overridden with all-ones and so OVMF tries to use the QEMU hotplug interface, which consequently fails.