### PR TITLE
arch: Fix Clippy lints for CPUID updates

### DIFF
--- a/arch/src/x86_64/mod.rs
+++ b/arch/src/x86_64/mod.rs
@@ -870,15 +870,13 @@ fn required_common_cpuid_updates(
     for entry in cpuid.as_mut_slice().iter_mut() {
         match entry.function {
             // Clear AMX related bits if the AMX feature is not enabled
-            0x7 => {
-                if !config.amx {
-                    if entry.index == 0 {
-                        entry.edx &= !((1 << AMX_BF16) | (1 << AMX_TILE) | (1 << AMX_INT8));
-                    }
-                    if entry.index == 1 {
-                        entry.eax &= !(1 << AMX_FP16);
-                        entry.edx &= !(1 << AMX_COMPLEX);
-                    }
+            0x7 if !config.amx => {
+                if entry.index == 0 {
+                    entry.edx &= !((1 << AMX_BF16) | (1 << AMX_TILE) | (1 << AMX_INT8));
+                }
+                if entry.index == 1 {
+                    entry.eax &= !(1 << AMX_FP16);
+                    entry.edx &= !(1 << AMX_COMPLEX);
                 }
             }
             // Tile Information (purely AMX related).
@@ -888,45 +886,44 @@ fn required_common_cpuid_updates(
                 entry.ecx = 0;
                 entry.edx = 0;
             }
-            0x1e => {
+            0x1e if !config.amx => {
                 // TMUL information (purely AMX related)
-                if !config.amx {
-                    entry.eax = 0;
-                    entry.ebx = 0;
-                    entry.ecx = 0;
-                    entry.edx = 0;
-                }
+                entry.eax = 0;
+                entry.ebx = 0;
+                entry.ecx = 0;
+                entry.edx = 0;
             }
 
             // Copy host L1 cache details if not populated by KVM
-            0x8000_0005 => {
-                if entry.eax == 0 && entry.ebx == 0 && entry.ecx == 0 && entry.edx == 0 {
-                    #[allow(unused_unsafe)]
-                    // SAFETY: cpuid called with valid leaves
-                    if unsafe { std::arch::x86_64::__cpuid(0x8000_0000).eax } >= 0x8000_0005 {
-                        // SAFETY: cpuid called with valid leaves
-                        let leaf = unsafe { std::arch::x86_64::__cpuid(0x8000_0005) };
-                        entry.eax = leaf.eax;
-                        entry.ebx = leaf.ebx;
-                        entry.ecx = leaf.ecx;
-                        entry.edx = leaf.edx;
-                    }
-                }
+            #[allow(unused_unsafe)]
+            0x8000_0005
+                if entry.eax == 0 && entry.ebx == 0 && entry.ecx == 0 && entry.edx == 0
+                // SAFETY: cpuid called with valid leaves
+                 && unsafe { std::arch::x86_64::__cpuid(0x8000_0000).eax } >= 0x8000_0005 =>
+            {
+                // SAFETY: cpuid called with valid leaves
+                let leaf = unsafe { std::arch::x86_64::__cpuid(0x8000_0005) };
+                entry.eax = leaf.eax;
+                entry.ebx = leaf.ebx;
+                entry.ecx = leaf.ecx;
+                entry.edx = leaf.edx;
             }
             // Copy host L2 cache details if not populated by KVM
-            0x8000_0006 => {
-                if entry.eax == 0 && entry.ebx == 0 && entry.ecx == 0 && entry.edx == 0 {
-                    #[allow(unused_unsafe)]
+            #[allow(unused_unsafe)]
+            0x8000_0006
+                if entry.eax == 0
+                    && entry.ebx == 0
+                    && entry.ecx == 0
+                    && entry.edx == 0
                     // SAFETY: cpuid called with valid leaves
-                    if unsafe { std::arch::x86_64::__cpuid(0x8000_0000).eax } >= 0x8000_0006 {
-                        // SAFETY: cpuid called with valid leaves
-                        let leaf = unsafe { std::arch::x86_64::__cpuid(0x8000_0006) };
-                        entry.eax = leaf.eax;
-                        entry.ebx = leaf.ebx;
-                        entry.ecx = leaf.ecx;
-                        entry.edx = leaf.edx;
-                    }
-                }
+                    && unsafe { std::arch::x86_64::__cpuid(0x8000_0000).eax } >= 0x8000_0006 =>
+            {
+                // SAFETY: cpuid called with valid leaves
+                let leaf = unsafe { std::arch::x86_64::__cpuid(0x8000_0006) };
+                entry.eax = leaf.eax;
+                entry.ebx = leaf.ebx;
+                entry.ecx = leaf.ecx;
+                entry.edx = leaf.edx;
             }
             // Set CPU physical bits
             0x8000_0008 => {


### PR DESCRIPTION
Weird that that the CI didn't catch it some days ago. I found this when executing Clippy locally on my machine.

This fixes lints of the following kind:
```
error: this `if` can be collapsed into the outer `match`
   --> arch/src/x86_64/mod.rs:874:17
    |
874 | /                 if !config.amx {
875 | |                     if entry.index == 0 {
876 | |                         entry.edx &= !((1 << AMX_BF16) | (1 << AMX_TILE) | (1 << AMX_INT8));
...   |
882 | |                 }
    | |_________________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_match
    = note: `-D clippy::collapsible-match` implied by `-D clippy::all`
    = help: to override `-D clippy::all` add `#[allow(clippy::collapsible_match)]`
help: collapse nested if block
    |
873 ~             0x7
874 ~                 if !config.amx => {
875 |                     if entry.index == 0 {
...
881 |                     }
882 ~                 }
    |
```
